### PR TITLE
feat: automate Ollama setup in local-ai-assistant

### DIFF
--- a/examples/local-ai-assistant/.env.example
+++ b/examples/local-ai-assistant/.env.example
@@ -1,0 +1,34 @@
+# PAP Local AI Assistant — Configuration
+#
+# Copy this file to .env and customize:
+#   cp .env.example .env
+#
+# Docker Compose automatically reads .env from the same directory as docker-compose.yml.
+
+# ─── LLM Model ───────────────────────────────────────────────────
+# The Ollama model to pull and use. Any Ollama-supported model works.
+# The ollama-pull service downloads it automatically on first `docker compose up`.
+#
+# Lightweight options (good for demos, runs on CPU):
+#   mistral          ~4 GB   Fast, good tool-calling ability  (default)
+#   llama3.2:3b      ~2 GB   Very fast, solid quality
+#   gemma2:2b        ~2 GB   Google Gemma, efficient
+#   phi3:mini        ~2 GB   Microsoft Phi-3, small footprint
+#
+# Higher quality (recommended with GPU):
+#   llama3.1:8b      ~5 GB   Strong reasoning
+#   mistral-nemo     ~7 GB   Mistral + Nvidia, excellent tool use
+#   llama3.1:70b    ~40 GB   Best quality, needs significant RAM/VRAM
+#
+# Browse all models: https://ollama.com/library
+LLM_MODEL=mistral
+
+# ─── API Keys ────────────────────────────────────────────────────
+# OpenWeatherMap free tier (get one at https://openweathermap.org/appid)
+# Without a real key, weather queries still work but return stub data.
+OPENWEATHER_API_KEY=demo
+
+# ─── Security ────────────────────────────────────────────────────
+# Secret key for the self-hosted SearXNG instance.
+# Change this for any non-local deployment.
+SEARXNG_SECRET=pap-demo-secret

--- a/examples/local-ai-assistant/README.md
+++ b/examples/local-ai-assistant/README.md
@@ -27,20 +27,65 @@ The orchestrator is the **only** component that knows who you are. Every downstr
 ## Quick Start
 
 ```bash
-# Start all services
+# 1. Start all services (model is pulled automatically — no manual step needed)
 docker compose up -d
 
-# Pull an LLM model
-docker exec ollama ollama pull mistral
-
-# Ask a question (triggers PAP handshake with external services)
+# 2. Ask a question (triggers PAP handshake with external services)
 curl http://localhost:9010/ask \
   -H "Content-Type: application/json" \
   -d '{"query": "What is the weather in Seattle and what is the population?"}'
 
-# View the disclosure audit log
+# 3. View the disclosure audit log
 curl http://localhost:9090/receipts | jq .
+# Or open http://localhost:9090 in a browser
 ```
+
+**First startup takes a few minutes** — Docker builds the Rust services and pulls the LLM model. Subsequent starts are fast (model is cached in the `ollama_data` volume).
+
+## Configuration
+
+Copy `.env.example` to `.env` to customize:
+
+```bash
+cp .env.example .env
+```
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `LLM_MODEL` | `mistral` | Ollama model to pull and use. See `.env.example` for options. |
+| `OPENWEATHER_API_KEY` | `demo` | OpenWeatherMap free-tier key ([get one here](https://openweathermap.org/appid)) |
+| `SEARXNG_SECRET` | `pap-demo-secret` | SearXNG instance secret |
+
+**Changing the model**: Update `LLM_MODEL` in `.env` and re-run `docker compose up -d`. The `ollama-pull` service will fetch the new model automatically.
+
+## GPU Acceleration (NVIDIA)
+
+For faster inference, overlay the GPU compose file:
+
+```bash
+# Install NVIDIA Container Toolkit first (one-time setup):
+# https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+
+docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+
+# Verify GPU is visible to Ollama:
+docker exec ollama nvidia-smi
+```
+
+## Using Host Ollama (already installed locally)
+
+If Ollama is already running on your machine, you can skip the container entirely and save ~4 GB of RAM. Override the LLM URL when starting:
+
+```bash
+# macOS / Linux — host is reachable as host-gateway
+LLM_URL=http://host.docker.internal:11434/api/generate \
+  docker compose up -d --scale ollama=0 --scale ollama-pull=0
+
+# The orchestrator will use your local Ollama instead of the container.
+# Make sure your model is already pulled: ollama pull mistral
+```
+
+> **Note on Windows/WSL2**: `host.docker.internal` resolves automatically. On Linux, you may need to add `--add-host=host-gateway:host-gateway` to the orchestrator service, or use your machine's LAN IP.
 
 ## What You'll See
 
@@ -58,13 +103,6 @@ The orchestrator decomposes your question into sub-tasks, discovers providers vi
 [receipt] Encyclopedia: {disclosed: [], values: []}
 ```
 
-## Environment Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| `OPENWEATHER_API_KEY` | `demo` | OpenWeatherMap API key (free tier: openweathermap.org/appid) |
-| `SEARXNG_SECRET` | `pap-demo-secret` | SearXNG instance secret |
-
 ## Services
 
 | Service | Port | Description |
@@ -76,7 +114,20 @@ The orchestrator decomposes your question into sub-tasks, discovers providers vi
 | Weather Provider | 9002 | PAP-wrapped OpenWeatherMap |
 | Wikipedia Provider | 9003 | PAP-wrapped Wikipedia API |
 | Orchestrator | 9010 | PAP orchestrator + LLM integration |
-| Receipt Viewer | 9090 | Disclosure audit log viewer |
+| Receipt Viewer | 9090 | Disclosure audit log viewer (browser UI) |
+
+## Startup Sequence
+
+```
+ollama          (starts, begins serving)
+  └─► ollama-pull  (waits for healthy, pulls LLM model, exits 0)
+        └─► orchestrator  (starts only after model is confirmed ready)
+              └─► receipt-viewer
+marketplace ──► search-provider, weather-provider, wikipedia-provider
+searxng     ──► search-provider
+```
+
+No manual model-pull step. No race conditions on cold start.
 
 ## The Point
 

--- a/examples/local-ai-assistant/docker-compose.gpu.yml
+++ b/examples/local-ai-assistant/docker-compose.gpu.yml
@@ -1,0 +1,27 @@
+# docker-compose.gpu.yml — NVIDIA GPU acceleration for Ollama
+#
+# Overlay this file to enable GPU pass-through. Everything else is unchanged.
+#
+# Requirements:
+#   - NVIDIA GPU with drivers installed
+#   - NVIDIA Container Toolkit
+#     Install: https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/install-guide.html
+#     Quick:   sudo apt install nvidia-container-toolkit && sudo nvidia-ctk runtime configure --runtime=docker
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
+#
+# Verify GPU is visible inside container:
+#   docker exec ollama nvidia-smi
+
+version: "3.9"
+
+services:
+  ollama:
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all          # use all available GPUs; set to 1 for single-GPU
+              capabilities: [gpu]

--- a/examples/local-ai-assistant/docker-compose.yml
+++ b/examples/local-ai-assistant/docker-compose.yml
@@ -12,8 +12,14 @@
 #
 # Usage:
 #   docker compose up -d
-#   docker exec ollama ollama pull mistral
-#   curl http://localhost:9010/ask -d '{"query": "What is the weather in Seattle?"}'
+#   curl http://localhost:9010/ask -H "Content-Type: application/json" \
+#        -d '{"query": "What is the weather in Seattle?"}'
+#
+# Configuration (optional):
+#   cp .env.example .env   # then edit .env to set LLM_MODEL, API keys, etc.
+#
+# GPU acceleration (NVIDIA):
+#   docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d
 #
 # Architecture:
 #   [You] -> [Ollama LLM] -> [PAP Orchestrator] -> [Marketplace] -> [Provider Agents]
@@ -34,6 +40,27 @@ services:
     volumes:
       - ollama_data:/root/.ollama
     restart: unless-stopped
+    healthcheck:
+      # `ollama list` connects to the local API and exits 0 when the server is ready.
+      # No curl required — uses the ollama binary already in the image.
+      test: ["CMD", "ollama", "list"]
+      interval: 10s
+      timeout: 5s
+      retries: 15
+      start_period: 30s
+
+  # ─── Pull LLM model (runs once; orchestrator waits for completion) ──
+  # This replaces the manual `docker exec ollama ollama pull mistral` step.
+  # Set LLM_MODEL in .env (or export it) to change the model.
+  ollama-pull:
+    image: ollama/ollama:latest
+    depends_on:
+      ollama:
+        condition: service_healthy
+    command: ["pull", "${LLM_MODEL:-mistral}"]
+    environment:
+      - OLLAMA_HOST=http://ollama:11434
+    restart: "no"
 
   # ─── Private Search (no query logging, no tracking) ─────────────
   searxng:
@@ -129,6 +156,7 @@ services:
   # ─── PAP Orchestrator Agent ─────────────────────────────────────
   # The brain: issues mandates, discovers providers, runs handshakes.
   # This is the ONLY component that knows who you are.
+  # Waits for ollama-pull to complete before starting — no cold-start LLM errors.
   orchestrator:
     build:
       context: ../../
@@ -138,17 +166,22 @@ services:
     environment:
       - RUST_LOG=info
       - LLM_URL=http://ollama:11434/api/generate
-      - LLM_MODEL=mistral
+      - LLM_MODEL=${LLM_MODEL:-mistral}
       - MARKETPLACE_URL=http://marketplace:9000
       - MANDATE_TTL_HOURS=8
       - AUTO_APPROVE_ZERO_DISCLOSURE=true
       - BIND_ADDR=0.0.0.0:9010
     depends_on:
-      - ollama
-      - marketplace
-      - search-provider
-      - weather-provider
-      - wikipedia-provider
+      ollama-pull:
+        condition: service_completed_successfully
+      marketplace:
+        condition: service_started
+      search-provider:
+        condition: service_started
+      weather-provider:
+        condition: service_started
+      wikipedia-provider:
+        condition: service_started
     restart: unless-stopped
 
   # ─── Receipt Viewer (audit what was disclosed) ──────────────────


### PR DESCRIPTION
## Summary

- **Healthcheck on `ollama`**: Uses `ollama list` (no curl needed — binary already in image) to gate service readiness before downstream services start
- **`ollama-pull` init service**: Auto-pulls `LLM_MODEL` (default: `mistral`) via the Ollama HTTP API before the orchestrator starts — eliminates the manual `docker exec ollama ollama pull mistral` step entirely
- **Dependency chain**: Orchestrator now has `depends_on: ollama-pull: condition: service_completed_successfully` — no more cold-start LLM errors on first run
- **`.env.example`**: Documents `LLM_MODEL`, `OPENWEATHER_API_KEY`, `SEARXNG_SECRET` with model recommendations and size guidance
- **`docker-compose.gpu.yml`**: NVIDIA GPU acceleration overlay (`docker compose -f docker-compose.yml -f docker-compose.gpu.yml up -d`)
- **README updates**: Removed manual pull step, added Configuration table, GPU section, host-Ollama instructions, and startup sequence diagram

## Test plan

- [ ] `docker compose up -d` starts cleanly with no manual steps
- [ ] `ollama-pull` service exits 0 after model download
- [ ] Orchestrator starts only after model is confirmed ready
- [ ] `LLM_MODEL=llama3.2:3b docker compose up -d` pulls and uses the alternate model
- [ ] GPU override composes without validation errors
- [ ] `.env.example` values round-trip correctly through docker-compose variable substitution

🤖 Generated with [Claude Code](https://claude.com/claude-code)