### PR TITLE
fix: install cargo-tauri before building Tauri desktop binaries in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,6 +128,9 @@ jobs:
         working-directory: apps/papillion/frontend
         run: trunk build --release
 
+      - name: Install cargo-tauri
+        run: cargo install tauri-cli --locked
+
       - name: Build and upload Tauri app
         uses: tauri-apps/tauri-action@v0
         env:


### PR DESCRIPTION
## Summary
- Adds missing installation of `cargo-tauri` CLI in release workflow before Tauri build step
- Fixes v0.3.0 release build failure on all platforms (macOS, Linux, Windows)
- Uses `--locked` flag to ensure reproducible builds with consistent dependencies

## Root Cause
The `tauri-apps/tauri-action@v0` action requires the `cargo-tauri` CLI tool to execute build commands. The workflow was missing the installation step, causing all three platform builds to fail with:
```
error: no such command: `tauri`
Command "cargo ["tauri","build"]" failed with exit code 101
```

## Technical Details
- Installs `tauri-cli` via `cargo install tauri-cli --locked`
- Runs on all platforms before the build step (macOS, Linux, Windows)
- Uses `--locked` to match the Cargo.lock in the repository

## Testing
- This PR can be merged to main and will trigger the release workflow
- The v0.3.0 release can then be published with the desktop binaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)