### PR TITLE
fix(dx): add local WASM build check to catch frontend compilation errors before CI

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,0 +1,44 @@
+#!/bin/bash
+# Pre-push hook: run WASM compilation check when frontend or its deps change.
+# Mirrors the wasm32-unknown-unknown step in CI (web-build.yml / ci.yml smoke-test).
+#
+# The frontend lives in its own Cargo workspace (excluded from --workspace flags),
+# so cargo check/test --workspace silently skips it. This hook fills that gap.
+
+set -e
+
+# Directories whose changes should trigger a WASM check
+FRONTEND_PATTERNS=(
+    "apps/papillon/frontend/"
+    "crates/papillon-shared/"
+    "crates/pap-did/"
+    "crates/pap-proto/"
+    "crates/pap-core/"
+)
+
+# git passes push info on stdin: <local-ref> <local-sha> <remote-ref> <remote-sha>
+CHANGED=""
+while read -r local_ref local_sha remote_ref remote_sha; do
+    if [ "$remote_sha" = "0000000000000000000000000000000000000000" ]; then
+        # New branch — diff against immediate parent commit
+        CHANGED=$(git diff --name-only HEAD~1 HEAD 2>/dev/null || true)
+    else
+        CHANGED=$(git diff --name-only "$remote_sha" "$local_sha" 2>/dev/null || true)
+    fi
+done
+
+NEEDS_WASM_CHECK=0
+for pattern in "${FRONTEND_PATTERNS[@]}"; do
+    if echo "$CHANGED" | grep -q "$pattern"; then
+        NEEDS_WASM_CHECK=1
+        break
+    fi
+done
+
+if [ "$NEEDS_WASM_CHECK" -eq 1 ]; then
+    echo "Frontend or WASM-dep changed — running just check-wasm..."
+    just check-wasm
+    echo "WASM check passed."
+fi
+
+exit 0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -310,6 +310,19 @@ cargo clippy --workspace --all-targets -- -D warnings
 cargo test --workspace
 ```
 
+If you modified anything under `apps/papillon/frontend/` **or** any crate it depends on
+(`crates/papillon-shared`, `crates/pap-did`, `crates/pap-proto`, `crates/pap-core`), also run:
+
+```bash
+just check-wasm
+```
+
+The frontend lives in its own Cargo workspace and is excluded from `--workspace` flags, so
+`cargo check/test --workspace` silently skips it. `just check-wasm` runs
+`cargo check --target wasm32-unknown-unknown` against the frontend manifest directly, catching
+`js-sys`/`web-sys` API errors and missing struct fields in seconds rather than waiting for
+`trunk build --release` to fail in CI.
+
 ## Code Style
 
 - Rust stable toolchain

--- a/justfile
+++ b/justfile
@@ -112,6 +112,11 @@ lint:
 
 alias check := lint
 
+# Check frontend WASM target compiles (catches js-sys / web-sys API errors before CI)
+check-wasm:
+    cargo check --target wasm32-unknown-unknown \
+        --manifest-path apps/papillon/frontend/Cargo.toml
+
 # Auto-format all crates
 fmt:
     cargo fmt --all


### PR DESCRIPTION
## Problem

\`cargo check/test --workspace\` silently skips \`apps/papillon/frontend\` because the frontend
lives in its own Cargo workspace (explicitly excluded in the root \`Cargo.toml\`). WASM-only
errors — wrong \`js_sys\` API, missing struct fields — only surface when \`trunk build --release\`
runs in CI, costing ~20 min per cycle (see PR #277).

## Changes

- **\`justfile\`**: new \`check-wasm\` recipe — \`cargo check --target wasm32-unknown-unknown --manifest-path apps/papillon/frontend/Cargo.toml\`
- **\`CONTRIBUTING.md\`**: documents \`just check-wasm\` under *Before opening a PR*, explains why \`--workspace\` skips the frontend
- **\`.githooks/pre-push\`**: auto-runs \`check-wasm\` when a push touches \`apps/papillon/frontend/\` or its five local crate deps; reuses existing \`.githooks/\` pattern, no new tooling

## Testing

\`just check-wasm\` completes in seconds on a warm cache. To verify it catches the original bug,
temporarily revert one \`Date::new_with_str(...)\` call — the recipe fails immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)