### PR TITLE
docs(site): Zero Trust Internet reframe + Papillon tech showcase

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -3,15 +3,15 @@
 <head>
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-  <title>Baur Software — Zero Trust AI. Open Source Forever.</title>
-  <meta name="description" content="Baur Software builds open-source tools for AI you control. PAP protocol, Papillon desktop app, and Chrysalis agent registry." />
-  <meta property="og:title" content="Baur Software — Zero Trust AI. Open Source Forever." />
-  <meta property="og:description" content="Open-source tools for AI you control. Protocol spec, desktop app, and federated registry." />
+  <title>Baur Software — Zero Trust Internet. Open Source Forever.</title>
+  <meta name="description" content="Baur Software builds open-source tools for programmable delegation. PAP protocol, Papillon desktop app, and Chrysalis agent registry." />
+  <meta property="og:title" content="Baur Software — Zero Trust Internet. Open Source Forever." />
+  <meta property="og:description" content="Open-source tools for programmable delegation. Protocol spec, desktop app, and federated registry." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
-  <meta name="twitter:title" content="Baur Software — Zero Trust AI" />
-  <meta name="twitter:description" content="Open-source tools for AI you control." />
+  <meta name="twitter:title" content="Baur Software — Zero Trust Internet" />
+  <meta name="twitter:description" content="Open-source tools for programmable delegation." />
   <meta name="twitter:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -238,6 +238,10 @@
       background: rgba(46,196,160,.1); color: var(--teal);
       border: 1px solid rgba(46,196,160,.2);
     }
+    .product-tag-dev {
+      background: rgba(240,160,48,.1); color: var(--amber);
+      border: 1px solid rgba(240,160,48,.2);
+    }
     .product-desc {
       font-size: .9rem; color: var(--muted); line-height: 1.65; flex: 1;
     }
@@ -308,12 +312,12 @@
   <div class="container">
     <img src="assets/images/papillon-icon.png" alt="Baur Software" class="hero-logo reveal" />
     <h1 class="reveal reveal-delay-1">
-      Zero Trust AI.<br />
+      Zero Trust Internet.<br />
       <span class="gradient-text">Open Source Forever.</span>
     </h1>
     <p class="reveal reveal-delay-2">
-      AI should answer to you, not to a platform. We build the protocol, the canvas, and the registry
-      that give you cryptographic control over every agent interaction.
+      Any program on the Internet should answer to you. We build the protocol, the canvas, and the registry
+      that give you cryptographic control over every service interaction.
     </p>
     <div class="hero-cta reveal reveal-delay-3">
       <a href="pap/" class="btn btn-primary">Read the Protocol</a>
@@ -344,12 +348,13 @@
       <a href="papillon/" class="product-card product-card-papillon reveal reveal-delay-1">
         <div class="product-icon product-icon-papillon" aria-hidden="true"><img src="assets/images/papillon-icon.png" alt="" width="32" height="32" /></div>
         <span class="product-tag product-tag-app">Desktop App</span>
+        <span class="product-tag product-tag-dev">In Development</span>
         <div class="product-name">Papillon</div>
         <p class="product-desc">
           One canvas, many agents, your rules. Specialized agents work together on your tasks &#8212;
           each seeing only what it needs. Preview plans before execution, verify results after.
         </p>
-        <span class="product-link">Try Papillon &#8594;</span>
+        <span class="product-link">See Papillon &#8594;</span>
       </a>
 
       <a href="chrysalis.html" class="product-card product-card-chrysalis reveal reveal-delay-2">

--- a/docs/pap/index.html
+++ b/docs/pap/index.html
@@ -4,14 +4,14 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PAP — Principal Agent Protocol</title>
-  <meta name="description" content="AI should answer to you, not to a platform. PAP is a zero-trust protocol that gives you cryptographic control over what your AI can do." />
+  <meta name="description" content="Any program on the Internet should answer to you. PAP is a zero-trust protocol for programmable delegation — cryptographic control over every service interaction." />
   <meta property="og:title" content="PAP — Principal Agent Protocol" />
-  <meta property="og:description" content="AI should answer to you, not to a platform. Zero-trust agent negotiation — no new cryptography, no token economy, no central registry." />
+  <meta property="og:description" content="Any program on the Internet should answer to you. Zero-trust agent negotiation — no new cryptography, no token economy, no central registry." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://baur-software.github.io/pap/assets/images/og-card-pap.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="PAP — Principal Agent Protocol" />
-  <meta name="twitter:description" content="AI should answer to you, not to a platform. A zero-trust protocol for agent negotiation." />
+  <meta name="twitter:description" content="Any program on the Internet should answer to you. A zero-trust protocol for programmable delegation." />
   <meta name="twitter:image" content="https://baur-software.github.io/pap/assets/images/og-card-pap.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/docs/papillon/index.html
+++ b/docs/papillon/index.html
@@ -4,9 +4,9 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Papillon — One canvas. Many agents. Your rules.</title>
-  <meta name="description" content="A canvas where specialized AI agents work together on your tasks. Preview their plans, approve their actions, verify their results. No agent ever sees your full context." />
+  <meta name="description" content="A canvas where specialized agents work together on your tasks. Preview their plans, approve their actions, verify their results. No agent ever sees your full context." />
   <meta property="og:title" content="Papillon — One canvas. Many agents. Your rules." />
-  <meta property="og:description" content="Specialized AI agents work together on your tasks. Preview plans, approve actions, verify results. No agent sees your full context." />
+  <meta property="og:description" content="Specialized agents work together on your tasks. Preview plans, approve actions, verify results. No agent sees your full context." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
@@ -545,6 +545,7 @@
 <!-- ─── Hero ─────────────────────────────────────────────────────── -->
 <section class="hero" id="hero">
   <div>
+    <div style="display:inline-flex;align-items:center;gap:6px;padding:4px 14px;border-radius:99px;background:rgba(245,158,11,.1);border:1px solid rgba(245,158,11,.25);color:#f59e0b;font-size:.75rem;font-weight:600;letter-spacing:.05em;text-transform:uppercase;margin-bottom:20px;">In Development</div>
     <h1>See what they'll do<br><span>before they do it.</span></h1>
     <p class="subtitle">Multiple agents work your task. Each sees only what it needs.<br>Preview the plan, approve the action, expand the receipt.</p>
     <div class="hero-ctas">
@@ -558,8 +559,8 @@
 <section class="section" id="problem">
   <div class="container reveal">
     <span class="section-label">The problem</span>
-    <h2>AI assistants see everything.<br>You see nothing.</h2>
-    <p class="lead">Today's AI tools hand your entire context to every agent in the chain. You trade privacy for convenience.</p>
+    <h2>Every service sees everything.<br>You see nothing.</h2>
+    <p class="lead">Today's tools hand your entire context to every service in the chain. You trade privacy for convenience.</p>
     <div class="problem-grid">
       <div class="problem-card">
         <div class="problem-icon">&#x1F441;</div>
@@ -584,7 +585,7 @@
 <section class="section" id="shift">
   <div class="container reveal">
     <span class="section-label">The shift</span>
-    <h2>The canvas inverts how AI works.</h2>
+    <h2>The canvas inverts how delegation works.</h2>
     <p class="lead">You describe what you want. Agents come to you with only what they need. The output is the interface.</p>
     <div class="shift-steps">
       <div class="shift-step">

--- a/docs/papillon/index.html
+++ b/docs/papillon/index.html
@@ -517,6 +517,44 @@
       opacity: 1;
       transform: translateY(0);
     }
+
+    /* ─── Tech Section ───────────────────────────────────────────── */
+    .tech-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+      gap: 20px;
+      margin-top: 48px;
+    }
+    .tech-card {
+      padding: 28px 24px;
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      display: flex; flex-direction: column; gap: 12px;
+      transition: border-color .2s;
+    }
+    .tech-card:hover { border-color: rgba(139,92,246,.25); }
+    .tech-badge {
+      display: inline-flex; align-items: center;
+      padding: 3px 10px; border-radius: 99px;
+      font-size: .7rem; font-weight: 600; letter-spacing: .05em;
+      text-transform: uppercase; width: fit-content;
+    }
+    .tech-badge-emerald { background: rgba(16,185,129,.1);  color: var(--emerald); border: 1px solid rgba(16,185,129,.2); }
+    .tech-badge-violet  { background: rgba(139,92,246,.1);  color: var(--violet);  border: 1px solid rgba(139,92,246,.2); }
+    .tech-badge-indigo  { background: rgba(99,102,241,.1);  color: var(--indigo);  border: 1px solid rgba(99,102,241,.2); }
+    .tech-badge-amber   { background: rgba(245,158,11,.1);  color: var(--amber);   border: 1px solid rgba(245,158,11,.2); }
+    .tech-badge-teal    { background: rgba(20,184,166,.08); color: #5ee7d0;        border: 1px solid rgba(20,184,166,.15); }
+    .tech-icon { font-size: 1.5rem; line-height: 1; }
+    .tech-title { font-size: 1.05rem; font-weight: 700; letter-spacing: -.01em; }
+    .tech-desc { color: var(--muted); font-size: .9rem; line-height: 1.65; flex: 1; }
+    .tech-facts { display: flex; flex-wrap: wrap; gap: 6px; margin-top: 4px; }
+    .tech-fact {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: .7rem; color: var(--faint);
+      padding: 3px 8px; border-radius: 5px;
+      background: var(--surface2); border: 1px solid var(--border);
+    }
   </style>
 </head>
 <body>
@@ -807,6 +845,78 @@
         <div class="demo-dot" onclick="demoGoTo(4)"></div>
         <div class="demo-dot" onclick="demoGoTo(5)"></div>
       </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── Technology ──────────────────────────────────────────────── -->
+<section class="section" id="technology">
+  <div class="container reveal">
+    <span class="section-label">The Technology</span>
+    <h2>A canvas built for the age of intent-driven Internet.</h2>
+    <p class="lead">Five guarantees that hold whether your agents use AI or not.</p>
+    <div class="tech-grid">
+
+      <div class="tech-card">
+        <span class="tech-badge tech-badge-emerald">Renderer</span>
+        <div class="tech-icon">&#x1F9E9;</div>
+        <div class="tech-title">Type-Safe Renderer</div>
+        <p class="tech-desc">Agents return Schema.org JSON-LD. Papillon dispatches to a two-tier renderer &mdash; agent-scoped first, then type-global, then generic fallback. 20+ registered types produce rich views: flight cards, hotel blocks, search results, answer text. All values rendered as text only. Never innerHTML.</p>
+        <div class="tech-facts">
+          <span class="tech-fact">FlightReservation &rarr; route card</span>
+          <span class="tech-fact">SearchResultsPage &rarr; result list</span>
+          <span class="tech-fact">Answer &rarr; on-device text</span>
+        </div>
+      </div>
+
+      <div class="tech-card">
+        <span class="tech-badge tech-badge-violet">Memory</span>
+        <div class="tech-icon">&#x1F9E0;</div>
+        <div class="tech-title">Long Horizon Memex</div>
+        <p class="tech-desc">Every interaction is stored as a receipt-anchored episode &mdash; outcome, scope exercised, disclosure refs, duration. Never raw values. After 5+ episodes, Papillon scores each agent: 35% success rate (EMA &alpha;=0.2) + 35% quality + 20% preference + 10% keyword match. The canvas improves with use.</p>
+        <div class="tech-facts">
+          <span class="tech-fact">EMA &alpha;=0.2 success rate</span>
+          <span class="tech-fact">minimal disclosure set</span>
+          <span class="tech-fact">SQLite, local only</span>
+        </div>
+      </div>
+
+      <div class="tech-card">
+        <span class="tech-badge tech-badge-indigo">Protocol</span>
+        <div class="tech-icon">&#x1F9ED;</div>
+        <div class="tech-title">Intent-First, Not Query-First</div>
+        <p class="tech-desc">The pap:// scheme is a contract. Every protocol link requires your explicit confirmation before dispatch &mdash; no background requests, no silent handshakes. You describe what you want. The canvas resolves which agents can do it. Your intent shapes the Internet, not the other way around.</p>
+        <div class="tech-facts">
+          <span class="tech-fact">pap://</span>
+          <span class="tech-fact">pap+https://</span>
+          <span class="tech-fact">pap+wss://</span>
+        </div>
+      </div>
+
+      <div class="tech-card">
+        <span class="tech-badge tech-badge-amber">Workflow</span>
+        <div class="tech-icon">&#x1F4CB;</div>
+        <div class="tech-title">Dry Runs &amp; Approval Gates</div>
+        <p class="tech-desc">Before any agent executes, ghost blocks preview the full plan &mdash; which agent, what it will see, what it will return. The canvas enters AwaitingApproval state with a skeleton preview of the output. No mandate is created, no data is disclosed, until you press Approve.</p>
+        <div class="tech-facts">
+          <span class="tech-fact">Ghost &rarr; AwaitingApproval</span>
+          <span class="tech-fact">skeleton output preview</span>
+          <span class="tech-fact">explicit mandate creation</span>
+        </div>
+      </div>
+
+      <div class="tech-card">
+        <span class="tech-badge tech-badge-teal">Canvas</span>
+        <div class="tech-icon">&#x1F5BC;&#xFE0F;</div>
+        <div class="tech-title">The Canvas</div>
+        <p class="tech-desc">Two layers: the Surface shows synthesized outcomes &mdash; readable answers to your actual question, composed on-device. The Provenance layer is always one click away &mdash; each agent block, mandate scope, timing, and co-signed receipt. One canvas, many agents, your rules.</p>
+        <div class="tech-facts">
+          <span class="tech-fact">on-device synthesis</span>
+          <span class="tech-fact">provenance on demand</span>
+          <span class="tech-fact">Candle / local LLM</span>
+        </div>
+      </div>
+
     </div>
   </div>
 </section>

--- a/docs/pitch-deck.html
+++ b/docs/pitch-deck.html
@@ -628,6 +628,11 @@
         --text:    #16141f;
       }
 
+      *, *::before, *::after {
+        -webkit-print-color-adjust: exact !important;
+        print-color-adjust: exact !important;
+      }
+
       html, body {
         overflow: visible;
         width: 100%;


### PR DESCRIPTION
## Summary

- Reframes site messaging from \"Zero Trust AI\" to \"Zero Trust Internet\" — PAP is a trust and delegation layer for any program on the Internet, not AI-specific
- Updates hero, subtitle, and all meta/OG/Twitter tags across \`docs/index.html\`, \`docs/pap/index.html\`, and \`docs/papillon/index.html\`
- Adds amber \"In Development\" badge to the Papillon product card (main page) and hero (Papillon page)
- Adds \"The Technology\" five-card showcase section to the Papillon page surfacing real implementation detail: Type-Safe Renderer, Long Horizon Memex (EMA α=0.2 scoring), Intent-First pap:// protocol, Dry Runs & Approval Gates (Ghost → AwaitingApproval state machine), and The Canvas two-layer model
- Also includes \`feat(pitch-deck): add print CSS for full-slide PDF export\` with \`print-color-adjust\` and light-mode palette

## Files changed

- \`docs/index.html\` — hero, meta, Papillon card badges + CTA
- \`docs/pap/index.html\` — meta tags
- \`docs/papillon/index.html\` — hero badge, problem/shift copy, full tech section
- \`docs/pitch-deck.html\` — print CSS (conflict-resolved against main)

## Test plan

- [ ] All CI checks pass (docs-only change — no Rust code modified)
- [ ] GitHub Pages deploy fires automatically after merge to main via \`pages.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)