### PR TITLE
fix(catalog): escape nested quotes in zip_code_lookup TOML

### DIFF
--- a/crates/pap-agents/catalog/geo/zip_code_lookup.toml
+++ b/crates/pap-agents/catalog/geo/zip_code_lookup.toml
@@ -13,5 +13,5 @@ subagents = []
 [endpoint]
 url_template = "https://api.zippopotam.us/us/{query}"
 method = "Get"
-response_jsonpath = "$.places[0]."place name""
+response_jsonpath = '$.places[0]."place name"'
 response_schema_type = "schema:Place"


### PR DESCRIPTION
## Summary

Runtime error on catalog load:
```
[catalog] parse error in zip_code_lookup.toml: TOML parse error at line 16, column 35
response_jsonpath = "$.places[0]."place name""
                                  ^
expected newline, #
```

The `response_jsonpath` value had unescaped double quotes inside a double-quoted TOML string. Fix: use a TOML literal string (single quotes) to preserve the inner JSON-path quotes.

Scanned all 305 catalog entries with Python `tomllib` — this was the only parse error.

## Test plan
- [x] `cargo test -p pap-agents -- catalog` — all 6 tests pass
- [x] Python `tomllib.load()` confirms clean parse with correct value: `$.places[0]."place name"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)