### PR TITLE
fix(release): canary Playwright setup + WASM artifact

### DIFF
--- a/.github/workflows/release-papillion.yml
+++ b/.github/workflows/release-papillion.yml
@@ -519,22 +519,32 @@ jobs:
   # ── 10. Post-deploy canary ───────────────────────────────────────────────────
   canary-verify:
     name: Post-Deploy Canary Verification
-    needs: publish-release
+    needs: [publish-release, build-web]
     runs-on: ubuntu-latest
     if: success()
     steps:
       - uses: actions/checkout@v4
 
+      - name: Download WASM frontend artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: papillion-web-dist
+          path: apps/papillion/frontend/dist/
+
       - name: Set up Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: "20"
+          node-version: "22"
 
       - name: Install dependencies
-        run: npm install -D @playwright/test
+        working-directory: e2e
+        run: |
+          npm install -D @playwright/test
+          npx playwright install --with-deps chromium
 
       - name: Run canary health checks
-        run: npm exec playwright test e2e/tests/canary.spec.ts --reporter=html
+        working-directory: e2e
+        run: npx playwright test tests/canary.spec.ts --reporter=html
         timeout-minutes: 15
 
       - name: Upload canary report on failure

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [0.5.5] - 2026-03-26
+
+### Fixed
+
+- Canary: download WASM artifact, install Playwright chromium, run from e2e/ working directory
+
 ## [0.5.4] - 2026-03-26
 
 ### Fixed

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,7 +31,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.4"
+version = "0.5.5"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary

The Post-Deploy Canary Verification job was failing because:
1. No WASM frontend artifact — Playwright config serves `apps/papillion/frontend/dist/` via http-server
2. No browser binary — `npm install @playwright/test` installs the package but not chromium
3. Wrong working directory — `playwright.config.ts` lives in `e2e/`

### Fixes
- Download `papillion-web-dist` artifact before tests
- `npx playwright install --with-deps chromium` for browser binaries
- Run from `e2e/` working directory
- Add `build-web` to `canary-verify` needs chain
- Bump v0.5.5

## Test plan
- [ ] CI passes
- [ ] v0.5.5 release: all jobs green including canary

🤖 Generated with [Claude Code](https://claude.com/claude-code)