### PR TITLE
feat: web browsing on canvas via pap://domain.com

### DIFF
--- a/apps/papillon/frontend/src/components/block_renderer/mod.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/mod.rs
@@ -78,6 +78,8 @@ pub fn create_default_registry() -> Arc<RendererRegistry> {
     // Vocabulary
     registry.register(Arc::new(templates::DefinedTermTemplate));
     registry.register(Arc::new(templates::QuotationTemplate));
+    // Web
+    registry.register(Arc::new(templates::WebPageTemplate));
     registry
 }
 

--- a/apps/papillon/frontend/src/components/block_renderer/templates.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/templates.rs
@@ -862,3 +862,111 @@ impl BlockRenderer for QuotationTemplate {
         vec!["Quotation"]
     }
 }
+
+// ── Web ───────────────────────────────────────────────────────────────────────
+
+/// WebPage template — browser-tab-style block for web browsing on the canvas.
+///
+/// Rendered when the Web Page Reader agent returns `schema:WebPage` JSON-LD,
+/// which happens whenever the user browses via `pap://domain.com`. The block
+/// shows a URL bar, page title, description, publisher, and body text extract.
+///
+/// The URL bar renders the page URL as a `pap://` link so that clicking it
+/// opens a new browse block via `submit_agent_link()` (LinkOrigin::Agent).
+pub struct WebPageTemplate;
+
+impl BlockRenderer for WebPageTemplate {
+    fn render(&self, content: &Value) -> AnyView {
+        let title = text_field(content, "name");
+        let url = text_field(content, "url");
+        let description = text_field(content, "description");
+        let body_text = text_field(content, "text");
+
+        // Publisher: either a bare string or an object with "name".
+        let publisher = content
+            .get("publisher")
+            .and_then(|p| p.get("name").or(Some(p)))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Author: either a bare string or an object with "name".
+        let author = content
+            .get("author")
+            .and_then(|a| a.get("name").or(Some(a)))
+            .and_then(|v| v.as_str())
+            .unwrap_or("")
+            .to_string();
+
+        // Published date — trim to date part if it includes a time component.
+        let date_raw = text_field(content, "datePublished");
+        let date = if date_raw == "-" {
+            String::new()
+        } else {
+            date_raw
+                .split('T')
+                .next()
+                .unwrap_or(&date_raw)
+                .to_string()
+        };
+
+        // Rewrite the URL to a pap:// link so it routes through submit_agent_link().
+        let pap_url = if url.starts_with("https://") {
+            format!("pap://{}", &url["https://".len()..])
+        } else if url.starts_with("http://") {
+            format!("pap://{}", &url["http://".len()..])
+        } else {
+            url.clone()
+        };
+
+        view! {
+            <div class="typed-webpage">
+                // ── URL bar ───────────────────────────────────────────────────
+                <div class="typed-webpage-bar">
+                    <span class="typed-webpage-favicon" aria-hidden="true">"🌐"</span>
+                    <a class="typed-webpage-url" href=pap_url>{url.clone()}</a>
+                </div>
+                // ── Page body ─────────────────────────────────────────────────
+                <div class="typed-webpage-body">
+                    <h2 class="typed-webpage-title">{title}</h2>
+
+                    // Byline: publisher · author · date
+                    {
+                        let byline_parts: Vec<String> = [
+                            if publisher.is_empty() { None } else { Some(publisher) },
+                            if author.is_empty() { None } else { Some(author) },
+                            if date.is_empty() { None } else { Some(date) },
+                        ]
+                        .into_iter()
+                        .flatten()
+                        .collect();
+
+                        if byline_parts.is_empty() {
+                            view! { <></> }.into_any()
+                        } else {
+                            let byline = byline_parts.join(" \u{00b7} ");
+                            view! { <p class="typed-webpage-byline">{byline}</p> }.into_any()
+                        }
+                    }
+
+                    {if description != "-" && !description.is_empty() {
+                        view! { <p class="typed-webpage-description">{description}</p> }.into_any()
+                    } else {
+                        view! { <></> }.into_any()
+                    }}
+
+                    {if body_text != "-" && !body_text.is_empty() {
+                        view! { <div class="typed-webpage-text">{body_text}</div> }.into_any()
+                    } else {
+                        view! { <></> }.into_any()
+                    }}
+                </div>
+            </div>
+        }
+        .into_any()
+    }
+
+    fn schema_types(&self) -> Vec<&'static str> {
+        vec!["WebPage"]
+    }
+}

--- a/apps/papillon/frontend/src/components/topbar.rs
+++ b/apps/papillon/frontend/src/components/topbar.rs
@@ -124,13 +124,26 @@ fn TopbarPrompt() -> impl IntoView {
     let input_value = RwSignal::new(String::new());
     let selected_idx: RwSignal<Option<usize>> = RwSignal::new(None);
 
-    // Live pap:// completions from the catalog — only when user types "pap://".
+    // Live pap:// completions from the catalog, plus web-browse for domains.
+    //
+    // - Web domain (prefix contains '.') → single "Browse → domain" suggestion.
+    //   Any external domain resolves to HttpsEndpoint and routes to Web Page Reader.
+    // - Catalog name (no dot) → agent name completions from local catalog.
     let pap_suggestions = Memo::new(move |_| {
         let val = input_value.get();
         if !val.starts_with("pap://") {
             return vec![];
         }
         let prefix = val["pap://".len()..].to_lowercase();
+        if prefix.is_empty() {
+            return vec![];
+        }
+        // Web domain: show a single confirm suggestion so the user can see
+        // that pressing Enter will browse the site on the canvas.
+        if prefix.contains('.') {
+            return vec![prefix];
+        }
+        // Catalog agent name match.
         let entries = catalog_state
             .map(|c| c.entries.get())
             .unwrap_or_default();
@@ -164,7 +177,16 @@ fn TopbarPrompt() -> impl IntoView {
             "Enter" => {
                 if let Some(idx) = selected_idx.get_untracked() {
                     if let Some(name) = suggestions.get(idx) {
-                        input_value.set(format!("pap://{name}"));
+                        let full = format!("pap://{name}");
+                        if name.contains('.') {
+                            // Web domain: submit immediately.
+                            canvas_state.submit_prompt(full);
+                            input_value.set(String::new());
+                        } else {
+                            // Catalog agent: fill the address bar so the user
+                            // can review / refine before submitting.
+                            input_value.set(full);
+                        }
                         selected_idx.set(None);
                         return;
                     }
@@ -235,20 +257,38 @@ fn TopbarPrompt() -> impl IntoView {
                 <div class="topbar-suggestions">
                     {move || pap_suggestions.get().into_iter().enumerate().map(|(i, name)| {
                         let name_for_click = name.clone();
+                        let is_web_domain = name.contains('.');
                         view! {
                             <button
                                 class="palette-suggestion palette-suggestion-pap"
                                 class:palette-suggestion--active=move || selected_idx.get() == Some(i)
                                 on:click=move |_| {
-                                    input_value.set(format!("pap://{}", name_for_click));
+                                    let full = format!("pap://{}", name_for_click);
+                                    // For web domains, selecting the suggestion submits immediately
+                                    // since what's typed is already the complete address.
+                                    if name_for_click.contains('.') {
+                                        canvas_state.submit_prompt(full);
+                                        input_value.set(String::new());
+                                    } else {
+                                        input_value.set(full);
+                                    }
                                     selected_idx.set(None);
                                     if let Some(el) = input_ref.get() {
                                         let _ = el.focus();
                                     }
                                 }
                             >
-                                <span class="pap-suggestion-scheme">"pap://"</span>
-                                <span class="pap-suggestion-name">{name}</span>
+                                {if is_web_domain {
+                                    view! {
+                                        <span class="pap-suggestion-scheme">"Browse  "</span>
+                                        <span class="pap-suggestion-name">{format!("pap://{}", name)}</span>
+                                    }.into_any()
+                                } else {
+                                    view! {
+                                        <span class="pap-suggestion-scheme">"pap://"</span>
+                                        <span class="pap-suggestion-name">{name}</span>
+                                    }.into_any()
+                                }}
                             </button>
                         }
                     }).collect::<Vec<_>>()}

--- a/crates/papillon-shared/src/pap_uri.rs
+++ b/crates/papillon-shared/src/pap_uri.rs
@@ -89,8 +89,8 @@ pub fn resolve_pap_uri(
         return Ok(ResolvedUri::Did(uri.to_string()));
     }
 
-    // Step 2: catalog name (no dot in authority, not a registry host)
-    if !is_registry_host(authority) {
+    // Step 2: catalog name (no dot in authority, not a local registry host or web domain)
+    if !is_local_registry(authority) && !is_web_domain(authority) {
         if let Some(did) = catalog.get(authority_lower.as_str()) {
             // Reject path traversal before rewriting.
             // Check both literal ".." and common percent-encoded forms.
@@ -107,15 +107,34 @@ pub fn resolve_pap_uri(
         return Err(PapUriError::NotFound(authority_lower));
     }
 
-    // Step 3: registry hostname / localhost / IPv4
+    // Step 3a: external web domain — zero-trust browse via https.
+    //
+    // Registries are federated and discovered at handshake time, not via the
+    // URI scheme. A bare `pap://domain.com` always means "browse this site".
+    if is_web_domain(authority) {
+        let https_url = format!("https://{}{}", authority, path);
+        return Ok(ResolvedUri::HttpsEndpoint(https_url));
+    }
+
+    // Step 3b: localhost / IPv4 / IPv6 — local federated registry peer
+    // (used in development and LAN deployments).
     Ok(ResolvedUri::Registry(uri.to_string()))
 }
 
-fn is_registry_host(authority: &str) -> bool {
-    authority == "localhost"
-        || authority.starts_with('[')
-        || is_ipv4(authority)
-        || authority.contains('.')
+/// Returns true for local/loopback addresses that identify a registry peer
+/// during development or LAN deployment.
+fn is_local_registry(authority: &str) -> bool {
+    // Strip optional port before matching.
+    let host = authority.split(':').next().unwrap_or(authority);
+    host == "localhost" || authority.starts_with('[') || is_ipv4(host)
+}
+
+/// Returns true for external dotted-domain names — these are browsed as web
+/// pages, not treated as registry peers. Registry federation is announced at
+/// handshake time, not encoded in the URI scheme.
+fn is_web_domain(authority: &str) -> bool {
+    let host = authority.split(':').next().unwrap_or(authority);
+    host.contains('.') && !is_ipv4(host) && !host.starts_with('[')
 }
 
 fn is_ipv4(s: &str) -> bool {
@@ -290,21 +309,71 @@ mod tests {
     }
 
     #[test]
-    fn registry_hostname_passthrough() {
-        let uri = "pap://chrysalis.example.com/agents/arxiv/SearchAction";
-        let r = resolve_pap_uri(uri, &empty(), LinkOrigin::Principal).unwrap();
-        assert_eq!(r, ResolvedUri::Registry(uri.into()));
+    fn external_domain_resolves_to_https_endpoint() {
+        // Registries are federated (announced at handshake), not addressed by
+        // URI scheme. pap://domain.com always means "browse this site".
+        let r = resolve_pap_uri(
+            "pap://chrysalis.example.com/page",
+            &empty(),
+            LinkOrigin::Principal,
+        )
+        .unwrap();
+        assert_eq!(
+            r,
+            ResolvedUri::HttpsEndpoint("https://chrysalis.example.com/page".into())
+        );
     }
 
     #[test]
-    fn localhost_is_registry_host() {
+    fn bare_domain_browse() {
+        let r = resolve_pap_uri("pap://ebay.com", &empty(), LinkOrigin::Principal).unwrap();
+        assert_eq!(r, ResolvedUri::HttpsEndpoint("https://ebay.com".into()));
+    }
+
+    #[test]
+    fn domain_with_path_browse() {
+        let r = resolve_pap_uri(
+            "pap://ebay.com/electronics/laptops",
+            &empty(),
+            LinkOrigin::Principal,
+        )
+        .unwrap();
+        assert_eq!(
+            r,
+            ResolvedUri::HttpsEndpoint("https://ebay.com/electronics/laptops".into())
+        );
+    }
+
+    #[test]
+    fn domain_with_port_browse() {
+        let r = resolve_pap_uri(
+            "pap://example.com:8080/path",
+            &empty(),
+            LinkOrigin::Principal,
+        )
+        .unwrap();
+        assert_eq!(
+            r,
+            ResolvedUri::HttpsEndpoint("https://example.com:8080/path".into())
+        );
+    }
+
+    #[test]
+    fn localhost_is_local_registry() {
         let uri = "pap://localhost/agents/dev/SearchAction";
         let r = resolve_pap_uri(uri, &empty(), LinkOrigin::Principal).unwrap();
         assert_eq!(r, ResolvedUri::Registry(uri.into()));
     }
 
     #[test]
-    fn ipv4_is_registry_host() {
+    fn localhost_with_port_is_local_registry() {
+        let uri = "pap://localhost:8080/agents/dev/SearchAction";
+        let r = resolve_pap_uri(uri, &empty(), LinkOrigin::Principal).unwrap();
+        assert_eq!(r, ResolvedUri::Registry(uri.into()));
+    }
+
+    #[test]
+    fn ipv4_is_local_registry() {
         let uri = "pap://192.168.1.1/agents/local/SearchAction";
         let r = resolve_pap_uri(uri, &empty(), LinkOrigin::Principal).unwrap();
         assert_eq!(r, ResolvedUri::Registry(uri.into()));


### PR DESCRIPTION
## Summary

- **`pap_uri.rs`**: Split `is_registry_host` into `is_local_registry` (localhost/IPv4/IPv6 → `Registry`) and `is_web_domain` (dotted FQDN → `HttpsEndpoint`). `pap://ebay.com` now resolves to `https://ebay.com` instead of misrouting to a registry peer. Registries are federated and announced at handshake time — not addressed via the URI scheme.
- **`templates.rs`**: Add `WebPageTemplate` — renders `schema:WebPage` JSON-LD as a browser-tab-style canvas block with URL bar (pap:// link for in-canvas navigation), title, byline, description, and body text extract.
- **`mod.rs`**: Register `WebPageTemplate` in `create_default_registry()`.
- **`topbar.rs`**: `pap://` suggestion dropdown now shows `Browse  pap://domain.com` for web domains and auto-submits on selection; catalog agent completions unchanged.

## End-to-end flow

```
pap://ebay.com  →  HttpsEndpoint("https://ebay.com")
  →  detect_intent: starts_with "https://"  →  Web Page Reader
  →  GET https://ebay.com  →  schema:WebPage JSON-LD
  →  WebPageTemplate.render()  →  browser-tab block on canvas
  →  links in block  →  pap://ebay.com/...  →  next browse block
```

## Test plan

- [ ] `cargo test -p papillon-shared` — 41 `pap_uri` tests green including `bare_domain_browse`, `domain_with_path_browse`, `domain_with_port_browse`, `localhost_is_local_registry`, `localhost_with_port_is_local_registry`
- [ ] `pap://ebay.com` in address bar → canvas block with title, description, body text
- [ ] `pap://localhost:8080` → still routes to Registry (no regression)
- [ ] `https://ebay.com` typed directly → still works
- [ ] Clicking URL in WebPage block → new browse block

🤖 Generated with [Claude Code](https://claude.com/claude-code)