### PR TITLE
ci: force Node.js 24 runtime in CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,7 @@ on:
 
 env:
   CARGO_TERM_COLOR: always
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   check:


### PR DESCRIPTION
## Summary
- Add `FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true` env var to CI workflow, matching what `pages.yml` already has
- Fixes Node.js 20 deprecation warnings in GitHub Actions

## Test plan
- [ ] Verify CI jobs pass with Node.js 24 runtime

🤖 Generated with [Claude Code](https://claude.com/claude-code)