### PR TITLE
chore: add pre-commit hook for rustfmt

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Pre-commit hook to run rustfmt on Rust files
+
+# Get the repository root
+REPO_ROOT=$(git rev-parse --show-toplevel)
+
+# Find all staged Rust files
+RUST_FILES=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.rs$' || true)
+
+if [ -z "$RUST_FILES" ]; then
+    exit 0
+fi
+
+# Run rustfmt on staged files
+echo "Running rustfmt on staged Rust files..."
+for file in $RUST_FILES; do
+    if [ -f "$REPO_ROOT/$file" ]; then
+        rustfmt "$REPO_ROOT/$file"
+        git add "$REPO_ROOT/$file"
+    fi
+done
+
+echo "rustfmt check complete"
+exit 0


### PR DESCRIPTION
Adds a pre-commit hook that automatically runs rustfmt on staged Rust files before each commit.

The hook:
- Finds all staged .rs files
- Runs rustfmt on each one
- Re-stages the formatted files

This ensures consistent code formatting across the project.