### PR TITLE
docs: LangChain/CrewAI/MCP integration guide (ISS-844)

### DIFF
--- a/docs/integration-guides/langchain-crewai-mcp.md
+++ b/docs/integration-guides/langchain-crewai-mcp.md
@@ -11,7 +11,7 @@ verifiable scope, TTL, and selective-disclosure policy.
 ## Prerequisites
 
 ```bash
-pip install pap langchain langchain-openai crewai mcp
+pip install pap langchain langchain-core langchain-openai crewai mcp
 ```
 
 PAP requires Python 3.8+. If you are building the Rust extension from source:
@@ -116,7 +116,7 @@ any global mutable state.
 import datetime
 from typing import Optional, Type
 
-from langchain.tools import BaseTool
+from langchain_core.tools import BaseTool
 from pydantic import BaseModel, Field
 
 from pap import (


### PR DESCRIPTION
## Summary

- Adds `docs/integration-guides/langchain-crewai-mcp.md`, a comprehensive integration guide showing how to use the PAP Python SDK (`pap`) with the three most common AI orchestration stacks
- **LangChain**: `BaseTool` subclass with per-tool mandate enforcement, scope/TTL checks before every `_run`, capability token minting, and safe error handling for `PapSignatureError` / `PapScopeError`
- **CrewAI**: multi-agent pipeline where the human principal issues a root mandate to an orchestrator, which re-delegates narrowed mandates to search and booking workers; full `MandateChain` verification before crew kickoff; TTL refresh helper for long-running crews
- **MCP**: PAP as the authorization layer for MCP tool servers — `verify_capability_token` middleware, a complete `mcp.Server` with a guarded `web_search` tool, matching client-side token issuance, and a reusable `require_pap_token` decorator
- **Common patterns section**: issue/verify mandate helpers, selective disclosure via `SelectiveDisclosureJwt`, co-signed `TransactionReceipt` construction, scope enforcement utilities, TTL health reporting, and a security checklist
- Self-contained demo script (`pap_integration_demo.py`) exercising all primitives without live AI backends

## Test plan

- [ ] Read through the guide and verify all code examples are syntactically correct Python
- [ ] Confirm all PAP API calls match the public surface in `crates/pap-python/src/lib.rs` (classes, method names, signatures)
- [ ] Verify the delegation chain example enforces scope narrowing and TTL shrinking per level
- [ ] Confirm `TransactionReceipt` examples use property references (e.g. `schema:Person.schema:name`), never literal values
- [ ] Check that the MCP example's `verify_capability_token` correctly raises `PapSignatureError` for unknown issuers and `PapScopeError` for action mismatches
- [ ] Run the self-contained demo script after `maturin develop` to confirm it completes without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)