### PR TITLE
fix(release): Capacitor 8 SPM, Node 22 glob conflict

### DIFF
--- a/.github/workflows/release-papillion.yml
+++ b/.github/workflows/release-papillion.yml
@@ -208,10 +208,6 @@ jobs:
             --web-dir frontend/dist
 
           npx cap add ios
-
-          # Capacitor 8 requires iOS 15.0 minimum deployment target
-          sed -i '' "s/platform :ios, '.*'/platform :ios, '15.0'/" ios/App/Podfile
-
           npx cap sync ios
 
       - name: Install Apple certificate and provisioning profile
@@ -280,8 +276,6 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const path = require('path');
-            const glob = require('@actions/glob');
             const globber = await glob.create(`${process.env.RUNNER_TEMP}/**/*.ipa`);
             for await (const file of globber.globGenerator()) {
               const data = fs.readFileSync(file);
@@ -391,8 +385,6 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const glob = require('@actions/glob');
-
             const globber = await glob.create('apps/papillion/android/**/*-release*.apk');
             for await (const file of globber.globGenerator()) {
               if (file.includes('unsigned')) continue;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [0.5.3] - 2026-03-26
+
+### Fixed
+
+- Papillion iOS: remove CocoaPods Podfile sed (Capacitor 8 uses Swift Package Manager)
+- Papillion mobile upload scripts: remove `require('@actions/glob')` (conflicts with Node 22 built-in)
+
 ## [0.5.2] - 2026-03-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.2"
+version = "0.5.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary

- **iOS**: Remove `sed` Podfile fix — Capacitor 8 uses Swift Package Manager, not CocoaPods. The Podfile no longer exists.
- **Android/iOS upload**: Remove `require('@actions/glob')` — `glob` is already provided as a built-in by `actions/github-script@v7` and conflicts with Node 22's built-in `glob` module.
- Bump v0.5.3

## What failed (v0.5.2)

| Platform | Error | Fix |
|----------|-------|-----|
| iOS | `sed: ios/App/Podfile: No such file or directory` | Remove sed — Cap 8 uses SPM |
| Android | `SyntaxError: Identifier 'glob' has already been declared` | Remove `require('@actions/glob')` |

## Test plan

- [ ] CI passes
- [ ] v0.5.3 release: all Papillion jobs green (desktop + mobile + web + npm + Docker)
- [ ] v0.5.3 release: all Chrysalis jobs green (server + npm + Docker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)