### PR TITLE
fix: bundle agent catalog, wire empty-state tiles, clean status bar

### DIFF
--- a/apps/papillon/frontend/src/app.rs
+++ b/apps/papillon/frontend/src/app.rs
@@ -339,14 +339,6 @@ pub fn App() -> impl IntoView {
                     </Routes>
                 </main>
                 <footer class="status-bar app-statusbar">
-                    <span class="status-bar-item active">
-                        <svg width="10" height="10" viewBox="0 0 24 24" fill="currentColor"><circle cx="12" cy="12" r="5"/></svg>
-                        "ZERO_TRUST_ENFORCED"
-                    </span>
-                    <span class="status-bar-sep">"|"</span>
-                    <span class="status-bar-item">"LOCAL_VAULT_ENCRYPTED"</span>
-                    <span class="status-bar-sep">"|"</span>
-                    <span class="status-bar-item">"NO_TELEMETRY"</span>
                     <span class="status-bar-spacer" />
                     <span class="status-bar-item">"PAPILLON_v0.6.0"</span>
                     <span class="status-bar-sep">"|"</span>

--- a/apps/papillon/frontend/src/pages/canvas.rs
+++ b/apps/papillon/frontend/src/pages/canvas.rs
@@ -152,12 +152,31 @@ pub fn CanvasPage() -> impl IntoView {
     }
 }
 
-/// Minimal empty state — the prompt bar above is the primary affordance.
+/// Empty-state capability tiles — shown when the canvas has no blocks.
+/// Each tile prefills the prompt bar so the user can complete and submit.
 #[component]
 fn CanvasEmptyState() -> impl IntoView {
+    let canvas_state = expect_context::<CanvasState>();
+
     view! {
         <div class="canvas-empty-state">
-            <p class="canvas-empty-hint">"Ask anything, or navigate to an agent"</p>
+            <div class="agent-tiles">
+                {AGENT_TILES.iter().map(|&(label, example)| {
+                    let canvas_state = canvas_state;
+                    view! {
+                        <button
+                            class="agent-tile"
+                            on:click=move |_| {
+                                canvas_state.prefill_prompt.set(Some(example.to_string()));
+                                canvas_state.focus_prompt.update(|n| *n += 1);
+                            }
+                        >
+                            <span class="agent-tile-label">{label}</span>
+                            <span class="agent-tile-example">{example}</span>
+                        </button>
+                    }
+                }).collect::<Vec<_>>()}
+            </div>
         </div>
     }
 }

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -4153,16 +4153,53 @@ body {
     display: flex;
     flex-direction: column;
     align-items: center;
-    justify-content: center;
-    padding: var(--sp-3xl) 0;
+    justify-content: flex-start;
+    padding: var(--sp-3xl) var(--sp-xl);
     gap: var(--sp-md);
 }
 
-.canvas-empty-hint {
-    font-size: 13px;
+/* Agent capability tiles shown in the canvas empty state */
+.agent-tiles {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+    gap: var(--sp-sm);
+    width: 100%;
+    max-width: 720px;
+}
+
+.agent-tile {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 4px;
+    padding: var(--sp-sm) var(--sp-md);
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(255,255,255,0.07);
+    border-radius: var(--r-md);
+    cursor: pointer;
+    text-align: left;
+    transition: background 0.15s, border-color 0.15s;
+}
+
+.agent-tile:hover {
+    background: rgba(108, 92, 231, 0.12);
+    border-color: var(--purple);
+}
+
+.agent-tile-label {
+    font: var(--text-small);
+    font-weight: 600;
+    color: var(--text-1);
+    letter-spacing: 0.03em;
+}
+
+.agent-tile-example {
+    font: var(--text-small);
     color: var(--text-3);
-    text-align: center;
-    font-family: var(--font-body);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    max-width: 100%;
 }
 
 /* ─── AwaitingApproval block ─── */

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -313,8 +313,7 @@ body {
     flex-shrink: 0;
 }
 
-.status-bar-item.active { color: var(--teal); }
-.status-bar-item.warn { color: var(--gold); }
+/* .status-bar-item.active/.warn removed — status colour now driven by .status-indicator classes */
 
 .status-bar-sep {
     color: rgba(255, 255, 255, 0.15);

--- a/apps/papillon/src/lib.rs
+++ b/apps/papillon/src/lib.rs
@@ -43,6 +43,34 @@ pub fn run() {
                 .expect("failed to resolve resource dir");
             let catalog_dir = resource_dir.join("catalog");
 
+            // Dev-mode fallback: when running via `cargo tauri dev` the resource
+            // bundle hasn't been assembled yet, so fall back to the workspace path.
+            let catalog_dir = if catalog_dir.exists() {
+                eprintln!("INFO papillon: catalog at {}", catalog_dir.display());
+                catalog_dir
+            } else {
+                let ws_catalog = std::env::var("CARGO_MANIFEST_DIR")
+                    .map(|d| {
+                        std::path::PathBuf::from(d)
+                            .join("../..")
+                            .join("crates/pap-agents/catalog")
+                    })
+                    .unwrap_or_default();
+                if ws_catalog.exists() {
+                    eprintln!(
+                        "INFO papillon: catalog not in resources, using workspace path {}",
+                        ws_catalog.display()
+                    );
+                    ws_catalog
+                } else {
+                    eprintln!(
+                        "WARN papillon: catalog not found at {} — agents will not be seeded",
+                        catalog_dir.display()
+                    );
+                    catalog_dir
+                }
+            };
+
             // Open (or create) the persistent principal keypair store.
             // The 32-byte Ed25519 seed is stored as `principal.key` with mode
             // 0600 and zeroized in memory on drop.

--- a/apps/papillon/tauri.conf.json
+++ b/apps/papillon/tauri.conf.json
@@ -40,7 +40,8 @@
       "icons/icon.png"
     ],
     "resources": {
-      "models/*": "models/"
+      "models/*": "models/",
+      "../../crates/pap-agents/catalog/**/*": "catalog/"
     }
   }
 }


### PR DESCRIPTION
## Summary

Two QA-driven fixes from first-launch testing of the canvas rethink (#267).

### 1. Agent catalog never bundled → `schema:SearchAction` always fails (P0)
The 305-agent catalog at `crates/pap-agents/catalog/` was never listed in `tauri.conf.json` resources. `catalog_dir.exists()` returned `false` on every launch, so zero agents were ever seeded into the DB. Every schema:SearchAction/CheckAction/FindAction call hit an empty registry and failed with:
```
Failed at phase 1: No agent for schema:SearchAction
```

**Fix**: Add `"../../crates/pap-agents/catalog/**/*": "catalog/"` to `tauri.conf.json` resources. Add dev-mode fallback via `CARGO_MANIFEST_DIR` for `cargo tauri dev`. Startup now logs which catalog path was used (or warns if none found).

### 2. `AGENT_TILES` dead code → empty state was bare (P1)
The `AGENT_TILES` constant (13 labelled capability tiles) was declared but never rendered, producing a dead_code compiler warning. `CanvasEmptyState` just showed "Ask anything..." text.

**Fix**: Wire `AGENT_TILES` into `CanvasEmptyState` — renders a responsive grid of clickable capability tiles. Each click prefills the prompt bar via `canvas_state.prefill_prompt`.

### 3. Status bar static labels (P2)
`ZERO_TRUST_ENFORCED`, `LOCAL_VAULT_ENCRYPTED`, `NO_TELEMETRY` are protocol invariants — always true, never change at runtime. Displaying them as live status indicators implies variability that doesn't exist.

**Fix**: Remove the 3 hardcoded left items. Status bar now shows only dynamic data: version + live `OrchestratorStatus` (Ready / Downloading… / Agents only).

## Files changed
- `apps/papillon/tauri.conf.json` — add catalog to bundle resources
- `apps/papillon/src/lib.rs` — dev-mode catalog fallback + startup logging
- `apps/papillon/frontend/src/pages/canvas.rs` — wire AGENT_TILES to CanvasEmptyState
- `apps/papillon/frontend/styles/main.css` — agent tile grid styles, remove dead CSS
- `apps/papillon/frontend/src/app.rs` — remove static status bar labels

## Test plan
- [ ] On fresh install: catalog agents seed on first launch (check DB)
- [ ] "search for Rust programming" resolves instead of failing at phase 1
- [ ] Canvas empty state shows 13 agent capability tiles
- [ ] Clicking a tile prefills and focuses the prompt bar
- [ ] Dev mode finds catalog via workspace fallback
- [ ] Status bar shows only `PAPILLON_v0.6.0 | <status>`
- [ ] Build clean, no dead_code warnings, Clippy clean ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)