### PR TITLE
fix: correct Docker COPY path for registry styles directory

### DIFF
--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -29,7 +29,7 @@ COPY crates/pap-federation ./crates/pap-federation
 COPY apps/registry/Cargo.toml ./apps/registry/Cargo.toml
 COPY apps/registry/src ./apps/registry/src
 # CSS source referenced by [[workspace.metadata.leptos]] style-file
-COPY apps/registry/frontend/styles ./apps/registry/frontend/styles
+COPY apps/registry/styles ./apps/registry/styles
 
 # Patch the workspace members list to remove crates we didn't copy.
 # Anchor to lines starting with whitespace+quote (member entries only),


### PR DESCRIPTION
## Summary
Fixed Docker build failure caused by incorrect path to registry styles directory.

The Dockerfile was looking for `apps/registry/frontend/styles` but the actual path is `apps/registry/styles`.

## Changes
- Updated line 32 in `apps/registry/Dockerfile` to use the correct path

## Testing
Docker build should now proceed without "not found" errors for the styles directory.

🤖 Generated with Claude Code