### PR TITLE
Add marketing content, docker-compose example, and enhanced README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,28 @@ A principal-first, zero-trust agent negotiation protocol for the open web.
 
 ## The Problem
 
-Every agent-to-agent protocol currently in development — A2A, ACP, AgentConnect, MCP — was designed to serve platform operators, not human principals. The trust models are thin, context minimization is voluntary, session residue is undefined, and the economic model underneath each protocol is cloud compute metering.
+Every agent protocol in production today — A2A, MCP, ACP, AGNTCY — was designed to serve platform operators, not human principals.
+
+- **A2A** authenticates agents as platform entities. Privacy is an "opacity principle" — aspirational, not enforced. No context minimization. No session ephemerality.
+- **MCP** connects models to tools. It is not an agent-to-agent negotiation protocol. Its own spec acknowledges it "cannot enforce these security principles at the protocol level."
+- **ACP** handles REST-based agent interop. Thin trust layer. No cryptographic identity.
+- **CrewAI, LangGraph, OpenAI Agents SDK** treat privacy as an implementation detail. LangGraph's default is a shared scratchpad where every agent sees everything.
+
+None enforce context minimization at the protocol level. None define session ephemerality as a guarantee. None have economic primitives. Privacy is always somebody else's problem.
 
 ## The Design
 
-PAP is designed from the opposite direction. The human principal is the root of trust. Every agent in a transaction carries a cryptographically verifiable mandate from that root. Sessions are ephemeral by design. Context disclosure is enforced by the protocol, not by policy. The cloud is a stateless utility invoked by agents, not a relationship that accumulates principal context.
+PAP makes it the protocol's problem.
+
+The human principal is the root of trust. Every agent in a transaction carries a cryptographically verifiable mandate from that root. Sessions are ephemeral by design. Context disclosure is enforced by the protocol, not by policy. The cloud is a stateless utility invoked by agents, not a relationship that accumulates principal context.
 
 **No new cryptography. No token economy. No central registry.**
+
+## Why Should I Care?
+
+You searched for a stroller once. Now every website thinks you're pregnant. For six months. That's one query, with a human behind a browser. Now imagine AI agents making hundreds of queries on your behalf — every one leaking context to platforms that build profiles, adjust prices, and sell your behavioral data to brokers you've never heard of.
+
+PAP ensures your agent discloses only what you explicitly permit, to the specific service that needs it, for the duration of a single session, with a signed receipt proving what happened.
 
 ## Trust Model
 
@@ -20,174 +35,239 @@ Human Principal (device-bound keypair, root of trust)
        └─ Downstream Agents (scoped task mandates)
             └─ Marketplace Agents (own principal chains)
 
-Transactions are handshakes between two chains, not two agents.
+Transactions are handshakes between two mandate chains, not two agents.
 ```
 
-- **Deny by default** — an agent can only do what its mandate explicitly permits
-- **Delegation cannot exceed parent** — scope and TTL are bounded by the issuing mandate
-- **Session DIDs are ephemeral** — unlinked to principal identity, discarded at close
-- **Receipts contain property references only** — never values
-- **No platform stores principal context**
+Five constraints enforced at the protocol level:
+
+1. **Deny by default** — an agent can only do what its mandate explicitly permits
+2. **Delegation cannot exceed parent** — scope and TTL are bounded, verified cryptographically
+3. **Session DIDs are ephemeral** — unlinked to principal identity, discarded at close
+4. **Receipts contain property references only** — never values
+5. **Non-renewal is revocation** — mandates degrade progressively (Active → Degraded → ReadOnly → Suspended)
+
+## Quick Start
+
+```bash
+git clone https://github.com/Baur-Software/pap.git
+cd pap
+cargo test
+
+# Core protocol examples
+cargo run --bin search               # Zero-disclosure search
+cargo run --bin travel-booking       # SD-JWT selective disclosure
+cargo run --bin delegation-chain     # 4-level trust hierarchy
+cargo run --bin payment              # Ecash + auto-approval + continuity
+
+# Transport & federation
+cargo run --bin networked-search     # Full 6-phase handshake over HTTP
+cargo run --bin federated-discovery  # Cross-registry agent discovery
+cargo run --bin webauthn-ceremony    # Device-bound key generation
+```
 
 ## Protocol Stack
 
-PAP is built entirely on existing, standardized primitives:
+Built entirely on existing, standardized primitives:
 
 | Layer | Standard | Purpose |
 |-------|----------|---------|
 | Identity | [WebAuthn](https://www.w3.org/TR/webauthn-3/) | Device-bound keypair generation |
-| Identity | [W3C DIDs](https://www.w3.org/TR/did-core/) | Decentralized identifiers |
+| Identity | [W3C DIDs](https://www.w3.org/TR/did-core/) | Decentralized identifiers (`did:key`) |
 | Credentials | [W3C VCs](https://www.w3.org/TR/vc-data-model-2.0/) | Mandate envelope |
 | Disclosure | [SD-JWT](https://www.ietf.org/archive/id/draft-ietf-oauth-selective-disclosure-jwt-08.txt) | Selective claim disclosure |
 | Vocabulary | [Schema.org](https://schema.org) | Capability and action types |
 | Data | [JSON-LD](https://www.w3.org/TR/json-ld11/) | Structured linked data |
 | Privacy | [Oblivious HTTP](https://www.rfc-editor.org/rfc/rfc9458) | Cloud request unlinkability |
+| Transport | HTTP/JSON | 6-phase session handshake |
+| Federation | HTTP/JSON | Cross-registry sync, announce, peer discovery |
 
 ## Crate Structure
 
 ```
 pap/
   crates/
-    pap-did/          # DID document generation, session keypairs (did:key, Ed25519)
-    pap-core/         # Mandate, scope, session, receipt primitives
+    pap-did/          # DID generation, session keypairs (did:key, Ed25519)
+    pap-core/         # Mandate, scope, session, receipt, extensions
     pap-credential/   # W3C VC envelope, SD-JWT selective disclosure
-    pap-marketplace/  # Agent advertisement schema, registry, discovery
+    pap-marketplace/  # Agent advertisement, registry, discovery
+    pap-proto/        # Protocol message types and envelope
+    pap-transport/    # HTTP client/server for 6-phase handshake
+    pap-federation/   # Cross-registry sync, announce, peer exchange
+    pap-webauthn/     # WebAuthn signer abstraction + software fallback
   examples/
-    search/           # End-to-end PoC: principal -> orchestrator -> search agent
+    search/              # Zero-disclosure end-to-end PoC
+    travel-booking/      # SD-JWT selective disclosure
+    delegation-chain/    # 4-level mandate hierarchy
+    payment/             # Ecash + auto-approval + continuity tokens
+    networked-search/    # HTTP transport handshake
+    federated-discovery/ # Cross-registry federation
+    webauthn-ceremony/   # Device-bound key generation
+    local-ai-assistant/  # Docker Compose: Ollama + SearXNG + PAP
 ```
 
 ### pap-did
 
-`PrincipalKeypair` — Ed25519 keypair with `did:key` derivation. Root of trust.
-`SessionKeypair` — Ephemeral, single-use, unlinked to principal identity.
-`DidDocument` — W3C DID Core document. Contains no personal information.
+- `PrincipalKeypair` — Ed25519 keypair with `did:key` derivation. Root of trust.
+- `SessionKeypair` — Ephemeral, single-use, unlinked to principal identity.
+- `DidDocument` — W3C DID Core document. Contains no personal information.
 
 ### pap-core
 
-`Scope` — Schema.org action references, deny-by-default. Schema.org describes the what; the protocol governs under what terms.
-`Mandate` — Hierarchical delegation with chain verification. Scope cannot exceed parent. TTL cannot exceed parent. Optional `payment_proof` for privacy-preserving payment (Chaumian ecash / Lightning).
-`DecayState` — Active / Degraded / ReadOnly / Suspended. Progressive scope reduction on non-renewal.
-`CapabilityToken` — Single-use, bound to target DID + action + nonce. Not a billable unit.
-`Session` — State machine: Initiated / Open / Executed / Closed.
-`TransactionReceipt` — Co-signed by both parties. Property references only, never values.
-`ContinuityToken` — Encrypted vendor state handed to the orchestrator at session close. Principal controls TTL and deletion. Vendor retains nothing.
-`AutoApprovalPolicy` — Principal-authored policy for micro-transactions. Cannot exceed mandate scope. Zero additional disclosure by default.
+- `Scope` — Schema.org action references, deny-by-default.
+- `Mandate` — Hierarchical delegation with chain verification. Scope/TTL bounded by parent. Optional `payment_proof`.
+- `DecayState` — Active / Degraded / ReadOnly / Suspended. Progressive scope reduction.
+- `CapabilityToken` — Single-use, bound to target DID + action + nonce. Not a billable unit.
+- `Session` — State machine: Initiated → Open → Executed → Closed.
+- `TransactionReceipt` — Co-signed by both parties. Property references only.
+- `ContinuityToken` — Encrypted vendor state. Principal controls TTL and deletion.
+- `AutoApprovalPolicy` — Principal-authored policies for micro-transactions.
 
 ### pap-credential
 
-`VerifiableCredential` — W3C VC Data Model 2.0 envelope wrapping mandate payloads.
-`SelectiveDisclosureJwt` — SD-JWT for the disclosure exchange in the session handshake. Over-disclosure is structurally prevented.
+- `VerifiableCredential` — W3C VC 2.0 envelope wrapping mandate payloads.
+- `SelectiveDisclosureJwt` — SD-JWT. Over-disclosure structurally prevented.
 
 ### pap-marketplace
 
-`AgentAdvertisement` — Signed JSON-LD using Schema.org types. Describes capabilities, disclosure requirements, return types.
-`MarketplaceRegistry` — Local registry for the PoC. Query by action type, filter by satisfiable disclosure requirements.
+- `AgentAdvertisement` — Signed JSON-LD. Capabilities, disclosure requirements, return types.
+- `MarketplaceRegistry` — Query by action type, filter by satisfiable disclosure.
 
-## Quick Start
+### pap-transport
 
-```bash
-# Clone and test
-git clone https://github.com/Baur-Software/pap.git
-cd pap
-cargo test
+- `AgentServer` — Axum HTTP server exposing 6 protocol phase endpoints.
+- `AgentClient` — HTTP client driving the handshake from the initiator side.
+- 6-phase protocol: Token → DID Exchange → Disclosure → Execution → Receipt → Close.
 
-# Run the examples
-cargo run --bin search            # Zero-disclosure search
-cargo run --bin travel-booking    # SD-JWT selective disclosure
-cargo run --bin delegation-chain  # Multi-hop trust hierarchy
-cargo run --bin payment           # Ecash + auto-approval + continuity
-```
+### pap-federation
+
+- `FederatedRegistry` — Local + remote agent tracking with content-hash dedup.
+- `FederationServer` — HTTP endpoints for query, announce, peer discovery.
+- `FederationClient` — Pull sync by action type, push announcements, peer exchange.
 
 ## Examples
 
-Four end-to-end examples demonstrate the full protocol surface. Each exercises protocol features the others do not.
+Seven examples demonstrate the full protocol surface. Each exercises features the others do not.
 
 ### `search` — Zero-Disclosure Transaction
 
-The simplest meaningful transaction that proves the trust model works end to end: a web search with zero personal disclosure.
+The simplest transaction that proves the trust model works: a web search with zero personal disclosure.
 
-1. Principal generates an Ed25519 keypair and DID document
-2. Principal issues a root mandate to the orchestrator (scope: `schema:SearchAction`)
-3. Orchestrator queries the local marketplace registry for a search agent
-4. Orchestrator mints a capability token bound to the search agent's DID
-5. Orchestrator delegates a task mandate to an initiating agent
-6. Initiating agent presents the capability token to the search agent
-7. Search agent verifies the token — target DID, nonce, signature chain
-8. Both agents exchange ephemeral session DIDs (unlinked to principal identity)
-9. Initiating agent discloses nothing — search requires no personal context
-10. Search agent executes and returns structured results
-11. Both agents co-sign a transaction receipt (property refs only, no values)
-12. Session closes — ephemeral keys discarded, nonce consumed
+12 protocol steps. Principal generates keypair → issues mandate → marketplace query → capability token → delegation → token presentation → session DID exchange → zero disclosure → execution → co-signed receipt → session close → receipt audit.
 
-The receipt is auditable by both principals. No platform stored anything.
+```bash
+cargo run --bin search
+```
 
 ### `travel-booking` — Selective Disclosure
 
-A flight booking that requires personal context — proving the disclosure controls work under real constraints.
+A flight booking requiring personal context. Proves disclosure controls work under real constraints.
 
-**Key features demonstrated:**
-- SD-JWT selective disclosure: 2 of 4 claims revealed (name + nationality), email + telephone withheld
-- W3C Verifiable Credential envelope wrapping the mandate
-- Marketplace disclosure filtering: agents requiring more than the mandate permits are filtered out before mandate issuance
-- `session_only` and `no_retention` enforcement on disclosed data
-- Receipt records property references only — "Alice Baur" and "US" never appear in the receipt
+- SD-JWT: 2 of 4 claims revealed (name + nationality). Email + telephone cryptographically withheld.
+- Marketplace filtering: agents requiring more than the mandate permits are excluded before mandate issuance.
+- Receipt: property references only. "Alice Baur" and "US" never appear.
+
+```bash
+cargo run --bin travel-booking
+```
 
 ### `delegation-chain` — Hierarchical Trust
 
-A 4-level mandate hierarchy for a travel orchestrator decomposing a trip into sub-tasks.
+4-level mandate hierarchy. Scope narrows and TTL shrinks at each level.
 
-**Key features demonstrated:**
-- Principal → Orchestrator → Trip Planner → Booking Agent (4 levels)
-- Scope narrows at each level: `[Search, Reserve(Flight), Reserve(Lodging), Pay]` → `[Search, Reserve(Flight)]` → `[Reserve(Flight)]`
-- TTL shrinks at each level: 4h → 3h → 2h (broader mandate = shorter life)
-- Full chain verification across all levels (signatures, parent hashes, scope containment, TTL monotonicity)
-- Three rejected delegations: scope exceeded, TTL exceeded, cross-object-type
-- Decay state transitions: Active → Degraded → ReadOnly → Suspended
-- Renewal restores Active from Degraded/ReadOnly; Suspended requires principal review
+| Level | Agent | Scope | TTL |
+|-------|-------|-------|-----|
+| 0 | Human Principal | (root) | — |
+| 1 | Orchestrator | Search, Reserve(Flight), Reserve(Lodging), Pay | 4h |
+| 2 | Trip Planner | Search, Reserve(Flight) | 3h |
+| 3 | Booking Agent | Reserve(Flight) | 2h |
+
+Three rejected delegations prove the constraints hold. Decay state transitions demonstrate progressive degradation.
+
+```bash
+cargo run --bin delegation-chain
+```
 
 ### `payment` — Protocol Extensions
 
-A digital purchase demonstrating the extensions from PAP spec sections 9.1, 9.3, and 9.4.
+Chaumian ecash payment proof (vendor cannot identify payer), value-capped auto-approval ($12.99 auto-approved below $20 threshold), and continuity tokens (90-day principal-controlled TTL, delete to sever).
 
-**Key features demonstrated:**
-- `payment_proof` field: Chaumian ecash blind-signed token (vendor cannot identify payer)
-- Value-capped scope conditions: `max_value: $50`, `requires_confirmation_above: $20`
-- Auto-approval policies: principal-authored, validated against mandate scope, rejected if policy exceeds mandate
-- $12.99 purchase auto-approved (below $20 threshold), zero personal disclosure
-- Continuity token: encrypted vendor state handed to orchestrator at session close, principal-controlled 90-day TTL
-- Relationship severance: principal deletes the token. Done.
+```bash
+cargo run --bin payment
+```
 
-## Protocol Extensions
+### `networked-search` — HTTP Transport
 
-The following extensions are part of the PAP design but not required for a minimal compliant implementation. Each is evaluated against a single test: does this reduce or expand the attack surface for incumbent platform capture?
+Same protocol invariants as the in-memory search, but over HTTP. Single binary spawns an Axum server on a random port, then the client drives the 6-phase handshake. Proves the transport is a thin wrapper — it doesn't change the trust model.
 
-**Privacy-Preserving Payment** — Chaumian ecash or Lightning preimage proofs. The vendor receives proof of value transfer but nothing that identifies the payer. Mandates carry an optional `payment_proof` field. Explicitly excluded: fiat-linked rails identifiable by the payment processor.
+```bash
+cargo run --bin networked-search
+```
 
-**Continuity Tokens** — Encrypted vendor state handed to the orchestrator at session close for long-term relationships (returns, support, subscriptions). The principal controls the TTL. The vendor cannot write without the principal presenting the token. Delete the token to sever the relationship.
+### `federated-discovery` — Marketplace Federation
 
-**Auto-Approval Tiers** — Principal-authored policies for micro-transactions. A policy cannot be more permissive than the underlying mandate. An agent cannot trigger a policy change by requesting it. Default: zero additional disclosure required.
+Two independent registries on different ports. Registry A has a search agent. Registry B has a payment agent. Federation sync makes search agents discoverable through Registry B. Push announcements, content-hash dedup, peer discovery.
 
-**Hardware-Constrained Principals** — Confidential computing enclaves (Nitro, SEV, TDX) as a declared fallback for principals without sufficient local hardware. Not equivalent to local — the spec is honest about the trust assumption. The enclave provider must not be the same entity as any marketplace agent.
+```bash
+cargo run --bin federated-discovery
+```
 
-**Institutional Recovery Nodes** — Banks, legal firms, and notaries can participate as threshold nodes in M-of-N social recovery. Cannot be single points of recovery. Explicitly excluded: institutions that are also platform operators, cloud providers, or advertising networks.
+### `webauthn-ceremony` — Device-Bound Keys
+
+WebAuthn-based key generation with mock authenticator for testing. Demonstrates the production path for device-bound principal keypairs.
+
+```bash
+cargo run --bin webauthn-ceremony
+```
+
+### `local-ai-assistant` — Docker Compose
+
+A complete local AI assistant: Ollama (local LLM) + SearXNG (private search) + PAP marketplace + three provider agents + orchestrator + receipt viewer. Your prompts never leave your machine. External tool use goes through PAP's full handshake with selective disclosure.
+
+```bash
+cd examples/local-ai-assistant
+docker compose up -d
+docker exec ollama ollama pull mistral
+curl http://localhost:9010/ask -d '{"query": "What is the weather in Seattle?"}'
+curl http://localhost:9090/receipts  # See what was disclosed
+```
 
 ## What This Replaces
 
-**A2A** authenticates agents as platform entities, not as mandate-holders for human principals.
-**ACP** focuses on enterprise workflow interoperability. The principal is the enterprise, not the individual.
-**MCP** handles tool-use for a single agent session. It is not a negotiation protocol between agents representing different principals.
+| Concern | A2A | MCP | ACP | PAP |
+|---------|-----|-----|-----|-----|
+| Context minimization | No | No | No | SD-JWT per interaction |
+| Session ephemerality | No | Stateful | Stateless option | Ephemeral DIDs, keys discarded |
+| Field-level disclosure | No | No | No | SD-JWT selective claims |
+| Cryptographic scope enforcement | No | No | No | Mandate chain verification |
+| Agent-to-agent negotiation | Yes | No (tool access) | Yes | Yes |
+| Privacy-preserving payment | No | No | No | Ecash / Lightning proofs |
+| Marketplace discovery | Agent Cards | None | HTTP | Federated, disclosure-filtered |
+| Audit trail | No | No | No | Co-signed receipts |
+| Principal control | Platform | User (stated) | Enterprise | Cryptographic mandate |
 
-None enforce context minimization at the protocol level. None define session ephemerality as a protocol guarantee. All are compatible with token economy monetization.
+## Protocol Extensions
 
-PAP has no token economy. The capability token is a single-use cryptographic proof, not a billable unit. When inference runs locally and sessions are ephemeral, there is no persistent relationship to monetize.
+Extensions evaluated against the capture test: does this reduce or expand the attack surface for incumbent platform capture?
+
+- **Privacy-Preserving Payment** — Ecash / Lightning proofs. Vendor cannot identify payer.
+- **Continuity Tokens** — Encrypted vendor state, principal-controlled TTL. Delete to sever.
+- **Auto-Approval Tiers** — Principal-authored policies. Cannot exceed mandate scope.
+- **Hardware-Constrained Principals** — Confidential computing fallback. Spec is honest about the trust assumption.
+- **Institutional Recovery** — M-of-N social recovery via banks/notaries. No single points. No platform operators.
 
 ## The Capture Test
 
-Any proposal that routes principal context through infrastructure owned by incumbent platforms is out of scope, regardless of the cryptographic framing around it. Every major internet protocol that started with user sovereignty has been captured by the entities with the largest infrastructure footprint.
+Any proposal that routes principal context through infrastructure owned by incumbent platforms is out of scope, regardless of the cryptographic framing. Every major internet protocol that started with user sovereignty has been captured by the entities with the largest infrastructure footprint.
 
-**Explicit non-goals:** compatibility with token economy monetization; enclave-as-equivalent-to-local; identity recovery through platform operators; payment mechanisms linkable to principal identity; central registries for agent discovery; mandate structures allowing runtime scope expansion; UI standards permitting arbitrary code execution in the orchestrator; any extension that trades trust guarantees for adoption ease.
+**Explicit non-goals:** token economy compatibility; enclave-as-equivalent-to-local; identity recovery through platform operators; payment mechanisms linkable to principal identity; central registries; runtime scope expansion; arbitrary code execution in the orchestrator; any extension that trades trust guarantees for adoption ease.
 
-Good feedback makes the protocol harder to capture. Proposals that introduce new trusted third parties, centralize discovery, soften disclosure enforcement, or create compatibility with metering models should be evaluated as potential capture vectors first and protocol improvements second.
+Good feedback makes the protocol harder to capture.
+
+## Blog Posts
+
+- [Your Agent Works for a Platform. It Should Work for You.](https://baursoftware.com/your-agent-works-for-a-platform-it-should-work-for-you/) — Protocol introduction + code walkthrough
+- [Show Me the Agents: PAP in Practice](https://baursoftware.com/show-me-the-agents-pap-in-practice/) — Real-world scenarios + docker-compose examples
+- [The Tollbooth Model Is Over](https://baursoftware.com/the-tollbooth-model-is-over/) — Economic context
 
 ## Specification
 

--- a/blog-post-examples.md
+++ b/blog-post-examples.md
@@ -1,0 +1,149 @@
+# Show Me the Agents: PAP in Practice
+
+The [first post](https://baursoftware.com/your-agent-works-for-a-platform-it-should-work-for-you/) introduced the Principal Agent Protocol and walked through the proof-of-concept examples. The protocol primitives work. The question that matters now: what would you actually build with this?
+
+This post answers that question with five concrete scenarios. Each one exercises a different combination of protocol features. Each one is designed to make a specific problem viscerally obvious — and then show what the same interaction looks like when the human principal controls the trust chain.
+
+## The Landscape: Protocols Without Privacy
+
+Before the scenarios, a quick orientation on why PAP exists.
+
+Six months into the agent protocol race, here is where we stand:
+
+**Google A2A** defines agent cards and task lifecycle. Privacy is an "opacity principle" — aspirational, not enforced. No context minimization. No session ephemerality. Auth formalization is still on the roadmap.
+
+**Anthropic MCP** connects models to tools and data sources. It does this well. But it is not an agent-to-agent protocol. There is no concept of agents negotiating with other agents, no selective disclosure, and no mechanism for the principal to constrain what the model shares with tools at the protocol level. MCP's security principles are stated, not enforced — the spec itself says this.
+
+**Microsoft Semantic Kernel / AutoGen** assumes all agents in the system trust each other. Identity is Azure AD. The trust boundary is the Microsoft ecosystem.
+
+**ACP** handles REST-based agent interoperability. Thin trust layer. No cryptographic identity. Now merging governance with A2A.
+
+**Every framework** — CrewAI, LangGraph, OpenAI Agents SDK — treats privacy as an implementation detail. LangGraph's default pattern is a shared scratchpad where every agent sees everything. None enforce context minimization. None define session ephemerality. None have economic primitives.
+
+The common thread: **no existing protocol enforces context minimization at the protocol level.** Disclosure is always voluntary. Session residue is always undefined. Privacy is always somebody else's problem.
+
+PAP makes it the protocol's problem.
+
+## Scenario 1: Your AI Assistant Uses Tools Without Leaking Your Identity
+
+The simplest scenario. The one every developer building on top of a local LLM will hit immediately.
+
+**The setup**: You run Mistral (or Llama, or Phi) via Ollama on your laptop. You ask: "What's the weather in Seattle and what's the latest news about renewable energy?"
+
+**What happens today**: Your assistant calls OpenWeatherMap and Brave Search with your API keys. Those services log your IP, your auth identity, and every query. Your weather lookups are correlated with your search history. Over time, the services build a profile of your interests and location patterns.
+
+**What happens with PAP**: Your orchestrator agent issues a mandate scoped to `[SearchAction, CheckAction]` with an 8-hour TTL. It queries the local marketplace for providers. SearXNG (self-hosted, zero-disclosure) handles search. OpenWeatherMap handles weather — but receives only an ephemeral session DID and the word "Seattle" via SD-JWT selective disclosure. Your name, IP, and device ID are cryptographically withheld. The session closes. The DID is discarded. Tomorrow's weather query is unlinkable to today's.
+
+```
+[mandate] Scope: [SearchAction, CheckAction], TTL: 8h, Disclosure: minimal
+[marketplace] Found 3 providers for SearchAction (0 require personal disclosure)
+[marketplace] Found 1 provider for CheckAction (requires: Place.name only)
+[session] Weather: disclosed [Place.name] via SD-JWT. Values: never in receipt.
+[session] Search: disclosed [] (nothing).
+[receipt] Signed by both parties. Auditable. Contains zero personal data.
+```
+
+**The docker-compose version** is in the repo: `examples/local-ai-assistant/`. Ollama, SearXNG, a PAP marketplace, three provider agents (search, weather, encyclopedia), an orchestrator, and a receipt viewer. `docker compose up -d` and you're running it.
+
+**What this proves**: tool use does not require identity disclosure. The protocol enforces this. The application developer does not have to remember to strip headers or rotate API keys. The mandate says what can be disclosed. The SD-JWT makes it structurally impossible to disclose more.
+
+## Scenario 2: Shopping Without Becoming a Target
+
+You searched for a stroller once. Now every website thinks you are pregnant. For six months.
+
+This is not an exaggeration. It is how behavioral advertising works. A single search query triggers profile updates across dozens of data brokers. Your "pregnancy score" affects insurance quotes, ad targeting, and financial product recommendations. You cannot undo it.
+
+**With PAP**: Your personal agent searches for strollers via SearXNG (zero disclosure). It contacts retailer agents via the marketplace. The mandate permits disclosure of: shipping region (zip prefix only) and budget range. Retailer agents compete on price and features without knowing who you are.
+
+The marketplace does the filtering before the negotiation starts. An agent that requires your full name, email, and phone number to show you stroller prices? It never appears in the results. The mandate cannot satisfy its disclosure requirements, so the marketplace excludes it.
+
+Three retailers respond. You pick one. Your agent handles payment through a privacy-preserving channel (Chaumian ecash proof — the vendor receives proof of value transfer but nothing that identifies the payer). The stroller arrives. The internet has no memory of your search.
+
+**What the demo shows**: A split screen. Left side: the normal flow — your query propagating through data brokers, profile updates, ad targeting. Right side: the PAP flow — three vendor agents competing, disclosure requirements color-coded (green = minimal, red = excessive), ephemeral sessions, and a final receipt showing exactly what was shared. The contrast is the entire argument.
+
+## Scenario 3: Your Child Online Without Surveillance Capitalism
+
+Your 11-year-old wants to look up volcanoes for a school project. You want them to be safe. YouTube wants to build a psychological profile that will follow them for the rest of their lives.
+
+By age 13, a child has a shadow profile across dozens of platforms that predicts their vulnerabilities, insecurities, and spending triggers. COPPA technically requires consent. The "consent" is a checkbox you clicked once.
+
+**With PAP**: You are the trust root. Your child's agent carries a mandate delegated from your keypair. The mandate specifies:
+
+- Scope: `education.content` (not social, not shopping, not entertainment)
+- Disclosure: `age_range: 10-12` via SD-JWT. Nothing else. No name, no school, no persistent ID.
+- TTL: 2 hours per session. Auto-expire. No continuity tokens issued.
+- Policy: approve educational content automatically, flag entertainment, block in-app purchases.
+
+Each content request uses a new session DID. The platform cannot correlate Monday's volcano search with Tuesday's dinosaur search. There is no longitudinal behavioral profile because there is no continuity for the protocol to leak.
+
+**The protocol feature that matters**: marketplace disclosure filtering. Content providers that require student identity, behavioral data, or engagement metrics are excluded before any connection is made. Your child never even sees the privacy-hostile option.
+
+## Scenario 4: Medical Questions Without a Permanent Record
+
+You have a weird mole. You want to know if it is something to worry about. You Google it.
+
+You have now altered your insurance risk profile. Health-adjacent data brokers flag you as "cancer concern." If you apply for life insurance, the underwriter's data vendor may surface your search history as a risk signal. You never had cancer. You had a normal mole. But the data says you were worried, and that data never expires.
+
+**With PAP**: Your local LLM does initial triage — no network call. If it needs external data, it queries a medical knowledge service via PAP. The SD-JWT discloses: `adult, dermatological inquiry`. Nothing else. The session DID is ephemeral. The service cannot link this query to any identity. The receipt records `[subject: dermatology]` — never the question you asked or the answer you received.
+
+You book a dermatologist appointment. Only at that point does your agent ask: "The booking service needs your name and insurance ID. Approve?" You approve. The booking agent receives exactly two fields. The medical knowledge service never learns your name. Your insurance company sees a routine dermatology visit, not a cancer scare.
+
+**The protocol feature that matters**: information flow isolation between scopes. Data obtained under the `health.research` scope cannot cross into the `health.booking` scope. This is enforced by the mandate chain, not by application logic.
+
+## Scenario 5: B2B Data Exchange with Revocable, Scoped Access
+
+During M&A due diligence, Company A's legal agent needs to share financial documents with Company B's analysis agent. Requirements that OAuth cannot satisfy:
+
+1. Access must be revocable at any moment by Company A's principal.
+2. Company B's agent should see specific fields (revenue, headcount) but not others (customer names, contracts).
+3. Every access must produce a non-repudiable receipt.
+4. The relationship should survive across weeks without re-authentication.
+
+**With PAP**: Company A issues a continuity token to Company B's agent. The token carries a 30-day TTL set by Company A (not Company B's preference). The mandate permits `ReadOnly` access to financial summaries. SD-JWT selective disclosure ensures Company B sees `revenue: $15M, headcount: 120` but never customer names or contract details — the SD-JWT payload structurally cannot reveal fields excluded by the mandate.
+
+Every access generates a signed receipt: `[accessed: financials.revenue, financials.headcount at 14:32 UTC]`. No values in the receipt — just property references. During a regulatory audit, Company A can prove exactly what categories of data were shared and when, without exposing the actual numbers.
+
+Company A revokes access mid-diligence? Delete the continuity token. Company B's next request fails with a signed revocation proof. There is no stale token floating in a cache somewhere. Revocation is instant because the token is the relationship.
+
+**The protocol feature that matters**: continuity tokens with principal-controlled TTL. The vendor (Company B) retains nothing. The relationship exists only because the principal (Company A) holds the token and chooses to present it.
+
+## What These Scenarios Have in Common
+
+Every scenario follows the same pattern:
+
+```
+[Principal] -> [Mandate with scoped permissions]
+    -> [Orchestrator discovers providers via marketplace]
+        -> [SD-JWT selective disclosure per interaction]
+            -> [Ephemeral session DIDs, no correlation]
+                -> [Signed receipts, no stored values]
+                    -> [Session closes, keys discarded]
+```
+
+And every scenario makes the same argument: the privacy gap in agent-to-agent communication is not a feature request. It is an architectural flaw in every protocol currently deployed. Policy-based privacy fails at agent scale because agents follow instructions, and the instructions come from whoever designed the agent — not necessarily from the principal the agent claims to serve.
+
+PAP makes the principal's intent cryptographically bound to every interaction. Not by policy. Not by configuration. By the mandate chain that every downstream agent must verify before it can act.
+
+## Try It
+
+The repo has seven working examples. Four exercise the core protocol (search, travel-booking, delegation-chain, payment). Three exercise the transport and federation layers (networked-search, federated-discovery, webauthn-ceremony). The local AI assistant docker-compose brings them together with real services.
+
+```bash
+git clone https://github.com/Baur-Software/pap.git
+cd pap
+cargo test                           # all tests
+cargo run --bin search               # zero disclosure
+cargo run --bin travel-booking       # selective disclosure
+cargo run --bin delegation-chain     # hierarchical trust
+cargo run --bin payment              # protocol extensions
+cargo run --bin networked-search     # HTTP transport
+cargo run --bin federated-discovery  # marketplace federation
+```
+
+The protocol is in the types. The constraints are in the compiler. The trust model is in the signatures.
+
+If you build agents, the question is not whether they can talk to each other. The question is who they answer to.
+
+---
+
+*Todd Baur is the founder of [Baur Software](https://baursoftware.com). PAP is open source under MIT/Apache-2.0. The repo is at [github.com/Baur-Software/pap](https://github.com/Baur-Software/pap). Comments, objections, and alternative proposals are the point of publishing at draft stage.*

--- a/examples/local-ai-assistant/README.md
+++ b/examples/local-ai-assistant/README.md
@@ -1,0 +1,85 @@
+# Local AI Assistant — PAP Example
+
+A personal AI assistant running entirely on your hardware, using PAP to safely interact with external services.
+
+## What This Demonstrates
+
+1. **Local-first AI**: Ollama runs your LLM locally. Your prompts never leave your machine.
+2. **Zero-disclosure search**: SearXNG provides private web search. No query logging. No tracking.
+3. **Selective disclosure**: Weather lookup discloses only a city name — no identity, no device info.
+4. **Marketplace discovery**: The orchestrator finds providers at runtime. No pre-configured API keys.
+5. **Ephemeral sessions**: Each service interaction uses throwaway session DIDs. No correlation possible.
+6. **Auditable receipts**: Every interaction produces a signed receipt showing what *types* of data were shared.
+
+## Architecture
+
+```
+[You] -> [Ollama LLM] -> [PAP Orchestrator] -> [Marketplace] -> [Provider Agents]
+                                                      |
+                                  +------------------+------------------+
+                                  |                  |                  |
+                            [SearXNG Agent]   [Weather Agent]   [Wikipedia Agent]
+                            (zero disclosure) (city name only)  (zero disclosure)
+```
+
+The orchestrator is the **only** component that knows who you are. Every downstream agent sees an ephemeral session DID and only the data fields permitted by the mandate.
+
+## Quick Start
+
+```bash
+# Start all services
+docker compose up -d
+
+# Pull an LLM model
+docker exec ollama ollama pull mistral
+
+# Ask a question (triggers PAP handshake with external services)
+curl http://localhost:9010/ask \
+  -H "Content-Type: application/json" \
+  -d '{"query": "What is the weather in Seattle and what is the population?"}'
+
+# View the disclosure audit log
+curl http://localhost:9090/receipts | jq .
+```
+
+## What You'll See
+
+The orchestrator decomposes your question into sub-tasks, discovers providers via the marketplace, and executes each with a separate PAP session:
+
+```
+[mandate] Scope: [SearchAction, CheckAction], TTL: 8h
+[marketplace] Found 3 providers for SearchAction (0 require personal disclosure)
+[marketplace] Found 1 provider for CheckAction (requires: Place.name)
+[session] Weather Agent: disclosed [Place.name: "Seattle"] via SD-JWT
+[session] Private Search Agent: disclosed [] (nothing)
+[session] Encyclopedia Agent: disclosed [] (nothing)
+[receipt] Weather: {disclosed: ["schema:Place.name"], values: [REDACTED]}
+[receipt] Search: {disclosed: [], values: []}
+[receipt] Encyclopedia: {disclosed: [], values: []}
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `OPENWEATHER_API_KEY` | `demo` | OpenWeatherMap API key (free tier: openweathermap.org/appid) |
+| `SEARXNG_SECRET` | `pap-demo-secret` | SearXNG instance secret |
+
+## Services
+
+| Service | Port | Description |
+|---------|------|-------------|
+| Ollama | 11434 | Local LLM inference |
+| SearXNG | 8888 | Private metasearch engine |
+| Marketplace | 9000 | PAP agent marketplace registry |
+| Search Provider | 9001 | PAP-wrapped SearXNG |
+| Weather Provider | 9002 | PAP-wrapped OpenWeatherMap |
+| Wikipedia Provider | 9003 | PAP-wrapped Wikipedia API |
+| Orchestrator | 9010 | PAP orchestrator + LLM integration |
+| Receipt Viewer | 9090 | Disclosure audit log viewer |
+
+## The Point
+
+You asked about the weather. A normal assistant would send your IP address, device fingerprint, and account identity to a weather API. This assistant sent an ephemeral DID and the word "Seattle."
+
+That's the difference between a tool that works for a platform and a tool that works for you.

--- a/examples/local-ai-assistant/docker-compose.yml
+++ b/examples/local-ai-assistant/docker-compose.yml
@@ -1,0 +1,169 @@
+# PAP Local AI Assistant — Docker Compose Example
+#
+# Demonstrates: A personal AI assistant running a local LLM (Ollama)
+# that uses PAP to query external services with zero identity disclosure.
+#
+# What this proves:
+# - Your AI runs locally. Your prompts never leave your machine.
+# - External tool use goes through PAP's 6-phase handshake.
+# - Each service sees only what the mandate permits (SD-JWT selective disclosure).
+# - Each session uses ephemeral DIDs — services cannot correlate your queries.
+# - Receipts log what *types* of data were shared, never the values.
+#
+# Usage:
+#   docker compose up -d
+#   docker exec ollama ollama pull mistral
+#   curl http://localhost:9010/ask -d '{"query": "What is the weather in Seattle?"}'
+#
+# Architecture:
+#   [You] -> [Ollama LLM] -> [PAP Orchestrator] -> [Marketplace] -> [Provider Agents]
+#                                                        |
+#                                    +------------------+------------------+
+#                                    |                  |                  |
+#                              [SearXNG Agent]   [Weather Agent]   [Wikipedia Agent]
+#                              (private search)   (OpenWeatherMap)  (encyclopedia)
+
+version: "3.9"
+
+services:
+  # ─── Local LLM (your AI, your hardware, your data) ──────────────
+  ollama:
+    image: ollama/ollama:latest
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_data:/root/.ollama
+    restart: unless-stopped
+
+  # ─── Private Search (no query logging, no tracking) ─────────────
+  searxng:
+    image: searxng/searxng:latest
+    ports:
+      - "8888:8080"
+    environment:
+      - SEARXNG_SECRET=${SEARXNG_SECRET:-pap-demo-secret}
+    volumes:
+      - ./searxng-settings.yml:/etc/searxng/settings.yml:ro
+    restart: unless-stopped
+
+  # ─── PAP Marketplace (agent discovery, disclosure filtering) ────
+  marketplace:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.marketplace
+    ports:
+      - "9000:9000"
+    environment:
+      - RUST_LOG=info
+      - BIND_ADDR=0.0.0.0:9000
+    restart: unless-stopped
+
+  # ─── Provider: Private Search Agent ─────────────────────────────
+  # Wraps SearXNG in a PAP-compliant agent. Requires zero disclosure.
+  search-provider:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.provider
+    ports:
+      - "9001:9001"
+    environment:
+      - PROVIDER_NAME=Private Search Agent
+      - PROVIDER_ORG=SearXNG (self-hosted)
+      - UPSTREAM_URL=http://searxng:8080/search?q={query}&format=json
+      - CAPABILITY=schema:SearchAction
+      - OBJECT_TYPE=schema:WebPage
+      - REQUIRED_DISCLOSURE=  # Empty = zero disclosure required
+      - RETURN_TYPE=schema:SearchResult
+      - BIND_ADDR=0.0.0.0:9001
+      - MARKETPLACE_URL=http://marketplace:9000
+    depends_on:
+      - marketplace
+      - searxng
+    restart: unless-stopped
+
+  # ─── Provider: Weather Agent ────────────────────────────────────
+  # Wraps OpenWeatherMap API. Requires only: location (city name).
+  # Does NOT require: name, email, device ID, or any personal info.
+  weather-provider:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.provider
+    ports:
+      - "9002:9002"
+    environment:
+      - PROVIDER_NAME=Weather Lookup Agent
+      - PROVIDER_ORG=OpenWeatherMap
+      - UPSTREAM_URL=https://api.openweathermap.org/data/2.5/weather?q={location}&appid=${OPENWEATHER_API_KEY:-demo}&units=imperial
+      - CAPABILITY=schema:CheckAction
+      - OBJECT_TYPE=schema:Weather
+      - REQUIRED_DISCLOSURE=schema:Place.name  # Only needs city name
+      - RETURN_TYPE=schema:WeatherReport
+      - BIND_ADDR=0.0.0.0:9002
+      - MARKETPLACE_URL=http://marketplace:9000
+    depends_on:
+      - marketplace
+    restart: unless-stopped
+
+  # ─── Provider: Wikipedia Agent ──────────────────────────────────
+  # Wraps Wikipedia API. Free, public, zero disclosure.
+  wikipedia-provider:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.provider
+    ports:
+      - "9003:9003"
+    environment:
+      - PROVIDER_NAME=Encyclopedia Agent
+      - PROVIDER_ORG=Wikipedia
+      - UPSTREAM_URL=https://en.wikipedia.org/w/api.php?action=query&list=search&srsearch={query}&format=json
+      - CAPABILITY=schema:SearchAction
+      - OBJECT_TYPE=schema:Article
+      - REQUIRED_DISCLOSURE=  # Zero disclosure
+      - RETURN_TYPE=schema:Article
+      - BIND_ADDR=0.0.0.0:9003
+      - MARKETPLACE_URL=http://marketplace:9000
+    depends_on:
+      - marketplace
+    restart: unless-stopped
+
+  # ─── PAP Orchestrator Agent ─────────────────────────────────────
+  # The brain: issues mandates, discovers providers, runs handshakes.
+  # This is the ONLY component that knows who you are.
+  orchestrator:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.orchestrator
+    ports:
+      - "9010:9010"
+    environment:
+      - RUST_LOG=info
+      - LLM_URL=http://ollama:11434/api/generate
+      - LLM_MODEL=mistral
+      - MARKETPLACE_URL=http://marketplace:9000
+      - MANDATE_TTL_HOURS=8
+      - AUTO_APPROVE_ZERO_DISCLOSURE=true
+      - BIND_ADDR=0.0.0.0:9010
+    depends_on:
+      - ollama
+      - marketplace
+      - search-provider
+      - weather-provider
+      - wikipedia-provider
+    restart: unless-stopped
+
+  # ─── Receipt Viewer (audit what was disclosed) ──────────────────
+  receipt-viewer:
+    build:
+      context: ../../
+      dockerfile: examples/local-ai-assistant/Dockerfile.receipt-viewer
+    ports:
+      - "9090:9090"
+    environment:
+      - ORCHESTRATOR_URL=http://orchestrator:9010
+      - BIND_ADDR=0.0.0.0:9090
+    depends_on:
+      - orchestrator
+    restart: unless-stopped
+
+volumes:
+  ollama_data:

--- a/examples/local-ai-assistant/searxng-settings.yml
+++ b/examples/local-ai-assistant/searxng-settings.yml
@@ -1,0 +1,35 @@
+# SearXNG settings for PAP demo — private search with no tracking
+use_default_settings: true
+
+general:
+  instance_name: "PAP Private Search"
+
+search:
+  safe_search: 0
+  default_lang: "en"
+  formats:
+    - html
+    - json
+
+server:
+  secret_key: "pap-demo-secret"
+  limiter: false
+
+ui:
+  static_use_hash: true
+
+engines:
+  - name: duckduckgo
+    engine: duckduckgo
+    shortcut: ddg
+    disabled: false
+
+  - name: wikipedia
+    engine: wikipedia
+    shortcut: wp
+    disabled: false
+
+  - name: wikidata
+    engine: wikidata
+    shortcut: wd
+    disabled: false

--- a/linkedin-post.md
+++ b/linkedin-post.md
@@ -1,0 +1,102 @@
+# LinkedIn Post Options for PAP Launch
+
+## Option A: The Provocation (Best for Engagement)
+
+---
+
+You searched for a stroller once. Now every website thinks you're pregnant. For six months.
+
+That's not a bug. That's how the current internet works. One query. Forty-seven data brokers. A "pregnancy score" attached to your identity that affects insurance quotes and ad targeting. You can't undo it.
+
+Now imagine every AI agent in your life — your assistant, your shopping agent, your health advisor — leaking context the same way. Except faster, more detailed, and fully automated.
+
+Every agent protocol currently being built makes this worse, not better. A2A, MCP, ACP — none enforce context minimization at the protocol level. Privacy is voluntary. Session data is undefined. Disclosure is the developer's problem.
+
+We built something different.
+
+The Principal Agent Protocol (PAP) puts the human at the root of trust. Not the platform. Not the cloud provider. You.
+
+- Your agent carries a cryptographic mandate from you. It can only do what you explicitly permit.
+- SD-JWT selective disclosure: share your city for a weather lookup. Withhold your name, email, and device ID. Structurally.
+- Ephemeral session DIDs: services can't correlate today's query with tomorrow's.
+- Receipts record what *types* of data were shared. Never the values.
+
+The repo is open source, written in Rust, with seven working examples you can run right now.
+
+New blog post walks through five real-world scenarios — from shopping without being profiled, to medical queries without creating a permanent record, to B2B data rooms with instant revocation.
+
+Blog: https://baursoftware.com/show-me-the-agents-pap-in-practice/
+Repo: https://github.com/Baur-Software/pap
+
+If you build agents, the question isn't whether they can talk to each other. The question is who they answer to.
+
+#AI #Privacy #AgentProtocol #OpenSource #Rust #ZeroTrust
+
+---
+
+## Option B: The Technical Hook (Best for Developer Audience)
+
+---
+
+I've been reviewing the agent protocol landscape: A2A, MCP, ACP, AGNTCY, CrewAI, LangGraph, OpenAI Agents SDK.
+
+Not one of them enforces context minimization at the protocol level. Not one defines session ephemerality as a guarantee. Not one has economic primitives for agent-to-agent transactions.
+
+Privacy in every existing protocol is a stated principle, not an enforced constraint. MCP's own spec says it "cannot enforce these security principles at the protocol level." A2A's Secure Passport extension is voluntary. LangGraph's default is a shared scratchpad where every agent sees everything.
+
+So we built PAP — the Principal Agent Protocol.
+
+The design premise: the human principal is the root of trust. Every downstream agent carries a cryptographically verifiable mandate. Delegation cannot exceed parent scope. Sessions use ephemeral DIDs. Receipts contain property references, never values. The cloud is a stateless utility, not a relationship that accumulates your context.
+
+Built on standards that already exist: WebAuthn, W3C DIDs, W3C VCs, SD-JWT, Schema.org, Oblivious HTTP. No new cryptography. No token economy. No central registry.
+
+The Rust implementation ships with seven examples: zero-disclosure search, selective disclosure with SD-JWT, 4-level delegation chains, privacy-preserving payment, HTTP transport, federated marketplace discovery, and WebAuthn integration.
+
+New post walks through five scenarios with docker-compose examples: local AI assistant with Ollama + SearXNG, private shopping agent, children's privacy, medical queries, and B2B data rooms.
+
+https://baursoftware.com/show-me-the-agents-pap-in-practice/
+https://github.com/Baur-Software/pap
+
+MIT/Apache-2.0. Clone it. Run the tests. Tell me what breaks.
+
+#AgentProtocol #Privacy #Rust #WebAuthn #DID #OpenSource
+
+---
+
+## Option C: The Story (Best for Broad Reach)
+
+---
+
+I Googled a mole once. Just checking if it was normal.
+
+Within hours, I started seeing ads for cancer screening. Life insurance companies. Health supplements. The search was logged, sold to data brokers, and attached to my identity. My "health concern score" went up. I never had cancer. I had a normal mole.
+
+Now imagine an AI agent doing this on your behalf — automatically, continuously, across every service it touches. That's where we're headed with current agent protocols. They're designed for platforms, not for people.
+
+We spent the last few months building a different kind of protocol. One where:
+
+Your AI asks a medical knowledge service about a mole. The service sees: "adult, dermatological inquiry." That's it. No name. No IP. No persistent ID. The session ends and the keys are thrown away.
+
+You ask about the weather. The service sees an ephemeral ID and the word "Seattle." Not your name. Not your location history.
+
+Your child researches volcanoes for school. YouTube sees: "minor, age 10-12, educational content." Not a name. Not a behavioral profile. Each session is unlinkable.
+
+This is what the Principal Agent Protocol does. The human is the root of trust. Every agent carries a cryptographic mandate that limits what it can see and share. The protocol enforces it — not the developer, not the platform.
+
+Open source. Rust. Seven working examples. New blog post with real-world scenarios:
+
+https://baursoftware.com/show-me-the-agents-pap-in-practice/
+
+Your agent should work for you, not for a platform.
+
+#AI #Privacy #OpenSource #AgentProtocol
+
+---
+
+## Posting Strategy
+
+**Recommended**: Post Option C (The Story) first — it has the broadest emotional resonance and is most likely to get reshares from non-technical audiences. Follow up 2-3 days later with Option B (Technical Hook) for the developer audience. Option A works as a comment-section conversation starter if the original post gets traction.
+
+**Timing**: Tuesday or Wednesday, 8-10 AM Eastern. LinkedIn's algorithm favors posts that get engagement in the first 60 minutes.
+
+**Engagement strategy**: Reply to every comment in the first 2 hours. Ask questions back. "What's your experience with agent privacy? Have you seen any protocol that actually enforces this?"


### PR DESCRIPTION
- New blog post (blog-post-examples.md): 5 real-world PAP scenarios covering local AI assistant, private shopping, children's privacy, medical queries, and B2B data rooms with competitive landscape context
- LinkedIn post variants (linkedin-post.md): 3 versions targeting different audiences (provocation, technical, story) with posting strategy
- Docker Compose example (examples/local-ai-assistant/): Ollama + SearXNG + PAP marketplace + 3 provider agents + orchestrator + receipt viewer
- README overhaul: added competitive comparison table, "Why Should I Care?" section, documented all 8 crates and 8 examples, linked blog posts