### PR TITLE
ci: opt into Node.js 24 for GitHub Pages deploy workflow

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -16,6 +16,9 @@ concurrency:
   group: "pages"
   cancel-in-progress: false
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
 jobs:
   deploy:
     name: Deploy to GitHub Pages


### PR DESCRIPTION
## Summary

- Adds `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to `pages.yml`
- Silences the Node 20 deprecation warning on all four actions (checkout, configure-pages, upload-pages-artifact, deploy-pages)
- Gets ahead of the forced June 2026 migration to Node 24

One-liner fix, no logic changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)