### PR TITLE
fix: strip pap-agents and pap-credential-store from Docker workspace members

### DIFF
--- a/apps/papillon/Dockerfile
+++ b/apps/papillon/Dockerfile
@@ -34,6 +34,8 @@ COPY apps/papillon/frontend ./apps/papillon/frontend
 # Patch workspace members to exclude crates we didn't copy.
 # Path deps still resolve; only the member list is trimmed.
 RUN sed -i \
+    -e '/^[[:space:]]*"crates\/pap-credential-store"/d' \
+    -e '/^[[:space:]]*"crates\/pap-agents"/d' \
     -e '/^[[:space:]]*"crates\/pap-webauthn"/d' \
     -e '/^[[:space:]]*"crates\/pap-transport"/d' \
     -e '/^[[:space:]]*"crates\/pap-federation"/d' \

--- a/apps/registry/Dockerfile
+++ b/apps/registry/Dockerfile
@@ -40,6 +40,8 @@ COPY apps/registry/assets ./apps/registry/assets
 # so workspace.dependencies path entries are left intact.
 RUN sed -i \
     -e '/^[[:space:]]*"crates\/pap-credential"/d' \
+    -e '/^[[:space:]]*"crates\/pap-credential-store"/d' \
+    -e '/^[[:space:]]*"crates\/pap-agents"/d' \
     -e '/^[[:space:]]*"crates\/pap-webauthn"/d' \
     -e '/^[[:space:]]*"crates\/pap-proto"/d' \
     -e '/^[[:space:]]*"crates\/pap-transport"/d' \
@@ -80,6 +82,8 @@ COPY apps/registry/src        ./apps/registry/src
 
 RUN sed -i \
     -e '/^[[:space:]]*"crates\/pap-credential"/d' \
+    -e '/^[[:space:]]*"crates\/pap-credential-store"/d' \
+    -e '/^[[:space:]]*"crates\/pap-agents"/d'     \
     -e '/^[[:space:]]*"crates\/pap-webauthn"/d'   \
     -e '/^[[:space:]]*"crates\/pap-proto"/d'       \
     -e '/^[[:space:]]*"crates\/pap-transport"/d'   \


### PR DESCRIPTION
## Summary
- Added `pap-agents` and `pap-credential-store` to the `sed` workspace-member filters in both the **registry** and **papillon** Dockerfiles
- These crates were added to the workspace but never included in the Dockerfile sed filters, causing `cargo-leptos` to fail with "No such file or directory" when resolving workspace members during Docker builds

## Test plan
- [ ] Registry Docker build succeeds (`docker compose up registry`)
- [ ] Papillon Docker build succeeds
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)