### PR TITLE
feat: local federated registry in Papillion settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2370,6 +2370,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "if-addrs"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc0fa01ffc752e9dbc72818cdb072cd028b86be5e09dd04c5a643704fe101a9"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "indexmap"
 version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3180,7 +3190,7 @@ dependencies = [
 
 [[package]]
 name = "pap-core"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3196,7 +3206,7 @@ dependencies = [
 
 [[package]]
 name = "pap-credential"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3213,7 +3223,7 @@ dependencies = [
 
 [[package]]
 name = "pap-did"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -3225,7 +3235,7 @@ dependencies = [
 
 [[package]]
 name = "pap-federation"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "axum",
  "axum-server",
@@ -3249,7 +3259,7 @@ dependencies = [
 
 [[package]]
 name = "pap-marketplace"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3266,7 +3276,7 @@ dependencies = [
 
 [[package]]
 name = "pap-proto"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -3283,7 +3293,7 @@ dependencies = [
 
 [[package]]
 name = "pap-python"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -3300,7 +3310,7 @@ dependencies = [
 
 [[package]]
 name = "pap-transport"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "axum",
  "axum-server",
@@ -3323,7 +3333,7 @@ dependencies = [
 
 [[package]]
 name = "pap-webauthn"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -3340,7 +3350,7 @@ dependencies = [
 
 [[package]]
 name = "papillion"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "axum",
  "axum-server",
@@ -3349,6 +3359,7 @@ dependencies = [
  "candle-transformers",
  "chrono",
  "ed25519-dalek",
+ "if-addrs",
  "pap-core",
  "pap-credential",
  "pap-did",
@@ -3374,7 +3385,7 @@ dependencies = [
 
 [[package]]
 name = "papillion-shared"
-version = "0.3.0"
+version = "0.3.4"
 dependencies = [
  "chrono",
  "serde",

--- a/apps/papillion/Cargo.toml
+++ b/apps/papillion/Cargo.toml
@@ -39,3 +39,4 @@ rusqlite = { version = "0.31", features = ["bundled", "serde_json"] }
 
 ed25519-dalek = { workspace = true }
 zeroize = { workspace = true }
+if-addrs = "0.7"

--- a/apps/papillion/frontend/Cargo.toml
+++ b/apps/papillion/frontend/Cargo.toml
@@ -18,5 +18,5 @@ serde-wasm-bindgen = "0.6"
 wasm-bindgen = "0.2"
 wasm-bindgen-futures = "0.4"
 js-sys = "0.3"
-web-sys = { version = "0.3", features = ["Window", "CustomEvent", "EventTarget", "HtmlInputElement", "KeyboardEvent"] }
+web-sys = { version = "0.3", features = ["Window", "CustomEvent", "EventTarget", "HtmlInputElement", "KeyboardEvent", "Navigator", "Clipboard"] }
 console_error_panic_hook = "0.1"

--- a/apps/papillion/frontend/src/pages/settings.rs
+++ b/apps/papillion/frontend/src/pages/settings.rs
@@ -611,6 +611,8 @@ fn IdentityTab() -> impl IntoView {
 fn AdvancedTab() -> impl IntoView {
     view! {
         <div>
+            <ThisNodeCard />
+            <SavedRegistriesCard />
             <div class="card" style="margin-bottom: 16px;">
                 <h3 style="font-size: 14px; margin-bottom: 12px;">"Registry Browser"</h3>
                 <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 12px;">
@@ -620,6 +622,306 @@ fn AdvancedTab() -> impl IntoView {
             </div>
             <RegistryBrowser />
             <AgentDetail />
+        </div>
+    }
+}
+
+#[component]
+fn ThisNodeCard() -> impl IntoView {
+    let node_did = RwSignal::new(String::new());
+    let node_fingerprint = RwSignal::new(String::new());
+    let node_addresses = RwSignal::new(Vec::<String>::new());
+    let copied = RwSignal::new(None::<String>);
+
+    Effect::new(move || {
+        if !bridge::tauri_available() {
+            return;
+        }
+        spawn_local(async move {
+            if let Ok(info) = bridge::invoke_no_args::<serde_json::Value>("get_node_info").await {
+                if let Some(did) = info.get("did").and_then(|v| v.as_str()) {
+                    node_did.set(did.to_string());
+                }
+                if let Some(fp) = info.get("cert_fingerprint").and_then(|v| v.as_str()) {
+                    node_fingerprint.set(fp.to_string());
+                }
+            }
+            if let Ok(addrs) = bridge::invoke_no_args::<Vec<String>>("get_node_addresses").await {
+                node_addresses.set(addrs);
+            }
+        });
+    });
+
+    let copy_to_clipboard = move |text: String| {
+        let text_clone = text.clone();
+        // If the same item is already showing "Copied!", toggle it off
+        if copied.get().as_deref() == Some(&text) {
+            copied.set(None);
+            return;
+        }
+        spawn_local(async move {
+            let promise = web_sys::window()
+                .and_then(|w| w.navigator().clipboard())
+                .map(|c| c.write_text(&text_clone));
+            if let Some(p) = promise {
+                let _ = wasm_bindgen_futures::JsFuture::from(p).await;
+            }
+            copied.set(Some(text_clone));
+        });
+    };
+
+    view! {
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="font-size: 14px; margin-bottom: 4px;">"This Node"</h3>
+            <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 12px;">
+                "Share a URL below with other devices on your LAN to let them connect to this node."
+            </p>
+
+            // LAN addresses
+            <Show
+                when=move || !node_addresses.get().is_empty()
+                fallback=move || view! {
+                    <p style="font-size: 12px; color: var(--text-secondary);">
+                        "No LAN addresses detected \u{2014} federation server may still be starting."
+                    </p>
+                }
+            >
+                <div style="margin-bottom: 12px;">
+                    <span style="font-size: 11px; color: var(--text-secondary); display: block; margin-bottom: 4px;">"LAN addresses"</span>
+                    <For
+                        each=move || node_addresses.get()
+                        key=|addr| addr.clone()
+                        let:addr
+                    >
+                        {
+                            let addr_copy = addr.clone();
+                            let addr_display = addr.clone();
+                            let is_copied = {
+                                let addr_check = addr.clone();
+                                move || copied.get().as_deref() == Some(&addr_check)
+                            };
+                            view! {
+                                <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 6px;">
+                                    <code style="font-size: 12px; background: var(--bg-tertiary); padding: 4px 8px; border-radius: 4px; flex: 1; word-break: break-all; font-family: 'JetBrains Mono', monospace;">
+                                        {addr_display}
+                                    </code>
+                                    <button
+                                        class="btn"
+                                        style="padding: 4px 10px; font-size: 11px; background: var(--bg-tertiary); color: var(--text-secondary); white-space: nowrap;"
+                                        on:click=move |_| copy_to_clipboard(addr_copy.clone())
+                                    >
+                                        {move || if is_copied() { "Copied!" } else { "Copy" }}
+                                    </button>
+                                </div>
+                            }
+                        }
+                    </For>
+                </div>
+            </Show>
+
+            // Cert fingerprint
+            <Show when=move || !node_fingerprint.get().is_empty()>
+                <div style="margin-bottom: 8px;">
+                    <span style="font-size: 11px; color: var(--text-secondary); display: block; margin-bottom: 4px;">"Certificate fingerprint (SHA-256)"</span>
+                    <code style="font-size: 11px; word-break: break-all; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;">
+                        {move || node_fingerprint.get()}
+                    </code>
+                </div>
+            </Show>
+
+            // DID
+            <Show when=move || !node_did.get().is_empty()>
+                <div>
+                    <span style="font-size: 11px; color: var(--text-secondary); display: block; margin-bottom: 4px;">"Node DID"</span>
+                    <code style="font-size: 11px; word-break: break-all; color: var(--text-secondary); font-family: 'JetBrains Mono', monospace;">
+                        {move || node_did.get()}
+                    </code>
+                </div>
+            </Show>
+        </div>
+    }
+}
+
+#[component]
+fn SavedRegistriesCard() -> impl IntoView {
+    use crate::state::registry::RegistryState;
+
+    let registry = expect_context::<RegistryState>();
+    let bookmarks = RwSignal::new(Vec::<String>::new());
+    let add_url = RwSignal::new(String::new());
+    let add_error = RwSignal::new(None::<String>);
+    let add_loading = RwSignal::new(false);
+
+    // Load bookmarks on mount
+    Effect::new(move || {
+        if !bridge::tauri_available() {
+            return;
+        }
+        spawn_local(async move {
+            if let Ok(bm) = bridge::invoke_no_args::<Vec<String>>("list_bookmarks").await {
+                bookmarks.set(bm);
+            }
+        });
+    });
+
+    let handle_connect = move |url: String| {
+        let url_clone = url.clone();
+        spawn_local(async move {
+            registry.current_url.set(url_clone.clone());
+            registry.loading.set(true);
+            registry.error.set(None);
+            match bridge::invoke::<serde_json::Value, papillion_shared::RegistryInfo>(
+                "navigate_registry",
+                &serde_json::json!({ "url": url_clone }),
+            )
+            .await
+            {
+                Ok(info) => {
+                    registry.info.set(Some(info));
+                    registry.loading.set(false);
+                }
+                Err(e) => {
+                    let msg = if e.contains("Tauri IPC") {
+                        "Backend unavailable.".to_string()
+                    } else {
+                        e
+                    };
+                    registry.error.set(Some(msg));
+                    registry.loading.set(false);
+                }
+            }
+        });
+    };
+
+    let handle_remove = move |url: String| {
+        spawn_local(async move {
+            match bridge::invoke::<serde_json::Value, Vec<String>>(
+                "remove_bookmark",
+                &serde_json::json!({ "registryUrl": url }),
+            )
+            .await
+            {
+                Ok(updated) => bookmarks.set(updated),
+                Err(_) => {}
+            }
+        });
+    };
+
+    let handle_add = move |_| {
+        let url = add_url.get().trim().to_string();
+        if url.is_empty() {
+            add_error.set(Some("Enter a registry URL, e.g. pap://192.168.1.x:7890".into()));
+            return;
+        }
+        add_error.set(None);
+        add_loading.set(true);
+        spawn_local(async move {
+            // TOFU handshake first — verify the registry is reachable
+            match bridge::invoke::<serde_json::Value, papillion_shared::RegistryInfo>(
+                "navigate_registry",
+                &serde_json::json!({ "url": url }),
+            )
+            .await
+            {
+                Ok(_) => {
+                    // Reachable — save the bookmark
+                    match bridge::invoke::<serde_json::Value, Vec<String>>(
+                        "add_bookmark",
+                        &serde_json::json!({ "registryUrl": url }),
+                    )
+                    .await
+                    {
+                        Ok(updated) => {
+                            bookmarks.set(updated);
+                            add_url.set(String::new());
+                        }
+                        Err(e) => add_error.set(Some(e)),
+                    }
+                }
+                Err(e) => {
+                    let msg = if e.contains("Tauri IPC") {
+                        "Backend unavailable.".to_string()
+                    } else {
+                        format!("Could not connect: {e}")
+                    };
+                    add_error.set(Some(msg));
+                }
+            }
+            add_loading.set(false);
+        });
+    };
+
+    view! {
+        <div class="card" style="margin-bottom: 16px;">
+            <h3 style="font-size: 14px; margin-bottom: 4px;">"Saved Registries"</h3>
+            <p style="font-size: 12px; color: var(--text-secondary); margin-bottom: 12px;">
+                "Registries saved here reconnect automatically on startup."
+            </p>
+
+            // Bookmark list
+            <For
+                each=move || bookmarks.get()
+                key=|url| url.clone()
+                let:url
+            >
+                {
+                    let url_connect = url.clone();
+                    let url_remove = url.clone();
+                    let url_display = url.clone();
+                    let is_local = url == "pap://local";
+                    view! {
+                        <div style="display: flex; align-items: center; gap: 8px; margin-bottom: 8px; padding: 8px; background: var(--bg-tertiary); border-radius: 6px;">
+                            <code style="flex: 1; font-size: 12px; word-break: break-all; font-family: 'JetBrains Mono', monospace;">
+                                {url_display}
+                            </code>
+                            <button
+                                class="btn"
+                                style="padding: 3px 10px; font-size: 11px; background: var(--bg-secondary); color: var(--text-primary); white-space: nowrap;"
+                                on:click=move |_| handle_connect(url_connect.clone())
+                            >
+                                "Connect"
+                            </button>
+                            <button
+                                class="btn"
+                                style="padding: 3px 8px; font-size: 11px; background: var(--bg-secondary); color: var(--error); white-space: nowrap;"
+                                disabled=move || is_local
+                                on:click=move |_| {
+                                    if !is_local {
+                                        handle_remove(url_remove.clone())
+                                    }
+                                }
+                            >
+                                "Remove"
+                            </button>
+                        </div>
+                    }
+                }
+            </For>
+
+            // Add registry form
+            <div style="border-top: 1px solid var(--border); padding-top: 12px; margin-top: 4px;">
+                <div style="display: flex; gap: 8px; align-items: flex-start;">
+                    <input
+                        type="text"
+                        placeholder="pap://192.168.1.x:7890"
+                        prop:value=move || add_url.get()
+                        on:input=move |ev| add_url.set(event_target_value(&ev))
+                        style="flex: 1; background: var(--bg-tertiary); border: 1px solid var(--border); border-radius: 6px; padding: 8px 10px; color: var(--text-primary); font-size: 13px; font-family: 'JetBrains Mono', monospace;"
+                    />
+                    <button
+                        class="btn btn-primary"
+                        on:click=handle_add
+                        disabled=move || add_loading.get()
+                    >
+                        {move || if add_loading.get() { "Connecting\u{2026}" } else { "Add" }}
+                    </button>
+                </div>
+                <Show when=move || add_error.get().is_some()>
+                    <p style="font-size: 12px; color: var(--error); margin-top: 6px;">
+                        {move || add_error.get().unwrap_or_default()}
+                    </p>
+                </Show>
+            </div>
         </div>
     }
 }

--- a/apps/papillion/src/commands/registry.rs
+++ b/apps/papillion/src/commands/registry.rs
@@ -336,12 +336,12 @@ pub async fn discover_peers(
         .collect())
 }
 
-/// Add a registry URL to bookmarks.
+/// Add a registry URL to bookmarks and persist to SQLite.
 #[tauri::command]
 pub fn add_bookmark(
     state: State<'_, AppState>,
     registry_url: String,
-) -> Result<(), PapillionError> {
+) -> Result<Vec<String>, PapillionError> {
     let mut bookmarks = state
         .bookmarks
         .write()
@@ -351,7 +351,31 @@ pub fn add_bookmark(
         bookmarks.push(registry_url);
     }
 
-    Ok(())
+    persist_bookmarks(&state.db, &bookmarks)?;
+    Ok(bookmarks.clone())
+}
+
+/// Remove a registry URL from bookmarks and persist the updated list.
+/// The built-in `pap://local` registry cannot be removed.
+#[tauri::command]
+pub fn remove_bookmark(
+    state: State<'_, AppState>,
+    registry_url: String,
+) -> Result<Vec<String>, PapillionError> {
+    if registry_url.trim() == LOCAL_REGISTRY_URL {
+        return Err(PapillionError::from(
+            "Cannot remove the built-in local registry".to_string(),
+        ));
+    }
+
+    let mut bookmarks = state
+        .bookmarks
+        .write()
+        .map_err(|e| PapillionError::from(e.to_string()))?;
+
+    bookmarks.retain(|u| u != &registry_url);
+    persist_bookmarks(&state.db, &bookmarks)?;
+    Ok(bookmarks.clone())
 }
 
 /// List bookmarked registry URLs.
@@ -363,6 +387,29 @@ pub fn list_bookmarks(state: State<'_, AppState>) -> Result<Vec<String>, Papilli
         .map_err(|e| PapillionError::from(e.to_string()))?;
 
     Ok(bookmarks.clone())
+}
+
+/// Return the LAN-reachable `pap://` URLs for this node.
+/// These are computed at startup and exclude loopback addresses.
+#[tauri::command]
+pub fn get_node_addresses(state: State<'_, AppState>) -> Result<Vec<String>, PapillionError> {
+    let urls = state
+        .local_pap_urls
+        .read()
+        .map_err(|e| PapillionError::from(e.to_string()))?;
+    Ok(urls.clone())
+}
+
+/// Serialize bookmarks (excluding pap://local) and write to the settings table.
+fn persist_bookmarks(db: &crate::db::Database, bookmarks: &[String]) -> Result<(), PapillionError> {
+    // Don't persist the built-in local entry — it is always re-added on startup
+    let to_persist: Vec<&String> = bookmarks
+        .iter()
+        .filter(|u| u.as_str() != LOCAL_REGISTRY_URL)
+        .collect();
+    let json = serde_json::to_string(&to_persist)
+        .map_err(|e| PapillionError::from(format!("bookmark serialization: {e}")))?;
+    db.set_setting("registry_bookmarks", &json)
 }
 
 /// Register a new agent advertisement on this node.

--- a/apps/papillion/src/lib.rs
+++ b/apps/papillion/src/lib.rs
@@ -76,7 +76,9 @@ pub fn run() {
             commands::registry::sync_agents,
             commands::registry::discover_peers,
             commands::registry::add_bookmark,
+            commands::registry::remove_bookmark,
             commands::registry::list_bookmarks,
+            commands::registry::get_node_addresses,
             commands::registry::register_agent,
             commands::registry::get_node_info,
             commands::orchestrator::get_orchestrator_config,
@@ -174,6 +176,23 @@ async fn start_federation_server_async(state: &AppState) -> Result<(), Box<dyn s
             eprintln!("Federation server error: {e}");
         }
     });
+
+    // Discover LAN addresses and store as pap:// URLs for the Settings UI
+    {
+        let pap_urls: Vec<String> = if_addrs::get_if_addrs()
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|iface| !iface.is_loopback())
+            .filter_map(|iface| {
+                if let if_addrs::IfAddr::V4(ref addr) = iface.addr {
+                    Some(format!("pap://{}:{}", addr.ip, port))
+                } else {
+                    None
+                }
+            })
+            .collect();
+        *state.local_pap_urls.write().unwrap() = pap_urls;
+    }
 
     // Spawn background discovery loop
     let discovery_registry = state.local_registry.clone();

--- a/apps/papillion/src/state.rs
+++ b/apps/papillion/src/state.rs
@@ -69,6 +69,9 @@ pub struct AppState {
     /// SHA-256 hex fingerprint of this node's TLS certificate.
     /// Peers pin this to verify our identity — no CA trust chain.
     pub node_cert_fingerprint: RwLock<String>,
+    /// LAN-reachable `pap://` URLs for this node, computed at startup.
+    /// Excludes loopback; populated by `start_federation_server_async`.
+    pub local_pap_urls: RwLock<Vec<String>>,
 }
 
 impl AppState {
@@ -114,6 +117,7 @@ impl AppState {
             federation_port: self.federation_port,
             node_endpoint: RwLock::new(self.node_endpoint.read().unwrap().clone()),
             node_cert_fingerprint: RwLock::new(self.node_cert_fingerprint.read().unwrap().clone()),
+            local_pap_urls: RwLock::new(self.local_pap_urls.read().unwrap().clone()),
         }
     }
 
@@ -214,6 +218,20 @@ impl AppState {
 
         let signer = SoftwareSigner::from_keypair(keypair);
 
+        // Load persisted bookmarks — always include pap://local as the first entry
+        let persisted_bookmarks: Vec<String> = db
+            .get_setting("registry_bookmarks")
+            .ok()
+            .flatten()
+            .and_then(|json| serde_json::from_str::<Vec<String>>(&json).ok())
+            .unwrap_or_default();
+        let mut bookmarks = vec![LOCAL_REGISTRY_URL.to_string()];
+        for url in persisted_bookmarks {
+            if url != LOCAL_REGISTRY_URL && !bookmarks.contains(&url) {
+                bookmarks.push(url);
+            }
+        }
+
         let model_manager = Arc::new(tokio::sync::Mutex::new(ModelManager::new()));
 
         // Spawn local agents — these are real AgentHandler implementations
@@ -236,7 +254,7 @@ impl AppState {
             profiles: RwLock::new(profiles),
             registries: RwLock::new(HashMap::new()),
             local_registry,
-            bookmarks: RwLock::new(vec![LOCAL_REGISTRY_URL.to_string()]),
+            bookmarks: RwLock::new(bookmarks),
             orchestrator_config: RwLock::new(OrchestratorConfig::default()),
             model_manager,
             agent_keypairs: RwLock::new(agent_keypairs),
@@ -249,6 +267,7 @@ impl AppState {
             federation_port: DEFAULT_FEDERATION_PORT,
             node_endpoint: RwLock::new(String::new()),
             node_cert_fingerprint: RwLock::new(String::new()),
+            local_pap_urls: RwLock::new(Vec::new()),
         }
     }
 


### PR DESCRIPTION
## Summary

- **Persist bookmarks** to SQLite (`settings` table, key `registry_bookmarks`); `pap://local` is always present but never stored
- **`remove_bookmark` command** — removes a saved registry; `pap://local` is protected
- **`get_node_addresses` command** — returns LAN-reachable `pap://IP:port` URLs (non-loopback IPv4 via `if-addrs`, computed once at server startup)
- **`local_pap_urls` field in `AppState`** — populated after TLS server binds
- **Settings › Advanced › This Node card** — shows all LAN addresses with copy buttons, cert fingerprint, and node DID
- **Settings › Advanced › Saved Registries card** — lists persisted bookmarks with Connect / Remove per entry; Add form does TOFU handshake before saving

## Test plan

- [ ] Add a `pap://` URL in Saved Registries → appears in list
- [ ] Restart Papillion → saved registry reappears (persistence check)
- [ ] Remove a registry → disappears; `pap://local` Remove button is disabled
- [ ] This Node card shows actual LAN IP(s), not `0.0.0.0`
- [ ] Copy button copies the `pap://` URL to clipboard
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)