### PR TITLE
fix(ci): evaluate all needs deps in publish-release condition

### DIFF
--- a/.github/workflows/release-papillon.yml
+++ b/.github/workflows/release-papillon.yml
@@ -655,7 +655,11 @@ jobs:
     if: |
       always() &&
       needs.create-release.result == 'success' &&
-      needs.build-desktop.result == 'success'
+      needs.build-desktop.result == 'success' &&
+      (needs.build-mobile-ios.result == 'success' || needs.build-mobile-ios.result == 'skipped') &&
+      (needs.build-mobile-android.result == 'success' || needs.build-mobile-android.result == 'skipped') &&
+      (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
+      (needs.publish-docker.result == 'success' || needs.publish-docker.result == 'skipped')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Root Cause

The **Release Papillon** workflow has failed on every single run since creation — zero jobs, instant failure with "This run likely failed because of a workflow file issue."

The `publish-release` job listed **6 dependencies** in `needs` but only evaluated **2** in its `if` condition while using `always()`:

```yaml
# BROKEN — GitHub's DAG validator rejects this
publish-release:
  needs: [create-release, build-desktop, build-mobile-ios, build-mobile-android, publish-npm, publish-docker]
  if: |
    always() &&
    needs.create-release.result == 'success' &&
    needs.build-desktop.result == 'success'
    # ← 4 deps missing from evaluation!
```

GitHub Actions requires all `needs` dependencies to be evaluable in `if` expressions when `always()` is present. The 4 unevaluated deps caused the workflow to be rejected at parse time.

## Fix

Evaluate all 6 deps. `create-release` + `build-desktop` must succeed; the optional jobs (mobile, npm, docker) are allowed to be `skipped` (they skip when version tag already exists):

```yaml
if: |
  always() &&
  needs.create-release.result == 'success' &&
  needs.build-desktop.result == 'success' &&
  (needs.build-mobile-ios.result == 'success' || needs.build-mobile-ios.result == 'skipped') &&
  (needs.build-mobile-android.result == 'success' || needs.build-mobile-android.result == 'skipped') &&
  (needs.publish-npm.result == 'success' || needs.publish-npm.result == 'skipped') &&
  (needs.publish-docker.result == 'success' || needs.publish-docker.result == 'skipped')
```

## Test plan
- [ ] Release workflow no longer fails with "workflow file issue"
- [ ] When version tag already exists: all jobs skip cleanly, no failure
- [ ] Schema validation passes: `check-jsonschema --builtin-schema vendor.github-workflows` ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)