### PR TITLE
fix(release): force binstall + correct Chrysalis binary path

### DIFF
--- a/.github/workflows/release-chrysalis.yml
+++ b/.github/workflows/release-chrysalis.yml
@@ -146,7 +146,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install cargo-leptos
-        run: cargo binstall cargo-leptos --no-confirm
+        run: cargo binstall cargo-leptos --no-confirm --force
 
       - name: Build Chrysalis server (cargo-leptos)
         if: matrix.target != 'universal-apple-darwin' && matrix.cross != true
@@ -157,7 +157,7 @@ jobs:
         run: |
           # Build for both architectures
           cargo leptos build --release -p pap-registry
-          BINARY_PATH="target/server/release/pap-registry"
+          BINARY_PATH="target/release/pap-registry"
           if [ -f "$BINARY_PATH" ]; then
             echo "Built universal binary at $BINARY_PATH"
           fi
@@ -181,9 +181,9 @@ jobs:
 
           # Copy server binary
           if [ "${{ matrix.platform }}" = "windows-latest" ]; then
-            cp target/server/release/pap-registry.exe "dist/${ARTIFACT}/chrysalis.exe"
+            cp target/release/pap-registry.exe "dist/${ARTIFACT}/chrysalis.exe"
           else
-            cp target/server/release/pap-registry "dist/${ARTIFACT}/chrysalis"
+            cp target/release/pap-registry "dist/${ARTIFACT}/chrysalis"
             chmod +x "dist/${ARTIFACT}/chrysalis"
           fi
 
@@ -252,7 +252,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install cargo-leptos
-        run: cargo binstall cargo-leptos --no-confirm
+        run: cargo binstall cargo-leptos --no-confirm --force
 
       - name: Build WASM site via cargo-leptos
         run: cargo leptos build --release -p pap-registry

--- a/.github/workflows/release-papillion.yml
+++ b/.github/workflows/release-papillion.yml
@@ -137,7 +137,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install trunk
-        run: cargo binstall trunk --no-confirm
+        run: cargo binstall trunk --no-confirm --force
 
       - name: Build frontend (WASM)
         working-directory: apps/papillion/frontend
@@ -421,7 +421,7 @@ jobs:
         uses: cargo-bins/cargo-binstall@main
 
       - name: Install trunk
-        run: cargo binstall trunk --no-confirm
+        run: cargo binstall trunk --no-confirm --force
 
       - name: Build frontend (WASM)
         working-directory: apps/papillion/frontend

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.1] - 2026-03-26
+
+### Fixed
+
+- Force-reinstall trunk/cargo-leptos binaries to avoid stale cache mismatches
+- Chrysalis server binary path corrected to `target/release/` (matches cargo-leptos output)
+
 ## [0.5.0] - 2026-03-26
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary
- **trunk/cargo-leptos not found**: `Swatinem/rust-cache` preserves `.crates.toml` metadata but not the actual binaries in `$CARGO_HOME/bin`. `cargo binstall` sees "already installed" and skips, but the binary is missing. Fix: add `--force` (matching existing pattern in ci.yml/web-build.yml).
- **Chrysalis server binary path**: Packaging step looked in `target/server/release/pap-registry` but cargo-leptos outputs to `target/release/pap-registry` (confirmed by working Dockerfile).
- **Version bump**: 0.5.0 → 0.5.1 to trigger clean release with both fixes.

## Test plan
- [ ] CI passes
- [ ] Merge triggers Release Papillion with `papillion-v0.5.1` — build-web succeeds
- [ ] Merge triggers Release Chrysalis with `chrysalis-v0.5.1` — build-server packaging succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)