### PR TITLE
fix(docs): restore Papillion logo to hub page hero

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -117,6 +117,12 @@
         transparent 70%);
     }
     .hero .container { position: relative; z-index: 1; }
+    .hero-logo {
+      height: 96px; width: auto; margin-bottom: 32px;
+      filter: drop-shadow(0 8px 24px rgba(108,92,231,.2));
+      transition: transform .3s ease;
+    }
+    .hero-logo:hover { transform: scale(1.05); }
     .hero h1 {
       font-family: 'Satoshi', sans-serif;
       font-size: clamp(2.25rem, 5vw, 3.5rem);
@@ -273,15 +279,16 @@
 <section class="hero" aria-label="Introduction">
   <div class="hero-bg" aria-hidden="true"></div>
   <div class="container">
-    <h1 class="reveal">
+    <img src="assets/images/papillion-icon.png" alt="Baur Software" class="hero-logo reveal" />
+    <h1 class="reveal reveal-delay-1">
       Zero Trust AI.<br />
       <span class="gradient-text">Open Source Forever.</span>
     </h1>
-    <p class="reveal reveal-delay-1">
+    <p class="reveal reveal-delay-2">
       AI should answer to you, not to a platform. We build the protocol, the app, and the registry
       that put you in cryptographic control of your agents.
     </p>
-    <div class="hero-cta reveal reveal-delay-2">
+    <div class="hero-cta reveal reveal-delay-3">
       <a href="pap/" class="btn btn-primary">Read the Protocol</a>
       <a href="https://github.com/Baur-Software/pap" class="btn btn-outline" target="_blank" rel="noopener">
         <svg class="gh-icon" viewBox="0 0 24 24" aria-hidden="true"><path d="M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61-.546-1.385-1.335-1.755-1.335-1.755-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12"/></svg>


### PR DESCRIPTION
## Summary

- Restored the Papillion butterfly logo to the hub page hero section
- Added subtle drop shadow and hover scale animation
- Fixed reveal animation cascade timing

The hub page rewrite accidentally dropped the logo.

## Test plan

- [ ] Verify logo renders in hero section above the heading
- [ ] Hover over logo — should scale up slightly

🤖 Generated with [Claude Code](https://claude.com/claude-code)