### PR TITLE
fix(release): iOS xcodeproj for Capacitor 8 SPM

### DIFF
--- a/.github/workflows/release-papillion.yml
+++ b/.github/workflows/release-papillion.yml
@@ -240,7 +240,7 @@ jobs:
       - name: Build iOS archive
         working-directory: apps/papillion/ios/App
         run: |
-          xcodebuild -workspace App.xcworkspace \
+          xcodebuild -project App.xcodeproj \
             -scheme App \
             -configuration Release \
             -archivePath $RUNNER_TEMP/Papillion.xcarchive \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.4] - 2026-03-26
+
+### Fixed
+
+- Papillion iOS: use `App.xcodeproj` instead of `App.xcworkspace` (Capacitor 8 uses SPM, not CocoaPods)
+
 ## [0.5.3] - 2026-03-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.3"
+version = "0.5.4"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary

Capacitor 8 uses Swift Package Manager instead of CocoaPods. There is no `App.xcworkspace` — only `App.xcodeproj`. The xcodebuild archive command needs `-project App.xcodeproj` instead of `-workspace App.xcworkspace`.

v0.5.3 results showed Android mobile passed (Capacitor 8 + JDK 21 + Node 22 working), but iOS failed with `'App.xcworkspace' does not exist`.

## Test plan

- [ ] CI passes
- [ ] v0.5.4 Papillion release: all jobs green including mobile-ios

🤖 Generated with [Claude Code](https://claude.com/claude-code)