### PR TITLE
fix: WebPage template CSS + catalog agents in fleet view

### DIFF
--- a/apps/papillon/frontend/src/pages/dashboard.rs
+++ b/apps/papillon/frontend/src/pages/dashboard.rs
@@ -32,6 +32,13 @@ pub fn DashboardPage() -> impl IntoView {
     let active_agents = move || -> Vec<_> {
         agents.get().into_iter().filter(|a| a.source == "compiled").collect()
     };
+    let catalog_agents = move || -> Vec<_> {
+        agents.get().into_iter().filter(|a| a.source == "catalog").collect()
+    };
+    let catalog_count = move || {
+        agents.get().iter().filter(|a| a.source == "catalog").count()
+    };
+    let catalog_open = RwSignal::new(false);
 
     view! {
         <div class="fleet-page">
@@ -80,6 +87,33 @@ pub fn DashboardPage() -> impl IntoView {
                     >
                         <div class="fleet-loading">"Loading agents\u{2026}"</div>
                     </Show>
+
+                    // ── Catalog agents (TOML-defined, collapsible) ──────────
+                    <Show when=move || { catalog_count() > 0 }>
+                        <div class="fleet-catalog-section">
+                            <div
+                                class="fleet-catalog-header"
+                                on:click=move |_| catalog_open.update(|v| *v = !*v)
+                            >
+                                <span class="fleet-section-title">"CATALOG AGENTS"</span>
+                                <span class="fleet-catalog-count">{move || catalog_count()}</span>
+                                <span class="fleet-catalog-toggle">
+                                    {move || if catalog_open.get() { "▲ COLLAPSE" } else { "▼ SHOW ALL" }}
+                                </span>
+                            </div>
+                            <Show when=move || catalog_open.get()>
+                                <div class="fleet-catalog-grid">
+                                    <For
+                                        each=catalog_agents
+                                        key=|a| a.content_hash.clone()
+                                        children=move |agent| {
+                                            view! { <CatalogRow agent=agent /> }
+                                        }
+                                    />
+                                </div>
+                            </Show>
+                        </div>
+                    </Show>
                 </div>
 
                 <div class="fleet-sidebar">
@@ -100,6 +134,29 @@ pub fn DashboardPage() -> impl IntoView {
                     </div>
                 </div>
             </div>
+        </div>
+    }
+}
+
+/// Compact single-row display for TOML catalog agents.
+#[component]
+fn CatalogRow(agent: AgentInfo) -> impl IntoView {
+    let action = agent
+        .capabilities
+        .first()
+        .map(|s| s.trim_start_matches("schema:").to_string())
+        .unwrap_or_default();
+    let live_class = if agent.live {
+        "fleet-catalog-live"
+    } else {
+        "fleet-catalog-live offline"
+    };
+
+    view! {
+        <div class="fleet-catalog-row">
+            <span class={live_class} title=if agent.live { "handler registered" } else { "handler not loaded" }></span>
+            <span class="fleet-catalog-name" title=agent.name.clone()>{agent.name.clone()}</span>
+            <span class="fleet-catalog-action">{action}</span>
         </div>
     }
 }

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -4627,3 +4627,198 @@ body {
     text-decoration: underline;
     opacity: 0.85;
 }
+
+/* ═══════════════════════════════════════════════════════════
+   WEBPAGE TEMPLATE — browser-tab-style canvas block
+   Rendered by WebPageTemplate for schema:WebPage blocks.
+   ═══════════════════════════════════════════════════════════ */
+
+.typed-webpage {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+}
+
+/* URL bar — mimics a browser address bar */
+.typed-webpage-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xs, 6px);
+    padding: 6px var(--sp-sm, 10px);
+    background: var(--bg-3, #2a2940);
+    border: 1px solid rgba(255,255,255,0.07);
+    border-radius: var(--r-sm, 4px) var(--r-sm, 4px) 0 0;
+}
+
+.typed-webpage-favicon {
+    font-size: 13px;
+    flex-shrink: 0;
+    line-height: 1;
+    opacity: 0.7;
+}
+
+.typed-webpage-url {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--purple, #6c5ce7);
+    text-decoration: none;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    flex: 1;
+    min-width: 0;
+}
+
+.typed-webpage-url:hover {
+    text-decoration: underline;
+    opacity: 0.85;
+}
+
+/* Page body — title, byline, description, text */
+.typed-webpage-body {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-sm, 8px);
+    padding: var(--sp-md, 14px) var(--sp-sm, 10px) var(--sp-sm, 10px);
+    border: 1px solid rgba(255,255,255,0.07);
+    border-top: none;
+    border-radius: 0 0 var(--r-sm, 4px) var(--r-sm, 4px);
+}
+
+.typed-webpage-title {
+    font-family: var(--font-display);
+    font-size: 16px;
+    font-weight: 700;
+    line-height: 1.3;
+    color: var(--text-1, #eeeef2);
+    margin: 0;
+}
+
+.typed-webpage-byline {
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--text-3, #6a6a80);
+    margin: 0;
+    letter-spacing: 0.02em;
+}
+
+.typed-webpage-description {
+    font-family: var(--font-body);
+    font-size: 13px;
+    line-height: 1.5;
+    color: var(--text-2, #9494a8);
+    font-style: italic;
+    margin: 0;
+}
+
+/* Body text extract — constrained height, scrollable */
+.typed-webpage-text {
+    font-family: var(--font-body);
+    font-size: 12px;
+    line-height: 1.6;
+    color: var(--text-2, #9494a8);
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 280px;
+    overflow-y: auto;
+    padding: var(--sp-sm, 8px);
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: var(--r-sm, 4px);
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,0.1) transparent;
+}
+
+/* ═══════════════════════════════════════════════════════════
+   FLEET CATALOG — compact list for TOML catalog agents
+   ═══════════════════════════════════════════════════════════ */
+
+.fleet-catalog-section {
+    border-top: 1px solid rgba(255,255,255,0.06);
+    padding: var(--sp-md) var(--sp-lg);
+}
+
+.fleet-catalog-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    margin-bottom: var(--sp-sm);
+    font: var(--text-small);
+    font-family: var(--font-mono);
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    cursor: pointer;
+    user-select: none;
+}
+
+.fleet-catalog-toggle {
+    margin-left: auto;
+    font-size: 11px;
+    color: rgba(255,255,255,0.35);
+    transition: opacity 0.15s;
+}
+
+.fleet-catalog-count {
+    background: rgba(108, 92, 231, 0.12);
+    color: var(--purple, #6c5ce7);
+    border: 1px solid rgba(108, 92, 231, 0.2);
+    padding: 2px 8px;
+    border-radius: 3px;
+    font-size: 11px;
+}
+
+.fleet-catalog-grid {
+    display: grid;
+    grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+    gap: 4px;
+    max-height: 380px;
+    overflow-y: auto;
+    scrollbar-width: thin;
+    scrollbar-color: rgba(255,255,255,0.08) transparent;
+}
+
+.fleet-catalog-row {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm, 8px);
+    padding: 5px var(--sp-sm, 8px);
+    border-radius: var(--r-sm, 4px);
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.04);
+    min-width: 0;
+}
+
+.fleet-catalog-row:hover {
+    background: rgba(255,255,255,0.04);
+}
+
+.fleet-catalog-live {
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+    flex-shrink: 0;
+    background: rgba(0,217,166,0.5);
+}
+
+.fleet-catalog-live.offline {
+    background: rgba(255,255,255,0.15);
+}
+
+.fleet-catalog-name {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-1, #eeeef2);
+    flex: 1;
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+.fleet-catalog-action {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-3, #6a6a80);
+    white-space: nowrap;
+    flex-shrink: 0;
+}


### PR DESCRIPTION
## Summary

**Bug 1 — Browse rendering shows raw text** (`typed-webpage*` CSS missing)
The `WebPageTemplate` (added in #288) generates correct HTML with classes like `.typed-webpage-bar`, `.typed-webpage-title`, etc., but no CSS was ever written for them. Without styling, the block collapses to unstyled text that looks identical to the generic renderer output.

Added browser-tab-style CSS:
- `.typed-webpage-bar` — 🌐 favicon + purple monospace URL link
- `.typed-webpage-title` — h2, display font, text-1
- `.typed-webpage-byline` — publisher · author · date, muted 11px
- `.typed-webpage-description` — italic text-2
- `.typed-webpage-text` — body extract, constrained to 280px, scrollable

**Bug 2 — 307 catalog agents not shown in fleet view** (filter regression from b818704)
`active_agents` was filtered to `source == "compiled"` only, hiding all TOML catalog agents. They appeared in TOTAL but had no UI representation anywhere.

Added collapsible **CATALOG AGENTS** section below ACTIVE AGENTS:
- Compact `fleet-catalog-grid` with one row per agent (name + action type + live-handler dot)
- Purple count badge, `▼ SHOW ALL` / `▲ COLLAPSE` toggle
- `CatalogRow` component — minimal, scannable

## Test plan
- [ ] Browse `pap://ebay.com` — block shows URL bar + title + description + scrollable text (no more raw dump)
- [ ] Fleet page — CATALOG AGENTS section shows `▼ SHOW ALL (307)` below ACTIVE AGENTS; click expands compact grid
- [ ] `cargo check --workspace`, `cargo clippy -- -D warnings`, `cargo fmt -- --check` — all pass
- [ ] WASM: `cargo check --target wasm32-unknown-unknown` in `apps/papillon/frontend` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)