### PR TITLE
fix: use SPA-capable server for Playwright CI tests

### DIFF
--- a/e2e/playwright.config.ts
+++ b/e2e/playwright.config.ts
@@ -20,7 +20,7 @@ export default defineConfig({
     //     npx serve handles WASM MIME types correctly.
     // Local: trunk serve compiles on-the-fly in dev mode.
     command: isCI
-      ? "npx -y http-server ../apps/papillon/frontend/dist -p 1420 -c-1 --cors --silent"
+      ? "npx -y serve -s ../apps/papillon/frontend/dist -l 1420 --cors --no-clipboard"
       : "cd ../apps/papillon/frontend && trunk serve --port 1420",
     port: 1420,
     reuseExistingServer: !isCI,


### PR DESCRIPTION
## Summary
- Replaced `http-server` with `serve -s` in Playwright CI config
- `http-server` has no SPA fallback — direct navigation to `/settings` or `/activity` returned 404, preventing the WASM app from loading
- `serve -s` returns `index.html` for all non-file routes, enabling Leptos client-side routing
- Fixes 11 E2E test timeouts in `app.spec.ts` (Settings page, Activity page, Settings persistence)

## Test plan
- [x] All 63 Playwright E2E tests pass locally with `CI=1`
- [x] Previously failing tests (`/settings`, `/activity` direct navigation) now work
- [x] `web-standalone.spec.ts` (13 tests) still passes
- [x] `smoke.spec.ts` (5 tests) still passes
- [x] `canary.spec.ts` (7 tests) still passes
- [x] `templates.spec.ts` (8 tests) still passes
- [x] `app.spec.ts` (30 tests) now fully passes (was 19/30)

🤖 Generated with [Claude Code](https://claude.com/claude-code)