### PR TITLE
ci: configure CHRYSALIS_URL so Chrysalis integration tests actually run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,3 +171,97 @@ jobs:
             e2e/test-results/
             e2e/playwright-report/
           retention-days: 7
+
+  chrysalis-e2e:
+    name: Chrysalis Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # ── Rust + WASM toolchain (for Papillon frontend) ──────────────────────
+      - name: Install system dependencies
+        run: sudo apt-get update && sudo apt-get install -y libgtk-3-dev libwebkit2gtk-4.1-dev libayatana-appindicator3-dev librsvg2-dev libssl-dev
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: "smoke-wasm"
+          cache-on-failure: true
+      - name: Install cargo-binstall
+        uses: cargo-bins/cargo-binstall@main
+      - name: Cache trunk binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/trunk
+          key: trunk-${{ runner.os }}-${{ hashFiles('apps/papillon/frontend/Cargo.lock') }}
+          restore-keys: trunk-${{ runner.os }}-
+      - name: Install trunk
+        run: cargo binstall trunk --no-confirm
+
+      # ── Node.js + Playwright ──────────────────────────────────────────────
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('e2e/package-lock.json', 'e2e/package.json') }}
+          restore-keys: playwright-${{ runner.os }}-
+      - name: Install Playwright + wait-on
+        working-directory: e2e
+        run: |
+          npm install
+          npx playwright install chromium --with-deps
+
+      # ── Papillon frontend (needed for UI integration tests in the spec) ────
+      - name: Build frontend (release WASM)
+        run: cd apps/papillon/frontend && trunk build --release
+
+      # ── Chrysalis CI image (lean SSR-only build, no WASM bundle) ──────────
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Build Chrysalis CI image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: e2e/Dockerfile.ci-chrysalis
+          push: false
+          load: true
+          tags: chrysalis-ci:latest
+          cache-from: type=gha,scope=chrysalis-ci
+          cache-to: type=gha,scope=chrysalis-ci,mode=max
+
+      # ── Start Chrysalis + wait for health ─────────────────────────────────
+      - name: Start Chrysalis container
+        run: |
+          docker run -d \
+            --name chrysalis-ci \
+            -p 8080:8080 \
+            chrysalis-ci:latest
+      - name: Wait for Chrysalis to be healthy
+        working-directory: e2e
+        run: npx wait-on http://localhost:8080/federation/identity --timeout 60000
+
+      # ── Run Chrysalis integration tests ───────────────────────────────────
+      - name: Run Chrysalis integration tests
+        working-directory: e2e
+        env:
+          CHRYSALIS_URL: http://localhost:8080
+        run: npx playwright test tests/chrysalis-integration.spec.ts --workers=1
+
+      # ── Diagnostics + artifacts ───────────────────────────────────────────
+      - name: Dump Chrysalis container logs
+        if: always()
+        run: docker logs chrysalis-ci || true
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: chrysalis-e2e-results
+          path: |
+            e2e/test-results/
+            e2e/playwright-report/
+          retention-days: 7

--- a/ci/check-docker-workspace.sh
+++ b/ci/check-docker-workspace.sh
@@ -25,6 +25,7 @@ mapfile -t MEMBERS < <(
 DOCKERFILES=(
     "apps/registry/Dockerfile"
     "apps/papillon/Dockerfile"
+    "e2e/Dockerfile.ci-chrysalis"
 )
 
 errors=0

--- a/e2e/Dockerfile.ci-chrysalis
+++ b/e2e/Dockerfile.ci-chrysalis
@@ -1,0 +1,86 @@
+# Build context: repo root (pap/)
+#   docker build -f e2e/Dockerfile.ci-chrysalis -t chrysalis-ci .
+#
+# Lean single-binary image for Chrysalis CI integration tests.
+# Builds only the SSR server binary (no WASM / cargo-leptos needed)
+# so the image compiles significantly faster than the production image.
+# API endpoints (/federation/identity, /api/browse, /federation/peers)
+# all work without the WASM bundle; only the web UI pages are absent.
+
+# ── Stage 1: Build SSR server binary ─────────────────────────────────────────
+FROM rust:1.94-slim AS builder
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    curl ca-certificates pkg-config libssl-dev libpq-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /build
+
+# Workspace root
+COPY Cargo.toml Cargo.lock ./
+COPY vendor-icu ./vendor-icu
+
+# Crates in pap-registry's transitive dependency graph (mirrors apps/registry/Dockerfile)
+COPY crates/pap-did              ./crates/pap-did
+COPY crates/pap-tee              ./crates/pap-tee
+COPY crates/pap-core             ./crates/pap-core
+COPY crates/pap-marketplace      ./crates/pap-marketplace
+COPY crates/pap-federation       ./crates/pap-federation
+COPY crates/pap-credential       ./crates/pap-credential
+COPY crates/pap-credential-store ./crates/pap-credential-store
+COPY crates/pap-webauthn         ./crates/pap-webauthn
+COPY crates/pap-proto            ./crates/pap-proto
+COPY crates/pap-transport        ./crates/pap-transport
+COPY crates/pap-agents           ./crates/pap-agents
+
+# Registry app
+COPY apps/registry/Cargo.toml ./apps/registry/Cargo.toml
+COPY apps/registry/src        ./apps/registry/src
+COPY apps/registry/styles     ./apps/registry/styles
+COPY apps/registry/assets     ./apps/registry/assets
+
+# Strip workspace members that were not copied (same sed as apps/registry/Dockerfile)
+RUN sed -i \
+    -e '/^[[:space:]]*"crates\/pap-python"/d' \
+    -e '/^[[:space:]]*"crates\/pap-c"/d' \
+    -e '/^[[:space:]]*"crates\/pap-wasm"/d' \
+    -e '/^[[:space:]]*"crates\/papillon-shared"/d' \
+    -e '/^[[:space:]]*"apps\/papillon"/d' \
+    -e '/^[[:space:]]*"benches"/d' \
+    -e '/^[[:space:]]*"examples\//d' \
+    Cargo.toml
+
+# Build server binary only — skip WASM (no wasm32 target, no cargo-leptos required)
+RUN cargo build --release -p pap-registry --features ssr
+
+# ── Stage 2: Minimal runtime image ───────────────────────────────────────────
+FROM debian:trixie-slim AS runtime
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates curl libpq5 \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /data /app/site /app/assets /app/styles
+
+WORKDIR /app
+
+COPY --from=builder /build/target/release/pap-registry ./pap-registry
+COPY --from=builder /build/apps/registry/assets        ./assets
+COPY --from=builder /build/apps/registry/styles/main.css ./styles/main.css
+
+# Plain HTTP on port 8080 — suitable for CI (no TLS certificates to manage)
+ENV PAP_REGISTRY_HOST=0.0.0.0
+ENV PAP_REGISTRY_PORT=8080
+ENV PAP_REGISTRY_NO_TLS=true
+ENV PAP_REGISTRY_ENDPOINT=http://localhost:8080
+ENV PAP_REGISTRY_DB=/data/registry.db
+ENV PAP_ASSETS_DIR=/app/assets
+ENV LEPTOS_SITE_ROOT=/app/site
+
+VOLUME ["/data"]
+EXPOSE 8080
+
+HEALTHCHECK --interval=5s --timeout=3s --start-period=10s --retries=6 \
+    CMD curl -sf http://localhost:8080/federation/identity > /dev/null
+
+ENTRYPOINT ["/app/pap-registry"]

--- a/e2e/package.json
+++ b/e2e/package.json
@@ -11,6 +11,7 @@
     "test:web:headed": "playwright test tests/web-standalone.spec.ts --headed"
   },
   "devDependencies": {
-    "@playwright/test": "^1.50.0"
+    "@playwright/test": "^1.50.0",
+    "wait-on": "^8.0.0"
   }
 }

--- a/e2e/tests/chrysalis-integration.spec.ts
+++ b/e2e/tests/chrysalis-integration.spec.ts
@@ -31,9 +31,18 @@ const CHRYSALIS_URL = process.env.CHRYSALIS_URL ?? "";
 const SKIP_MSG =
   "CHRYSALIS_URL not set — start Chrysalis (./scripts/start-chrysalis-dev.sh) and set CHRYSALIS_URL";
 
-// Helper: skip this test when no live server is available
+// In CI, CHRYSALIS_URL must always be provided (the chrysalis-e2e job sets it).
+// A missing URL in CI means the job was misconfigured — fail loudly so the
+// regression is caught rather than silently skipped past.
+// Outside CI (local dev), skip gracefully so developers can run `playwright test`
+// without starting Chrysalis first.
 function requireChrysalis() {
-  if (!CHRYSALIS_URL) test.skip(true, SKIP_MSG);
+  if (!CHRYSALIS_URL) {
+    if (process.env.CI) {
+      throw new Error(`CI misconfiguration: ${SKIP_MSG}`);
+    }
+    test.skip(true, SKIP_MSG);
+  }
 }
 
 // ── 1. Federation identity ────────────────────────────────────


### PR DESCRIPTION
## Summary

- **`e2e/Dockerfile.ci-chrysalis`** — lean two-stage image that builds only the `pap-registry` SSR binary (no cargo-leptos / WASM), runs on HTTP port 8080, and includes a Docker `HEALTHCHECK` on `/federation/identity`; first-run build is cached in GHA via `type=gha,scope=chrysalis-ci`
- **`chrysalis-e2e` CI job** — builds the image, starts the container, waits for health via `wait-on`, sets `CHRYSALIS_URL=http://localhost:8080`, and runs `playwright test tests/chrysalis-integration.spec.ts`; also builds the Papillon frontend so the UI-integration tests in sections 5–6 of the spec can exercise real Chrysalis data through the Tauri mock
- **`requireChrysalis()` guard** — throws `Error("CI misconfiguration: …")` when `process.env.CI` is set and `CHRYSALIS_URL` is absent, so a misconfigured job fails loudly instead of silently passing; preserves the graceful `test.skip` for local dev
- **`wait-on ^8.0.0`** added to `e2e/package.json` devDependencies
- **`ci/check-docker-workspace.sh`** — registers the new Dockerfile so any future workspace crate addition is automatically validated against it

## Test plan

- [ ] CI `chrysalis-e2e` job turns green on this PR
- [ ] Removing `CHRYSALIS_URL` from the job env and re-running confirms the guard throws (not skips)
- [ ] `docker build -f e2e/Dockerfile.ci-chrysalis -t chrysalis-ci . && docker run -p 8080:8080 chrysalis-ci` works locally and `/federation/identity` responds
- [ ] `ci/check-docker-workspace.sh` exits 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)