### PR TITLE
fix: model settings apply immediately without restart

### DIFF
--- a/apps/papillon/src/commands/orchestrator.rs
+++ b/apps/papillon/src/commands/orchestrator.rs
@@ -55,6 +55,17 @@ pub async fn configure_orchestrator(
         *current = config.clone();
     }
 
+    // Update the shared LLM provider so all DynamicAgentHandlers pick up the
+    // new settings immediately — without this they would keep using the
+    // provider snapshot from startup (the original bug).
+    {
+        let mut provider = state
+            .shared_llm_provider
+            .write()
+            .map_err(|e| PapillonError::from(e.to_string()))?;
+        *provider = config.inference_substrate.clone();
+    }
+
     // Persist the new config so it survives restarts.
     if let Ok(json) = serde_json::to_string(&config) {
         let _ = state.db.set_setting("orchestrator_config", &json);

--- a/apps/papillon/src/state.rs
+++ b/apps/papillon/src/state.rs
@@ -10,7 +10,7 @@ use pap_did::PrincipalKeypair;
 use pap_federation::FederatedRegistry;
 use pap_transport::{AgentHandler, EndpointRegistry};
 use pap_webauthn::{PrincipalSigner, SoftwareSigner};
-use papillon_shared::{OrchestratorConfig, SuccessorDesignation};
+use papillon_shared::{LlmProvider, OrchestratorConfig, SuccessorDesignation};
 use zeroize::Zeroizing;
 
 use crate::agents::on_device_ai::OnDeviceAiExecutor;
@@ -47,6 +47,9 @@ pub struct AppState {
     pub local_registry: Arc<Mutex<FederatedRegistry>>,
     pub bookmarks: RwLock<Vec<String>>,
     pub orchestrator_config: RwLock<OrchestratorConfig>,
+    /// Shared LLM provider — written by `configure_orchestrator` so all
+    /// `DynamicAgentHandler`s pick up new settings without a restart.
+    pub shared_llm_provider: Arc<RwLock<LlmProvider>>,
     /// On-device Candle model for the BuiltIn LLM provider.
     pub model_manager: Arc<tokio::sync::Mutex<ModelManager>>,
     /// Agent keypairs retained for both sides of the PAP handshake.
@@ -120,6 +123,7 @@ impl AppState {
             local_registry: self.local_registry.clone(),
             bookmarks: RwLock::new(self.bookmarks.read().unwrap().clone()),
             orchestrator_config: RwLock::new(self.orchestrator_config.read().unwrap().clone()),
+            shared_llm_provider: self.shared_llm_provider.clone(),
             model_manager: self.model_manager.clone(),
             agent_keypairs: RwLock::new(HashMap::new()), // Will be populated on demand
             db: self.db.clone(),
@@ -203,13 +207,16 @@ impl AppState {
             .and_then(|json| serde_json::from_str::<OrchestratorConfig>(&json).ok())
             .unwrap_or_default();
 
+        // ── Shared LLM provider — writable so configure_orchestrator can update it ─
+        let shared_llm_provider: Arc<RwLock<LlmProvider>> = Arc::new(RwLock::new(
+            saved_orchestrator_config.inference_substrate.clone(),
+        ));
+
         // ── Register all DB agents (catalog + user_created + generated) ───────────
         {
-            let orchestrator_config = saved_orchestrator_config.clone();
-            let llm_provider = Arc::new(orchestrator_config.inference_substrate.clone());
             let db_agents = db.load_all_agents().unwrap_or_default();
             for def in db_agents {
-                if let Err(e) = agent_set.register_dynamic(&def, llm_provider.clone()) {
+                if let Err(e) = agent_set.register_dynamic(&def, shared_llm_provider.clone()) {
                     eprintln!("Failed to register agent '{}': {e}", def.name);
                 }
             }
@@ -390,6 +397,7 @@ impl AppState {
             local_registry,
             bookmarks: RwLock::new(bookmarks),
             orchestrator_config: RwLock::new(saved_orchestrator_config),
+            shared_llm_provider,
             model_manager,
             agent_keypairs: RwLock::new(keypairs),
             db,

--- a/crates/pap-agents/src/dynamic_handler.rs
+++ b/crates/pap-agents/src/dynamic_handler.rs
@@ -8,7 +8,7 @@
 //! at save time by the Tauri command layer). RFC 1918, loopback, link-local,
 //! and IP-literal addresses are rejected before any network call.
 
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 use std::time::Duration;
 
 use pap_core::receipt::TransactionReceipt;
@@ -29,12 +29,12 @@ struct DynamicSession {
 
 pub struct DynamicAgentHandler {
     def: DynamicAgentDef,
-    llm_provider: Arc<LlmProvider>,
+    llm_provider: Arc<RwLock<LlmProvider>>,
     sessions: SessionStore<DynamicSession>,
 }
 
 impl DynamicAgentHandler {
-    pub fn new(def: DynamicAgentDef, llm_provider: Arc<LlmProvider>) -> Self {
+    pub fn new(def: DynamicAgentDef, llm_provider: Arc<RwLock<LlmProvider>>) -> Self {
         Self {
             def,
             llm_provider,
@@ -42,11 +42,12 @@ impl DynamicAgentHandler {
         }
     }
 
-    /// Build an [`LlmClient`] from the stored provider for a single
-    /// LLM call.  Cloning `Arc<LlmProvider>` is cheap; the client itself
-    /// is short-lived (used for one inference, then dropped).
+    /// Build an [`LlmClient`] from the current provider for a single
+    /// LLM call.  Reading through the `RwLock` ensures the latest
+    /// settings (changed via `configure_orchestrator`) are always used.
     fn make_llm_client(&self) -> Box<dyn LlmClient> {
-        (*self.llm_provider).clone().into_client()
+        let provider = self.llm_provider.read().unwrap_or_else(|e| e.into_inner());
+        (*provider).clone().into_client()
     }
 }
 
@@ -391,7 +392,7 @@ mod tests {
     #[test]
     fn ssrf_blocked_at_execution() {
         let def = make_def_with_endpoint("http://10.0.0.1/data");
-        let handler = DynamicAgentHandler::new(def, Arc::new(LlmProvider::None));
+        let handler = DynamicAgentHandler::new(def, Arc::new(RwLock::new(LlmProvider::None)));
         let token = make_token("schema:SearchAction");
         let (sid, _) = handler.handle_token(token).unwrap();
         handler.handle_did_exchange(&sid, "did:key:peer").unwrap();
@@ -465,7 +466,7 @@ mod tests {
     #[test]
     fn llm_none_provider_returns_error() {
         let def = make_def_llm_only();
-        let handler = DynamicAgentHandler::new(def, Arc::new(LlmProvider::None));
+        let handler = DynamicAgentHandler::new(def, Arc::new(RwLock::new(LlmProvider::None)));
         let token = make_token("schema:SearchAction");
         let (sid, _) = handler.handle_token(token).unwrap();
         handler.handle_did_exchange(&sid, "did:key:peer").unwrap();
@@ -478,7 +479,7 @@ mod tests {
     #[test]
     fn wrong_action_rejected() {
         let def = make_def_llm_only();
-        let handler = DynamicAgentHandler::new(def, Arc::new(LlmProvider::None));
+        let handler = DynamicAgentHandler::new(def, Arc::new(RwLock::new(LlmProvider::None)));
         assert!(handler
             .handle_token(make_token("schema:PayAction"))
             .is_err());
@@ -487,7 +488,7 @@ mod tests {
     #[test]
     fn unknown_session_did_exchange_errors() {
         let def = make_def_llm_only();
-        let handler = DynamicAgentHandler::new(def, Arc::new(LlmProvider::None));
+        let handler = DynamicAgentHandler::new(def, Arc::new(RwLock::new(LlmProvider::None)));
         assert!(handler
             .handle_did_exchange("no-such-session", "did:key:x")
             .is_err());

--- a/crates/pap-agents/src/registry.rs
+++ b/crates/pap-agents/src/registry.rs
@@ -5,7 +5,7 @@
 //! No more 3-file string matching.
 
 use std::collections::HashMap;
-use std::sync::Arc;
+use std::sync::{Arc, RwLock};
 
 use pap_did::PrincipalKeypair;
 use pap_federation::FederatedRegistry;
@@ -168,7 +168,7 @@ impl AgentSet {
     pub fn register_dynamic(
         &mut self,
         def: &DynamicAgentDef,
-        llm_provider: Arc<LlmProvider>,
+        llm_provider: Arc<RwLock<LlmProvider>>,
     ) -> Result<String, RegistrationError> {
         let seed = def
             .operator_key_seed
@@ -359,7 +359,7 @@ mod tests {
         let mut set = build_agents(vec![]);
         let def = make_dynamic_def(true);
         let did = set
-            .register_dynamic(&def, Arc::new(LlmProvider::None))
+            .register_dynamic(&def, Arc::new(RwLock::new(LlmProvider::None)))
             .unwrap();
         assert!(did.starts_with("did:key:z"), "got: {did}");
         let results = set.registry.query_local("schema:SearchAction");
@@ -372,7 +372,7 @@ mod tests {
     fn register_dynamic_missing_seed_errors() {
         let mut set = build_agents(vec![]);
         let def = make_dynamic_def(false);
-        let result = set.register_dynamic(&def, Arc::new(LlmProvider::None));
+        let result = set.register_dynamic(&def, Arc::new(RwLock::new(LlmProvider::None)));
         assert!(matches!(result, Err(RegistrationError::MissingKeySeed)));
     }
 
@@ -380,7 +380,7 @@ mod tests {
     fn register_dynamic_signed_advertisement() {
         let mut set = build_agents(vec![]);
         let def = make_dynamic_def(true);
-        set.register_dynamic(&def, Arc::new(LlmProvider::None))
+        set.register_dynamic(&def, Arc::new(RwLock::new(LlmProvider::None)))
             .unwrap();
         let ads = set.registry.all_advertisements();
         let ad = ads.iter().find(|a| a.name == "Test Dynamic Agent").unwrap();
@@ -411,13 +411,13 @@ mod tests {
         def.name = "Stable DID Agent A".into();
         let mut set = build_agents(vec![]);
         let did1 = set
-            .register_dynamic(&def, Arc::new(LlmProvider::None))
+            .register_dynamic(&def, Arc::new(RwLock::new(LlmProvider::None)))
             .unwrap();
 
         let mut set2 = build_agents(vec![]);
         def.name = "Stable DID Agent B".into();
         let did2 = set2
-            .register_dynamic(&def, Arc::new(LlmProvider::None))
+            .register_dynamic(&def, Arc::new(RwLock::new(LlmProvider::None)))
             .unwrap();
 
         assert_eq!(did1, did2, "same seed must produce same DID");


### PR DESCRIPTION
## Summary

- **Root cause**: `DynamicAgentHandler` stored `Arc<LlmProvider>` as a startup snapshot, so `configure_orchestrator` saves (e.g. switching from BuiltIn to HuggingFace) were never seen by existing handlers — retries and new queries kept using the stale provider from app launch
- **Fix**: Replace `Arc<LlmProvider>` with `Arc<RwLock<LlmProvider>>` shared across all handlers; `configure_orchestrator` now writes through the lock after persisting to SQLite, so any subsequent `make_llm_client()` call uses the current settings immediately
- **Scope**: 4 files — `dynamic_handler.rs`, `registry.rs`, `state.rs`, `orchestrator.rs`; all 103 pap-agents tests pass

## Test plan

- [ ] Change inference substrate in Settings → General from BuiltIn to HuggingFace (or any other provider)
- [ ] Click Save — confirm "Saved!" appears
- [ ] Submit a new query or click RETRY on a failed block
- [ ] Confirm the new provider is used (no "model file not found" error for the old BuiltIn model)
- [ ] Verify `cargo test --package pap-agents` passes (103 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)