### PR TITLE
release: v0.5.7 — fix desktop artifact versioning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+## [0.5.7] - 2026-03-27
+
+### Fixed
+
+- Sync `tauri.conf.json` version with workspace — desktop artifacts (rpm, deb, dmg, exe, msi, AppImage) now use the correct version in filenames
+
 ## [0.5.6] - 2026-03-27
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.5.6"
+version = "0.5.7"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"

--- a/apps/papillon/tauri.conf.json
+++ b/apps/papillon/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/nicegui/tauri_app/tauri.conf.schema.json",
   "productName": "Papillon",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "identifier": "com.baur-software.papillon",
   "build": {
     "beforeDevCommand": "cd papillon/frontend && trunk serve --port 1420",

--- a/packages/chrysalis-cli/package.json
+++ b/packages/chrysalis-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baur-software/chrysalis",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Chrysalis — Self-hostable PAP-compatible federated agent registry. Run locally with npx.",
   "keywords": ["ai", "agents", "pap", "principal-agent-protocol", "chrysalis", "registry", "federation"],
   "license": "MIT OR Apache-2.0",

--- a/packages/papillon-cli/package.json
+++ b/packages/papillon-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@baur-software/papillon",
-  "version": "0.5.6",
+  "version": "0.5.7",
   "description": "Papillon — PAP-native agent browser. Run locally with npx.",
   "keywords": ["ai", "agents", "pap", "principal-agent-protocol", "papillon"],
   "license": "MIT OR Apache-2.0",


### PR DESCRIPTION
## Summary

- Bump all version sources to `0.5.7`: workspace `Cargo.toml`, `tauri.conf.json`, and both npm packages
- v0.5.6 desktop artifacts were incorrectly named with `0.1.0` due to stale `tauri.conf.json`
- Tag protection rules prevented re-releasing 0.5.6, so this is a corrective patch release

## What changed
- `Cargo.toml` workspace: `0.5.6` → `0.5.7`
- `tauri.conf.json`: `0.5.6` → `0.5.7`  
- `@baur-software/papillon`: `0.5.6` → `0.5.7`
- `@baur-software/chrysalis`: `0.5.6` → `0.5.7`

## Test plan
- [ ] CI checks pass
- [ ] Release workflow produces artifacts named `Papillon_0.5.7_*` (not `0.1.0`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)