### PR TITLE
fix(ci): replace bare secrets.* with env var in release-papillon if condition

### DIFF
--- a/.github/workflows/release-papillon.yml
+++ b/.github/workflows/release-papillon.yml
@@ -121,6 +121,7 @@ jobs:
     env:
       HAS_APPLE_SIGNING: ${{ secrets.APPLE_CERTIFICATE != '' }}
       HAS_WINDOWS_SIGNING: ${{ secrets.WINDOWS_CERTIFICATE != '' }}
+      HAS_STORE_APP_ID: ${{ secrets.MICROSOFT_STORE_APP_ID != '' }}
     steps:
       - uses: actions/checkout@v4
 
@@ -201,7 +202,7 @@ jobs:
         if: |
           matrix.platform == 'windows-latest' &&
           env.HAS_WINDOWS_SIGNING == 'true' &&
-          secrets.MICROSOFT_STORE_APP_ID != ''
+          env.HAS_STORE_APP_ID == 'true'
         shell: pwsh
         env:
           AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}


### PR DESCRIPTION
## Summary

- Fixes `release-papillon.yml` failing at **parse time** on every push to main since #252
- Root cause: `secrets.MICROSOFT_STORE_APP_ID != ''` was used directly in an `if:` expression — GitHub Actions forbids `secrets.*` context outside `${{ }}` wrappers in conditions, causing 0 jobs to be created and an immediate workflow failure
- Fix: expose the boolean as `HAS_STORE_APP_ID: ${{ secrets.MICROSOFT_STORE_APP_ID != '' }}` in the job `env` block, then reference `env.HAS_STORE_APP_ID == 'true'` — identical to the existing pattern for `HAS_APPLE_SIGNING`, `HAS_WINDOWS_SIGNING`, and `HAS_ASC_API_KEY` in the same file

## Verification

After merge, `release-papillon.yml` will run `check-version`, find tag `papillon-v0.6.0` already exists, set `should_release=false`, skip all downstream jobs cleanly, and conclude as **success** instead of the current parse-time failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)