### PR TITLE
release: v0.5.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 ## [Unreleased]
 
+## [0.5.6] - 2026-03-27
+
+### Added
+
+- **papillon**: On-demand model downloading for built-in LLM models — models are fetched at first use instead of bundled with the app binary, reducing initial download size
+
+### Fixed
+
+- **papillon**: Wrap Tauri IPC args in named parameter objects — fixes invoke serialization for commands expecting structured arguments
+
 ### Changed
 
 - Rename `papillion` → `papillon` across entire codebase (correct French spelling)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.5"
+version = "0.5.6"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"

--- a/packages/chrysalis-cli/package.json
+++ b/packages/chrysalis-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baur-software/chrysalis",
-  "version": "0.4.2",
+  "version": "0.5.6",
   "description": "Chrysalis — Self-hostable PAP-compatible federated agent registry. Run locally with npx.",
   "keywords": ["ai", "agents", "pap", "principal-agent-protocol", "chrysalis", "registry", "federation"],
   "license": "MIT OR Apache-2.0",

--- a/packages/papillon-cli/package.json
+++ b/packages/papillon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baur-software/papillon",
-  "version": "0.4.2",
+  "version": "0.5.6",
   "description": "Papillon — PAP-native agent browser. Run locally with npx.",
   "keywords": ["ai", "agents", "pap", "principal-agent-protocol", "papillon"],
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump workspace version `0.5.5` → `0.5.6` (propagates to all crates)
- Sync npm packages (`@baur-software/papillon`, `@baur-software/chrysalis`) to `0.5.6`
- Update CHANGELOG with on-demand model downloading, Tauri IPC fix, and papillion→papillon rename

## Changelog

### Added
- **papillon**: On-demand model downloading for built-in LLM models — models are fetched at first use instead of bundled with the app binary

### Fixed
- **papillon**: Wrap Tauri IPC args in named parameter objects — fixes invoke serialization

### Changed
- Rename `papillion` → `papillon` across entire codebase (correct French spelling)

## Test plan
- [ ] `cargo metadata` confirms all crates resolve to 0.5.6
- [ ] CI checks pass (build, test, lint, CodeQL)
- [ ] Release workflows detect version bump and create tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)