### PR TITLE
fix: sync tauri.conf.json version for correct desktop artifact naming

### DIFF
--- a/apps/papillon/tauri.conf.json
+++ b/apps/papillon/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/nicegui/tauri_app/tauri.conf.schema.json",
   "productName": "Papillon",
-  "version": "0.1.0",
+  "version": "0.5.6",
   "identifier": "com.baur-software.papillon",
   "build": {
     "beforeDevCommand": "cd papillon/frontend && trunk serve --port 1420",


### PR DESCRIPTION
## Summary

- Bump `tauri.conf.json` version from `0.1.0` to `0.5.6`
- Fixes desktop artifact naming: RPM, deb, AppImage, dmg, exe, and msi were all stamped `0.1.0` instead of the workspace version

## Context

The release workflow reads the workspace `Cargo.toml` for git tags and release names, but Tauri uses its own `tauri.conf.json` version for naming built binaries. These were out of sync since the initial Tauri setup.

## Test plan
- [ ] CI passes (build, test, lint)
- [ ] Next release produces artifacts named with correct version (e.g., `Papillon_0.5.6_universal.dmg`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)