### PR TITLE
fix: wrap Tauri IPC args in named parameter objects

### DIFF
--- a/apps/papillon/frontend/src/pages/settings/templates_tab/mod.rs
+++ b/apps/papillon/frontend/src/pages/settings/templates_tab/mod.rs
@@ -147,7 +147,7 @@ pub fn TemplatesTab() -> impl IntoView {
         spawn_local(async move {
             match bridge::invoke::<serde_json::Value, ()>(
                 "create_template",
-                &serde_json::to_value(&template).unwrap(),
+                &serde_json::json!({ "template": &template }),
             )
             .await
             {
@@ -206,7 +206,7 @@ pub fn TemplatesTab() -> impl IntoView {
             spawn_local(async move {
                 match bridge::invoke::<serde_json::Value, ()>(
                     "update_template",
-                    &serde_json::to_value(&template).unwrap(),
+                    &serde_json::json!({ "template": &template }),
                 )
                 .await
                 {

--- a/apps/papillon/frontend/src/service/tauri_service.rs
+++ b/apps/papillon/frontend/src/service/tauri_service.rs
@@ -36,12 +36,12 @@ impl PapillonService for TauriService {
     }
 
     async fn create_template(&self, template: &Template) -> Result<(), String> {
-        bridge::invoke::<Value, ()>("create_template", &serde_json::to_value(template).map_err(|e| e.to_string())?)
+        bridge::invoke::<Value, ()>("create_template", &json!({ "template": template }))
             .await
     }
 
     async fn update_template(&self, template: &Template) -> Result<(), String> {
-        bridge::invoke::<Value, ()>("update_template", &serde_json::to_value(template).map_err(|e| e.to_string())?)
+        bridge::invoke::<Value, ()>("update_template", &json!({ "template": template }))
             .await
     }
 
@@ -128,7 +128,7 @@ impl PapillonService for TauriService {
     ) -> Result<OrchestratorConfig, String> {
         bridge::invoke::<Value, OrchestratorConfig>(
             "configure_orchestrator",
-            &serde_json::to_value(config).map_err(|e| e.to_string())?,
+            &json!({ "config": config }),
         )
         .await
     }
@@ -190,7 +190,7 @@ impl PapillonService for TauriService {
     }
 
     async fn update_agent_profile(&self, profile: &AgentProfileInfo) -> Result<(), String> {
-        bridge::invoke::<Value, ()>("update_agent_profile", &serde_json::to_value(profile).map_err(|e| e.to_string())?)
+        bridge::invoke::<Value, ()>("update_agent_profile", &json!({ "profile": profile }))
             .await
     }
 


### PR DESCRIPTION
## Summary
- Fixes `create_template` and `update_template` IPC calls that failed with `"missing required key template"` error
- Tauri 2 IPC requires named parameters wrapped as `{ "param_name": value }` — several calls were passing flat serialized structs instead
- Also fixes `configure_orchestrator` and `update_agent_profile` calls with the same bug pattern

## Test plan
- [ ] Create a new template in Settings → Templates tab — should succeed without error
- [ ] Edit an existing template — save should succeed
- [ ] Configure orchestrator settings — should apply without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)