### PR TITLE
feat: canvas provenance layer — trust transparency for outcome blocks

### DIFF
--- a/apps/papillon/frontend/src/components/block_renderer/mod.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/mod.rs
@@ -231,16 +231,24 @@ pub fn BlockRenderer(block: CanvasBlock) -> impl IntoView {
                         <div class="provenance-footer">
                             <button
                                 class="provenance-toggle"
-                                on:click=move |_| show_provenance.update(|v| *v = !*v)
+                                on:click=move |e: leptos::ev::MouseEvent| {
+                                    e.stop_propagation();
+                                    show_provenance.update(|v| *v = !*v);
+                                }
                             >
-                                {format!("{} agent{} contributed", prov_count, if prov_count == 1 { "" } else { "s" })}
                                 <span class="provenance-chevron"
                                     class:expanded=move || show_provenance.get()
-                                >">"</span>
+                                >"▶"</span>
+                                {format!("{} agent{} contributed", prov_count, if prov_count == 1 { "" } else { "s" })}
+                                <span class="provenance-privacy-badge">"Guarded"</span>
                             </button>
-                            <Show when=move || show_provenance.get()>
+                            // Always rendered; CSS grid-template-rows animates open/close.
+                            <div
+                                class="provenance-panel-wrap"
+                                class:expanded=move || show_provenance.get()
+                            >
                                 <ProvenanceLayer block_ids=prov_ids.clone() />
-                            </Show>
+                            </div>
                         </div>
                         <Show when=move || show_reprompt.get()>
                             <div class="block-reprompt">
@@ -286,8 +294,9 @@ fn PhaseDots(current_phase: u8, #[prop(default = false)] failed: bool) -> impl I
 }
 
 /// Expandable provenance layer showing the individual agent blocks that
-/// contributed to an outcome block. Each entry shows the agent name,
-/// action type, and a scope badge summarizing what it saw/returned.
+/// contributed to an outcome block. Each entry is a full ProvenancePanel
+/// showing agent DID, mandate scope, actions taken, receipt hash, and
+/// decay state — the trust transparency feature.
 #[component]
 fn ProvenanceLayer(block_ids: Vec<String>) -> impl IntoView {
     let canvas_state = expect_context::<CanvasState>();
@@ -313,34 +322,210 @@ fn ProvenanceLayer(block_ids: Vec<String>) -> impl IntoView {
                 each=entries
                 key=|b| b.id.clone()
                 children=move |block| {
-                    let agent_name = block
-                        .content
-                        .as_ref()
-                        .and_then(|c| c.get("agent"))
-                        .and_then(|v| v.as_str())
-                        .unwrap_or("Unknown agent")
-                        .to_string();
-                    let action = block
-                        .schema_type
-                        .clone()
-                        .unwrap_or_else(|| "Action".into());
-                    let has_receipt = block
-                        .content
-                        .as_ref()
-                        .map(|c| c.get("receipt").is_some())
-                        .unwrap_or(false);
-
-                    view! {
-                        <div class="provenance-entry">
-                            <span class="provenance-agent">{agent_name}</span>
-                            <span class="provenance-action">{action}</span>
-                            <Show when=move || has_receipt>
-                                <span class="scope-badge receipt">"co-signed"</span>
-                            </Show>
-                        </div>
-                    }
+                    view! { <ProvenancePanel block=block /> }
                 }
             />
+        </div>
+    }
+}
+
+/// Full provenance panel for a single contributing agent block.
+/// Shows: agent name + DID, mandate scope granted, actions taken,
+/// receipt hash with link to Receipts page, and mandate decay state.
+#[component]
+fn ProvenancePanel(block: papillon_shared::CanvasBlock) -> impl IntoView {
+    let content = block.content.clone();
+
+    // ── Extract fields from content JSON ────────────────────
+    let agent_name = content
+        .as_ref()
+        .and_then(|c| c.get("agent"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Unknown agent")
+        .to_string();
+
+    let action = content
+        .as_ref()
+        .and_then(|c| c.get("receipt"))
+        .and_then(|r| r.get("action"))
+        .and_then(|v| v.as_str())
+        .or_else(|| block.schema_type.as_deref())
+        .unwrap_or("Action")
+        .trim_start_matches("schema:")
+        .to_string();
+
+    // Provenance section (added by the handshake layer)
+    let prov = content.as_ref().and_then(|c| c.get("provenance")).cloned();
+
+    let agent_did = prov
+        .as_ref()
+        .and_then(|p| p.get("agent_did"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let issuer_did = prov
+        .as_ref()
+        .and_then(|p| p.get("issuer_did"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let decay_state = prov
+        .as_ref()
+        .and_then(|p| p.get("decay_state"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("Active")
+        .to_string();
+
+    let disclosed: Vec<String> = prov
+        .as_ref()
+        .and_then(|p| p.get("disclosed"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    let returns: Vec<String> = prov
+        .as_ref()
+        .and_then(|p| p.get("returns"))
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str())
+                .map(|s| s.to_string())
+                .collect()
+        })
+        .unwrap_or_default();
+
+    // Receipt section
+    let receipt = content.as_ref().and_then(|c| c.get("receipt")).cloned();
+
+    let session_id = receipt
+        .as_ref()
+        .and_then(|r| r.get("session_id"))
+        .and_then(|v| v.as_str())
+        .unwrap_or("")
+        .to_string();
+
+    let co_sigs = receipt
+        .as_ref()
+        .and_then(|r| r.get("co_signatures"))
+        .and_then(|v| v.as_u64())
+        .unwrap_or(0);
+
+    // Truncate a DID for display: show first 20 + "…" + last 8 chars.
+    fn truncate_did(did: &str) -> String {
+        if did.len() > 32 {
+            format!("{}…{}", &did[..20], &did[did.len() - 8..])
+        } else {
+            did.to_string()
+        }
+    }
+
+    let agent_did_short = truncate_did(&agent_did);
+    let issuer_did_short = truncate_did(&issuer_did);
+    let session_id_short = truncate_did(&session_id);
+
+    let is_on_device = agent_did.is_empty();
+    let has_receipt = !session_id.is_empty();
+    let zero_disclosure = disclosed.is_empty();
+    // Precomputed booleans for Show `when=` closures — avoids moving the
+    // underlying String/Vec into the condition closure when children also need them.
+    let has_issuer_did = !issuer_did.is_empty();
+    let has_returns_data = !returns.is_empty();
+
+    let decay_class = match decay_state.as_str() {
+        "Active" => "decay-badge decay-active",
+        "Degraded" => "decay-badge decay-degraded",
+        "ReadOnly" => "decay-badge decay-readonly",
+        "Suspended" => "decay-badge decay-suspended",
+        _ => "decay-badge decay-active",
+    };
+
+    view! {
+        <div class="provenance-entry">
+            // Header row: agent name + action badge
+            <div class="prov-header">
+                <span class="provenance-agent">{agent_name}</span>
+                <span class="provenance-action">{action}</span>
+                <span class=decay_class>{decay_state.clone()}</span>
+            </div>
+
+            // Agent DID row (hidden for on-device synthesizer)
+            <Show when=move || !is_on_device>
+                <div class="prov-did-row">
+                    <span class="prov-label">"DID"</span>
+                    <span class="prov-did" title=agent_did.clone()>{agent_did_short.clone()}</span>
+                </div>
+            </Show>
+
+            // Issuer DID row
+            <Show when=move || has_issuer_did>
+                <div class="prov-did-row">
+                    <span class="prov-label">"PRINCIPAL"</span>
+                    <span class="prov-did" title=issuer_did.clone()>{issuer_did_short.clone()}</span>
+                </div>
+            </Show>
+
+            // Mandate scope: what the agent was permitted to see
+            <div class="prov-scope-row">
+                <span class="prov-label">"SAW"</span>
+                <div class="scope-badges">
+                    {if zero_disclosure {
+                        vec![view! { <span class="scope-badge zero-disclosure">"zero disclosure"</span> }.into_any()]
+                    } else {
+                        disclosed.iter().map(|d| {
+                            let d = d.trim_start_matches("schema:").to_string();
+                            view! { <span class="scope-badge disclosure">{d}</span> }.into_any()
+                        }).collect::<Vec<_>>()
+                    }}
+                </div>
+            </div>
+
+            // What the agent returned
+            <Show when=move || has_returns_data>
+                <div class="prov-scope-row">
+                    <span class="prov-label">"RETURNED"</span>
+                    <div class="scope-badges">
+                        {returns.iter().map(|r| {
+                            let r = r.trim_start_matches("schema:").to_string();
+                            view! { <span class="scope-badge returns">{r}</span> }
+                        }).collect::<Vec<_>>()}
+                    </div>
+                </div>
+            </Show>
+
+            // On-device synthesis note
+            <Show when=move || is_on_device>
+                <div class="prov-scope-row">
+                    <span class="prov-label">"LOCAL"</span>
+                    <span class="prov-ondevice">"Composed on-device — never left this machine"</span>
+                </div>
+            </Show>
+
+            // Receipt section with link to Receipts page
+            <Show when=move || has_receipt>
+                <div class="prov-receipt-row">
+                    <span class="prov-label">"RECEIPT"</span>
+                    <span class="scope-badge receipt">
+                        {format!("{} co-sig{}", co_sigs, if co_sigs == 1 { "" } else { "s" })}
+                    </span>
+                    <a
+                        class="prov-receipt-link"
+                        href="/receipts"
+                        title=session_id.clone()
+                        on:click=|e: leptos::ev::MouseEvent| e.stop_propagation()
+                    >
+                        {session_id_short.clone()}
+                        <span class="prov-receipt-arrow">" →"</span>
+                    </a>
+                </div>
+            </Show>
         </div>
     }
 }

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -1918,6 +1918,7 @@ body {
     align-items: center;
     gap: var(--sp-xs);
     transition: color 0.15s ease;
+    width: 100%;
 }
 
 .provenance-toggle:hover {
@@ -1926,36 +1927,76 @@ body {
 
 .provenance-chevron {
     font-family: var(--font-mono);
-    font-size: 11px;
-    transition: transform 0.15s ease;
+    font-size: 9px;
+    transition: transform 0.2s cubic-bezier(0.4, 0, 0.2, 1);
     display: inline-block;
+    color: var(--text-3);
+    flex-shrink: 0;
 }
 
 .provenance-chevron.expanded {
     transform: rotate(90deg);
 }
 
+.provenance-privacy-badge {
+    margin-left: auto;
+    font: var(--text-label);
+    font-family: var(--font-mono);
+    letter-spacing: var(--ls-label);
+    text-transform: uppercase;
+    color: var(--teal);
+    background: rgba(46, 196, 160, 0.08);
+    border: 1px solid rgba(46, 196, 160, 0.2);
+    border-radius: var(--r-sm);
+    padding: 1px var(--sp-xs);
+}
+
+/* ── Smooth expand animation via CSS grid trick ── */
+.provenance-panel-wrap {
+    display: grid;
+    grid-template-rows: 0fr;
+    transition: grid-template-rows 240ms cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+.provenance-panel-wrap.expanded {
+    grid-template-rows: 1fr;
+}
+
 .provenance-layer {
+    overflow: hidden;
     display: flex;
     flex-direction: column;
     gap: var(--sp-xs);
+    padding: 0;
+}
+
+.provenance-panel-wrap.expanded .provenance-layer {
     padding: var(--sp-sm) 0 var(--sp-2xs);
 }
 
+/* ── Provenance entry card ── */
 .provenance-entry {
     display: flex;
-    align-items: center;
-    gap: var(--sp-sm);
-    padding: var(--sp-xs) var(--sp-sm);
-    background: var(--bg-2);
-    border-radius: var(--r-sm);
+    flex-direction: column;
+    gap: var(--sp-xs);
+    padding: var(--sp-sm);
+    background: var(--bg-1);
+    border-radius: var(--r-md);
     border: 1px solid var(--border-subtle);
 }
 
+/* Header row: name + action badge + decay state */
+.prov-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    flex-wrap: wrap;
+}
+
 .provenance-agent {
-    font: var(--text-small);
+    font-size: 13px;
     font-family: var(--font-body);
-    font-weight: 500;
+    font-weight: 600;
     color: var(--text-1);
 }
 
@@ -1964,7 +2005,126 @@ body {
     font-family: var(--font-mono);
     letter-spacing: var(--ls-label);
     text-transform: uppercase;
+    color: var(--purple);
+    background: var(--purple-muted);
+    border: 1px solid rgba(108, 92, 231, 0.2);
+    border-radius: var(--r-sm);
+    padding: 1px var(--sp-xs);
+}
+
+/* DID display rows */
+.prov-did-row {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+}
+
+.prov-label {
+    font: var(--text-label);
+    font-family: var(--font-mono);
+    letter-spacing: var(--ls-label);
+    text-transform: uppercase;
     color: var(--text-3);
+    flex-shrink: 0;
+    min-width: 64px;
+}
+
+.prov-did {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-2);
+    cursor: default;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    max-width: 260px;
+}
+
+/* Scope rows */
+.prov-scope-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--sp-sm);
+    flex-wrap: wrap;
+}
+
+.prov-ondevice {
+    font-size: 12px;
+    font-family: var(--font-body);
+    color: var(--text-3);
+    font-style: italic;
+}
+
+/* Zero-disclosure badge variant */
+.scope-badge.zero-disclosure {
+    border-color: rgba(46, 196, 160, 0.3);
+    color: var(--teal);
+    background: rgba(46, 196, 160, 0.08);
+    font-style: italic;
+}
+
+/* Receipt row */
+.prov-receipt-row {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    flex-wrap: wrap;
+}
+
+.prov-receipt-link {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-3);
+    text-decoration: none;
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+    transition: color 0.15s ease;
+    cursor: pointer;
+}
+
+.prov-receipt-link:hover {
+    color: var(--purple);
+}
+
+.prov-receipt-arrow {
+    font-size: 11px;
+    opacity: 0.7;
+}
+
+/* ── Mandate decay state badges ── */
+.decay-badge {
+    font: var(--text-label);
+    font-family: var(--font-mono);
+    letter-spacing: var(--ls-label);
+    text-transform: uppercase;
+    padding: 1px var(--sp-xs);
+    border-radius: var(--r-sm);
+    border: 1px solid;
+}
+
+.decay-active {
+    color: var(--teal);
+    background: rgba(46, 196, 160, 0.08);
+    border-color: rgba(46, 196, 160, 0.25);
+}
+
+.decay-degraded {
+    color: var(--gold);
+    background: rgba(240, 160, 48, 0.08);
+    border-color: rgba(240, 160, 48, 0.25);
+}
+
+.decay-readonly {
+    color: var(--blue);
+    background: rgba(80, 152, 224, 0.08);
+    border-color: rgba(80, 152, 224, 0.25);
+}
+
+.decay-suspended {
+    color: var(--coral);
+    background: rgba(232, 112, 106, 0.08);
+    border-color: rgba(232, 112, 106, 0.25);
 }
 
 /* ═══════════════════════════════════════════════════════════

--- a/apps/papillon/src/handshake.rs
+++ b/apps/papillon/src/handshake.rs
@@ -177,6 +177,11 @@ pub async fn execute(params: HandshakeParams<'_>) -> Result<HandshakeResult, Pap
             PapillonError::from(e.to_string())
         })?;
 
+    // Capture provenance data before phase 5 partially moves auth fields.
+    // receiver_session_did is the agent's ephemeral session DID for this handshake.
+    let prov_agent_did = auth.receiver_session_did.clone();
+    let prov_issuer_did = auth.principal_did.clone();
+
     // ── Phase 5: Co-sign receipt (session key signs here, then dropped) ──
     on_phase(5, "Co-signing receipt...");
 
@@ -264,6 +269,13 @@ pub async fn execute(params: HandshakeParams<'_>) -> Result<HandshakeResult, Pap
             "session_id": session_id_out,
             "co_signatures": sig_count,
             "action": action_type
+        },
+        "provenance": {
+            "agent_did": prov_agent_did,
+            "issuer_did": prov_issuer_did,
+            "disclosed": requires_disclosure,
+            "returns": returns,
+            "decay_state": "Active"
         }
     });
 


### PR DESCRIPTION
## Summary

- Each outcome block is now expandable to reveal the full provenance of every agent that contributed
- **ProvenancePanel** shows: agent name + action, agent DID, principal DID, mandate scope granted (SAW / zero disclosure), returns, receipt hash with link to Receipts page, and mandate decay state
- Handshake result content enriched with `provenance` field (agent_did, issuer_did, disclosed, returns, decay_state)
- Smooth expand animation via CSS `grid-template-rows: 0fr → 1fr` (240ms cubic-bezier)
- Decay state badges use wing spectrum colors (Active=teal, Degraded=gold, ReadOnly=blue, Suspended=coral)

## Test plan

- [ ] Run a canvas prompt — verify the outcome block shows "N agents contributed · Guarded" footer
- [ ] Click toggle — panel expands with smooth animation (~240ms)
- [ ] Confirm agent name, action badge (purple), decay badge (teal Active) render correctly
- [ ] For zero-disclosure agents (most built-ins): SAW row shows italic "zero disclosure" badge
- [ ] For agents with disclosure requirements: SAW row shows property name badges
- [ ] Receipt row shows co-sig count and truncated session DID linking to /receipts
- [ ] Click toggle again — panel collapses smoothly
- [ ] Verify `cargo check --package papillon` passes (backend)
- [ ] Verify no new errors in frontend check beyond pre-existing web_identity.rs issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)