### PR TITLE
fix: resolve Docker build issues

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,6 +66,7 @@ zeroize = { version = "1", features = ["derive"] }
 [[workspace.metadata.leptos]]
 name          = "pap-registry"
 bin-package   = "pap-registry"
+bin-target    = "pap-registry"
 lib-package   = "pap-registry"
 bin-features  = ["ssr"]
 lib-features  = ["hydrate"]

--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -40,6 +40,8 @@ RUN sed -i \
     -e '/^[[:space:]]*"crates\/pap-proto"/d' \
     -e '/^[[:space:]]*"crates\/pap-transport"/d' \
     -e '/^[[:space:]]*"crates\/pap-python"/d' \
+    -e '/^[[:space:]]*"crates\/pap-c"/d' \
+    -e '/^[[:space:]]*"crates\/pap-wasm"/d' \
     -e '/^[[:space:]]*"crates\/papillion-shared"/d' \
     -e '/^[[:space:]]*"apps\/papillion"/d' \
     Cargo.toml
@@ -75,6 +77,8 @@ RUN sed -i \
     -e '/^[[:space:]]*"crates\/pap-proto"/d'       \
     -e '/^[[:space:]]*"crates\/pap-transport"/d'   \
     -e '/^[[:space:]]*"crates\/pap-python"/d'      \
+    -e '/^[[:space:]]*"crates\/pap-c"/d'           \
+    -e '/^[[:space:]]*"crates\/pap-wasm"/d'        \
     -e '/^[[:space:]]*"crates\/papillion-shared"/d' \
     -e '/^[[:space:]]*"apps\/papillion"/d'         \
     Cargo.toml


### PR DESCRIPTION
## Summary
Fixed additional Docker build configuration issues that prevented cargo-leptos from building the registry.

## Changes
1. Added missing sed rules to remove `pap-c` and `pap-wasm` from the Cargo.toml workspace members list during Docker build
2. Added `bin-target` specification to Leptos workspace metadata to disambiguate between multiple binary targets in pap-registry

## Testing
Docker build now completes successfully and produces a working registry image (pap-registry:latest, 160MB).

Verified with: `docker build -f apps/registry/Dockerfile -t pap-registry:test .`

🤖 Generated with Claude Code