### PR TITLE
docs: reframe Chrysalis copy for agent builders

### DIFF
--- a/docs/chrysalis.html
+++ b/docs/chrysalis.html
@@ -3,10 +3,10 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Chrysalis — Where the canvas finds its agents</title>
-  <meta name="description" content="A federated agent registry that replaces app stores and API keys. Agents advertise capabilities, the canvas discovers them. Self-hostable, no central gatekeeper." />
-  <meta property="og:title" content="Chrysalis — Where the canvas finds its agents" />
-  <meta property="og:description" content="A federated agent registry. Agents advertise capabilities, the canvas discovers them. Self-hostable, no central gatekeeper." />
+  <title>Chrysalis — Publish your agent. Let any canvas find it.</title>
+  <meta name="description" content="A self-hostable federated agent registry. Build an agent, sign its advertisement, publish it to the network. Any PAP canvas can discover it — no app store, no gatekeeper." />
+  <meta property="og:title" content="Chrysalis — Publish your agent. Let any canvas find it." />
+  <meta property="og:description" content="Build an agent, sign its advertisement, publish it to the network. Self-hostable, federated, no gatekeeper." />
   <meta property="og:type" content="website" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -378,13 +378,14 @@
         </div>
         <h1 class="hero-title">
           <span class="gradient-text">Chrysalis.</span><br />
-          Where the canvas<br />
-          finds its agents.
+          Build an agent.<br />
+          Publish it to the network.
         </h1>
         <p class="hero-subtitle">
-          When the canvas needs a flight agent, a hotel agent, a weather agent — Chrysalis is how it finds them.
-          A federated registry where agents advertise capabilities and canvases discover them,
-          with no central platform deciding who's allowed.
+          You built something useful — a flight search, a booking engine, a weather service.
+          Sign its capability advertisement, publish it to a Chrysalis node, and any PAP-compatible
+          canvas can discover and negotiate with it. No app store approval. No platform cut.
+          Run your own node or publish to an existing one.
         </p>
         <div class="hero-actions">
           <a href="https://github.com/Baur-Software/pap" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
@@ -405,14 +406,14 @@
 <section class="section" aria-labelledby="features-heading">
   <div class="container">
     <div class="reveal" style="margin-bottom: 56px;">
-      <div class="section-label">What it does</div>
+      <div class="section-label">What you get</div>
       <h2 class="section-title" id="features-heading">
-        Configuration disappears.<br />
-        <span class="gradient-text">Discovery replaces integration.</span>
+        Everything an agent needs<br />
+        <span class="gradient-text">to be discoverable</span>
       </h2>
       <p class="section-sub">
-        No API keys, no OAuth flows, no settings page for connecting services.
-        Agents advertise what they can do. The canvas matches your intent to available capabilities.
+        Chrysalis handles identity, advertisement hosting, peer sync, and capability indexing.
+        You focus on building the agent. The registry makes it findable.
       </p>
     </div>
 
@@ -477,12 +478,12 @@
     <div class="reveal" style="margin-bottom: 56px;">
       <div class="section-label">Why a Registry?</div>
       <h2 class="section-title" id="why-heading">
-        The canvas can't compose agents<br />
-        <span class="gradient-text">without a discovery layer</span>
+        Your agent needs to be found<br />
+        <span class="gradient-text">without asking permission</span>
       </h2>
       <p class="section-sub">
-        A registry isn't a directory you phone home to — it's what makes "plan a trip" resolve
-        to three scoped agents instead of one monolithic assistant.
+        A registry isn't a directory you phone home to — it's a protocol component
+        that lets your agent be discovered, verified, and negotiated with by any client.
       </p>
     </div>
 
@@ -672,7 +673,7 @@
         <img src="assets/images/papillion-icon.png" alt="Papillion butterfly" />
         <div>
           <div class="papillion-link-name">Papillion</div>
-          <div class="papillion-link-desc">The canvas that composes agents from Chrysalis registries. macOS · Windows · Linux.</div>
+          <div class="papillion-link-desc">The desktop canvas that discovers and composes agents published to Chrysalis. macOS · Windows · Linux.</div>
         </div>
       </div>
       <span class="btn btn-outline">Download →</span>

--- a/docs/index.html
+++ b/docs/index.html
@@ -333,8 +333,8 @@
         <span class="product-tag product-tag-registry">Agent Registry</span>
         <div class="product-name">Chrysalis</div>
         <p class="product-desc">
-          Where the canvas finds its agents. A federated registry that replaces app stores
-          and API keys &#8212; agents advertise capabilities, the canvas discovers them. No central gatekeeper.
+          Build an agent, publish it to the network. A self-hostable federated registry &#8212;
+          sign a capability ad, push it to a node, and any PAP canvas can find you. No app store, no gatekeeper.
         </p>
         <span class="product-link">Learn more &#8594;</span>
       </a>


### PR DESCRIPTION
## Summary

Corrects Chrysalis copy that swung too far toward canvas-centric framing. Chrysalis is for the people **building** agents — the canvas is the consumer, not the headline.

### Changes

| Location | Before (canvas-centric) | After (builder-centric) |
|----------|------------------------|------------------------|
| **Page title** | "Where the canvas finds its agents" | "Publish your agent. Let any canvas find it." |
| **Hero headline** | "Where the canvas finds its agents" | "Build an agent. Publish it to the network." |
| **Hero subtitle** | "When the canvas needs a flight agent..." | "You built something useful... Sign its capability ad, publish it..." |
| **Features intro** | "Configuration disappears. Discovery replaces integration." | "Everything an agent needs to be discoverable" |
| **Why a Registry** | "The canvas can't compose agents without a discovery layer" | "Your agent needs to be found without asking permission" |
| **Hub card** | "Where the canvas finds its agents" | "Build an agent, publish it to the network" |
| **Papillion callout** | "The canvas that composes agents from Chrysalis registries" | "The desktop canvas that discovers and composes agents published to Chrysalis" |

The canvas connection remains as the "so what" (any PAP canvas can find your agent), but the primary audience is now the agent builder.

## Test plan

- [x] All changes are HTML text only — no structural, CSS, or JS changes
- [x] All internal links unchanged
- [x] Technical content in Why a Registry section preserved intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)