### PR TITLE
fix(release): Windows shell compat, Capacitor App ID, v0.5.0

### DIFF
--- a/.github/workflows/release-chrysalis.yml
+++ b/.github/workflows/release-chrysalis.yml
@@ -298,7 +298,7 @@ jobs:
           npm init -y
           npm install @capacitor/core @capacitor/cli @capacitor/ios
 
-          npx cap init "Chrysalis" "com.baur-software.chrysalis" \
+          npx cap init "Chrysalis" "com.baursoftware.chrysalis" \
             --web-dir ../../../site
 
           npx cap add ios
@@ -424,7 +424,7 @@ jobs:
           npm init -y
           npm install @capacitor/core @capacitor/cli @capacitor/android
 
-          npx cap init "Chrysalis" "com.baur-software.chrysalis" \
+          npx cap init "Chrysalis" "com.baursoftware.chrysalis" \
             --web-dir ../../../site
 
           npx cap add android

--- a/.github/workflows/release-papillion.yml
+++ b/.github/workflows/release-papillion.yml
@@ -144,9 +144,11 @@ jobs:
         run: trunk build --release
 
       - name: Setup model directory
+        shell: bash
         run: mkdir -p apps/papillion/models
 
       - name: Download bundled TinyLlama model from GitHub Release
+        shell: bash
         run: |
           gh release download models-v1 \
             --pattern "tinyllama-1.1b-chat-v1.0.Q4_K_M.gguf" \
@@ -202,7 +204,7 @@ jobs:
           npm init -y
           npm install @capacitor/core @capacitor/cli @capacitor/ios
 
-          npx cap init "Papillion" "com.baur-software.papillion" \
+          npx cap init "Papillion" "com.baursoftware.papillion" \
             --web-dir frontend/dist
 
           npx cap add ios
@@ -326,7 +328,7 @@ jobs:
           npm init -y
           npm install @capacitor/core @capacitor/cli @capacitor/android
 
-          npx cap init "Papillion" "com.baur-software.papillion" \
+          npx cap init "Papillion" "com.baursoftware.papillion" \
             --web-dir frontend/dist
 
           npx cap add android

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## [0.5.0] - 2026-03-26
+
+### Added
+
+- **Multi-platform release workflows** — Per-product CI/CD pipelines for Papillion and Chrysalis covering desktop (macOS/Linux/Windows), mobile (iOS/Android via Capacitor thin clients), web (WASM), Docker, and npm
+- **npm CLI packages** — `@baur-software/papillion` (serves WASM frontend) and `@baur-software/chrysalis` (downloads platform binary)
+- **Papillion Dockerfile** — Multi-stage trunk build to nginx:alpine with COOP/COEP headers
+
+### Fixed
+
+- Windows desktop build: PowerShell compatibility for mkdir and gh commands
+- Capacitor App ID validation: removed dashes from Java package names
+
 ## [0.4.4.0] - 2026-03-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.4.2"
+version = "0.5.0"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary
- **Windows desktop build**: `mkdir -p` and `gh release download` steps ran under PowerShell instead of bash, causing failures. Added `shell: bash` to both steps.
- **Capacitor App ID**: `com.baur-software.papillion` / `com.baur-software.chrysalis` contain dashes which are invalid in Java package names. Changed to `com.baursoftware.*`.
- **Version bump**: 0.4.2 → 0.5.0 to trigger a clean first release through the new pipelines.

## Test plan
- [ ] CI passes (Check, Test, Clippy, Format, CodeQL)
- [ ] Merge triggers Release Papillion workflow with `papillion-v0.5.0` tag
- [ ] Windows desktop build passes `Setup model directory` step
- [ ] iOS/Android Capacitor init succeeds with valid App ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)