### PR TITLE
fix(docs): vary repetitive phrasing on Papillion page

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -312,7 +312,7 @@
         <span class="product-tag product-tag-app">Desktop App</span>
         <div class="product-name">Papillion</div>
         <p class="product-desc">
-          AI that works for you, not on its own. Set rules, approve decisions, see everything.
+          AI that works for you, not on its own. Approve decisions, see everything that happens.
           Search the web, book travel, delegate tasks &#8212; Papillion only does what you ask.
         </p>
         <span class="product-link">Try Papillion &#8594;</span>

--- a/docs/papillion/index.html
+++ b/docs/papillion/index.html
@@ -562,7 +562,7 @@
     <div class="shift-steps">
       <div class="shift-step">
         <div class="step-number">1</div>
-        <h3>You define the rules</h3>
+        <h3>You set the boundaries</h3>
         <p>Set budgets, choose trusted vendors, require approval for important decisions.</p>
       </div>
       <div class="shift-step">
@@ -572,8 +572,8 @@
       </div>
       <div class="shift-step">
         <div class="step-number">3</div>
-        <h3>You stay in control</h3>
-        <p>See every decision, approve what matters, and get a clear receipt of what happened.</p>
+        <h3>Full visibility, always</h3>
+        <p>See every decision, approve what matters, and get a cryptographic receipt of what happened.</p>
       </div>
     </div>
   </div>
@@ -583,7 +583,7 @@
 <section class="section" id="rules">
   <div class="container reveal">
     <span class="section-label">What it feels like</span>
-    <h2>You set the rules.<br>Your AI follows them. Always.</h2>
+    <h2>Your boundaries.<br>Cryptographically enforced.</h2>
     <div class="rules-list">
       <div class="rule-item">
         <div class="rule-check">&#x2713;</div>
@@ -611,7 +611,7 @@
     <div class="demo-header reveal">
       <span class="section-label">Live example</span>
       <h2>Watch an AI make a purchase &mdash; safely</h2>
-      <p class="lead" style="margin: 12px auto 0;">Your assistant shops for a laptop, following your rules at every step.</p>
+      <p class="lead" style="margin: 12px auto 0;">Your assistant shops for a laptop, with every constraint enforced along the way.</p>
     </div>
 
     <div class="demo-container reveal">
@@ -657,13 +657,13 @@
           <div class="demo-step-label">Step 2 &mdash; AI searches</div>
           <h3>Searching across approved vendors...</h3>
           <p>Your assistant found <strong>12 products</strong> across 4 vendors.</p>
-          <button class="demo-nav-btn" onclick="demoNext()">Apply your rules &rarr;</button>
+          <button class="demo-nav-btn" onclick="demoNext()">Filter results &rarr;</button>
         </div>
 
         <!-- Step 3: Filter -->
         <div class="demo-step" data-step="2">
-          <div class="demo-step-label">Step 3 &mdash; AI filters by your rules</div>
-          <h3>Applying your constraints</h3>
+          <div class="demo-step-label">Step 3 &mdash; AI applies constraints</div>
+          <h3>Filtering against your mandate</h3>
           <div style="margin: 20px 0;">
             <div class="demo-filter-row">
               <span>Products found</span>
@@ -692,7 +692,7 @@
         <!-- Step 4: Selection -->
         <div class="demo-step" data-step="3">
           <div class="demo-step-label">Step 4 &mdash; AI selects best option</div>
-          <h3>Best match within your rules</h3>
+          <h3>Best match within budget</h3>
           <div style="padding: 20px; background: var(--surface2); border-radius: var(--radius); border: 1px solid var(--border); margin: 20px 0;">
             <div style="font-weight: 700; font-size: 1.1rem; margin-bottom: 4px;">ThinkPad X1 Carbon Gen 12</div>
             <div style="color: var(--muted); font-size: .9rem; margin-bottom: 12px;">14" / 16GB RAM / 512GB SSD</div>
@@ -778,7 +778,7 @@
       <div class="pillar">
         <div class="pillar-icon control">&#x1F3AF;</div>
         <h3>Control</h3>
-        <p>AI follows your rules. No exceptions, no surprises.</p>
+        <p>Boundaries are cryptographic, not optional.</p>
       </div>
       <div class="pillar">
         <div class="pillar-icon visible">&#x1F441;</div>
@@ -803,7 +803,7 @@
 <section class="section" id="trust">
   <div class="container reveal">
     <span class="section-label">Trust</span>
-    <h2>You're always in control.</h2>
+    <h2>Transparency at every step.</h2>
     <div class="trust-list">
       <div class="trust-item">
         <div class="trust-icon">&#x23F8;</div>
@@ -824,7 +824,7 @@
 <!-- ─── Footer CTA ───────────────────────────────────────────────── -->
 <section class="footer-cta reveal">
   <h2>Try Papillion</h2>
-  <p>See what it feels like to stay in control of AI.</p>
+  <p>See what it feels like when AI answers to you.</p>
   <div class="hero-ctas">
     <a href="#demo" class="btn-primary">Try the demo</a>
     <a href="../pap/" class="btn-secondary">For developers</a>


### PR DESCRIPTION
## Summary

- Replaced ~11 instances of repetitive "set the rules / your rules / stay in control" with varied language
- Now uses: **boundaries**, **constraints**, **mandate**, **cryptographically enforced**, **transparency**, **visibility**
- Keeps the core message without reading like a broken record

Follow-up to #111.

## Test plan

- [ ] Read through Papillion page — phrasing should feel varied, not repetitive
- [ ] No functional changes — just copy edits

🤖 Generated with [Claude Code](https://claude.com/claude-code)