### PR TITLE
refactor(fleet): Chrysalis Network — registry-discovery-first layout

### DIFF
--- a/apps/papillon/frontend/src/components/sidebar.rs
+++ b/apps/papillon/frontend/src/components/sidebar.rs
@@ -45,18 +45,6 @@ pub fn Sidebar() -> impl IntoView {
                 <IconChip />
             </A>
             <A
-                href="/activity"
-                attr:class=move || {
-                    if location.pathname.get().starts_with("/activity") {
-                        "sidebar-icon active"
-                    } else {
-                        "sidebar-icon"
-                    }
-                }
-            >
-                <IconDatabase />
-            </A>
-            <A
                 href="/receipts"
                 attr:class=move || {
                     if location.pathname.get().starts_with("/receipts") {
@@ -66,7 +54,7 @@ pub fn Sidebar() -> impl IntoView {
                     }
                 }
             >
-                <IconReceipt />
+                <IconHistory />
             </A>
             <div style="flex:1" />
             <A
@@ -129,12 +117,12 @@ fn IconDatabase() -> impl IntoView {
 }
 
 #[component]
-fn IconReceipt() -> impl IntoView {
+fn IconHistory() -> impl IntoView {
     view! {
         <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round">
-            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-            <polyline points="14 2 14 8 20 8"/>
-            <line x1="9" y1="15" x2="15" y2="15"/>
+            <polyline points="1 4 1 10 7 10"/>
+            <path d="M3.51 15a9 9 0 1 0 .49-4.5"/>
+            <polyline points="12 7 12 12 15 15"/>
         </svg>
     }
 }

--- a/apps/papillon/frontend/src/pages/dashboard.rs
+++ b/apps/papillon/frontend/src/pages/dashboard.rs
@@ -1,144 +1,497 @@
 use leptos::prelude::*;
+use leptos::ev::MouseEvent;
+use leptos_router::components::A;
 use wasm_bindgen_futures::spawn_local;
 
 use crate::bridge;
-use papillon_shared::AgentInfo;
+use papillon_shared::{AgentInfo, RegistryInfo};
+
+const LOCAL_URL: &str = "pap://local";
+
+// ── Helper: shorten a DID for display ──────────────────────────────────────
+fn short_did(did: &str) -> String {
+    if did.len() > 26 {
+        format!("{}…{}", &did[..14], &did[did.len() - 6..])
+    } else {
+        did.to_string()
+    }
+}
+
+// ── Main page ───────────────────────────────────────────────────────────────
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
-    let agents: RwSignal<Vec<AgentInfo>> = RwSignal::new(vec![]);
-    let loading = RwSignal::new(true);
+    // ── Network / node state ───────────────────────────────────────────────
+    let node_did: RwSignal<String> = RwSignal::new(String::new());
+    let node_port: RwSignal<u64> = RwSignal::new(0);
+    let node_addresses: RwSignal<Vec<String>> = RwSignal::new(vec![]);
+    let bookmarks: RwSignal<Vec<String>> = RwSignal::new(vec![]);
+    let registry_infos: RwSignal<Vec<(String, RegistryInfo)>> = RwSignal::new(vec![]);
 
+    // ── Connect form ───────────────────────────────────────────────────────
+    let connect_input: RwSignal<String> = RwSignal::new(String::new());
+    let connecting: RwSignal<bool> = RwSignal::new(false);
+    let connect_error: RwSignal<Option<String>> = RwSignal::new(None);
+
+    // ── Agents (secondary) ─────────────────────────────────────────────────
+    let agents: RwSignal<Vec<AgentInfo>> = RwSignal::new(vec![]);
+    let agents_loading: RwSignal<bool> = RwSignal::new(true);
+    let agents_open: RwSignal<bool> = RwSignal::new(false);
+    let catalog_open: RwSignal<bool> = RwSignal::new(false);
+
+    // ── Load data on mount ─────────────────────────────────────────────────
     Effect::new(move || {
         if bridge::tauri_available() {
             spawn_local(async move {
-                loading.set(true);
+                // 1. Node identity & counts
+                if let Ok(info) =
+                    bridge::invoke_no_args::<serde_json::Value>("get_node_info").await
+                {
+                    if let Some(d) = info.get("did").and_then(|v| v.as_str()) {
+                        node_did.set(d.to_string());
+                    }
+                    if let Some(p) = info.get("port").and_then(|v| v.as_u64()) {
+                        node_port.set(p);
+                    }
+                    let ac = info
+                        .get("agent_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
+                    let pc = info
+                        .get("peer_count")
+                        .and_then(|v| v.as_u64())
+                        .unwrap_or(0) as usize;
+                    registry_infos.update(|v| {
+                        v.retain(|(u, _)| u != LOCAL_URL);
+                        v.insert(
+                            0,
+                            (
+                                LOCAL_URL.to_string(),
+                                RegistryInfo {
+                                    url: LOCAL_URL.to_string(),
+                                    agent_count: ac,
+                                    peer_count: pc,
+                                },
+                            ),
+                        );
+                    });
+                }
+
+                // 2. LAN addresses
+                if let Ok(addrs) =
+                    bridge::invoke_no_args::<Vec<String>>("get_node_addresses").await
+                {
+                    node_addresses.set(addrs);
+                }
+
+                // 3. Bookmarks
+                if let Ok(bm) = bridge::invoke_no_args::<Vec<String>>("list_bookmarks").await {
+                    let remote: Vec<String> = bm
+                        .into_iter()
+                        .filter(|u| u.as_str() != LOCAL_URL)
+                        .collect();
+                    bookmarks.set(remote);
+                }
+
+                // 4. Local agents (used in the collapsible section)
+                agents_loading.set(true);
                 if let Ok(list) =
                     bridge::invoke_no_args::<Vec<AgentInfo>>("list_local_agents").await
                 {
                     agents.set(list);
                 }
-                loading.set(false);
+                agents_loading.set(false);
             });
         } else {
-            loading.set(false);
+            agents_loading.set(false);
         }
     });
 
-    let active_count = move || {
-        agents.get().iter().filter(|a| a.source == "compiled").count()
-    };
-    let total_count = move || agents.get().len();
+    // ── Derived: agent breakdown ───────────────────────────────────────────
     let active_agents = move || -> Vec<_> {
-        agents.get().into_iter().filter(|a| a.source == "compiled").collect()
+        agents
+            .get()
+            .into_iter()
+            .filter(|a| a.source == "compiled")
+            .collect()
     };
     let catalog_agents = move || -> Vec<_> {
-        agents.get().into_iter().filter(|a| a.source == "catalog").collect()
+        agents
+            .get()
+            .into_iter()
+            .filter(|a| a.source == "catalog")
+            .collect()
+    };
+    let active_count = move || {
+        agents
+            .get()
+            .iter()
+            .filter(|a| a.source == "compiled")
+            .count()
     };
     let catalog_count = move || {
-        agents.get().iter().filter(|a| a.source == "catalog").count()
+        agents
+            .get()
+            .iter()
+            .filter(|a| a.source == "catalog")
+            .count()
     };
-    let catalog_open = RwSignal::new(false);
+    let total_count = move || agents.get().len();
 
+    // ── Derived: local registry info ───────────────────────────────────────
+    let local_info = move || {
+        registry_infos
+            .get()
+            .into_iter()
+            .find(|(u, _)| u == LOCAL_URL)
+            .map(|(_, i)| i)
+    };
+
+    // ── Connect handler ────────────────────────────────────────────────────
+    let do_connect = move |_: MouseEvent| {
+        let url = connect_input.get();
+        let url = url.trim().to_string();
+        if url.is_empty() || connecting.get() {
+            return;
+        }
+        connect_error.set(None);
+        connecting.set(true);
+        spawn_local(async move {
+            #[derive(serde::Serialize)]
+            struct NavArgs {
+                url: String,
+            }
+            match bridge::invoke::<NavArgs, RegistryInfo>(
+                "navigate_registry",
+                &NavArgs { url: url.clone() },
+            )
+            .await
+            {
+                Ok(info) => {
+                    registry_infos.update(|v| {
+                        v.retain(|(u, _)| u != &url);
+                        v.push((url.clone(), info));
+                    });
+                    #[derive(serde::Serialize)]
+                    struct BmArgs {
+                        registry_url: String,
+                    }
+                    let _ = bridge::invoke::<BmArgs, Vec<String>>(
+                        "add_bookmark",
+                        &BmArgs {
+                            registry_url: url.clone(),
+                        },
+                    )
+                    .await;
+                    bookmarks.update(|b| {
+                        if !b.contains(&url) {
+                            b.push(url.clone());
+                        }
+                    });
+                    connect_input.set(String::new());
+                }
+                Err(e) => {
+                    connect_error.set(Some(e));
+                }
+            }
+            connecting.set(false);
+        });
+    };
+
+    // ── View ───────────────────────────────────────────────────────────────
     view! {
-        <div class="fleet-page">
-            <div class="fleet-header">
-                <div class="fleet-header-left">
-                    <div class="fleet-header-icon">
-                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                            <rect x="2" y="2" width="20" height="20" rx="2"/>
-                            <path d="M7 9h10M7 12h10M7 15h7"/>
+        <div class="chrysalis-page">
+
+            // ── Header ──────────────────────────────────────────────────
+            <div class="chrysalis-header">
+                <div class="chrysalis-header-left">
+                    <div class="chrysalis-header-icon">
+                        <svg width="20" height="20" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="1.8">
+                            <circle cx="12" cy="12" r="3"/>
+                            <circle cx="12" cy="12" r="9"/>
+                            <path d="M3.6 9h16.8M3.6 15h16.8"/>
+                            <path d="M12 3c-2.5 3-4 5.5-4 9s1.5 6 4 9"/>
+                            <path d="M12 3c2.5 3 4 5.5 4 9s-1.5 6-4 9"/>
                         </svg>
                     </div>
                     <div>
-                        <div class="fleet-header-title">"AGENT FLEET & CHRYSALIS NODES"</div>
-                        <div class="fleet-header-subtitle">"Multi-Agent Roster Management & Drop-in Coordination"</div>
+                        <div class="chrysalis-header-title">"CHRYSALIS NETWORK"</div>
+                        <div class="chrysalis-header-subtitle">
+                            "Federated Registry Discovery · " {move || {
+                                let n = bookmarks.get().len();
+                                if n == 0 {
+                                    "No remote nodes connected".to_string()
+                                } else if n == 1 {
+                                    "1 remote node".to_string()
+                                } else {
+                                    format!("{n} remote nodes")
+                                }
+                            }}
+                        </div>
                     </div>
                 </div>
-                <div class="fleet-header-right">
-                    <span class="fleet-badge active">"● "{move || active_count()}" ACTIVE"</span>
-                    <span class="fleet-badge total">"◎ "{move || total_count()}" TOTAL"</span>
-                    <button class="fleet-add-btn">"+ ADD AGENT"</button>
+                <div class="chrysalis-header-right">
+                    <Show when=move || { node_port.get() > 0 }>
+                        <span class="chrysalis-node-address">
+                            "◉ "
+                            {move || {
+                                let addrs = node_addresses.get();
+                                if let Some(first) = addrs.first() {
+                                    first.clone()
+                                } else {
+                                    format!("pap://localhost:{}", node_port.get())
+                                }
+                            }}
+                        </span>
+                    </Show>
                 </div>
             </div>
 
-            <div class="fleet-body">
-                <div class="fleet-agents">
-                    <div class="fleet-section-header">
-                        <span class="fleet-section-check">"✓"</span>
-                        <span class="fleet-section-title">"ACTIVE AGENTS"</span>
-                        <span class="fleet-section-count">{move || format!("{} Online", active_count())}</span>
-                        <span class="fleet-section-sort">"↕ SORT BY NAME"</span>
+            // ── Body ────────────────────────────────────────────────────
+            <div class="chrysalis-body">
+
+                // ── Left: Registry list ──────────────────────────────
+                <div class="chrysalis-nodes">
+                    <div class="chrysalis-section-label">"NETWORK NODES"</div>
+
+                    // pap://local — always first
+                    <div class="chrysalis-node-row local">
+                        <div class="chrysalis-node-dot local" title="Built-in local node"></div>
+                        <div class="chrysalis-node-info">
+                            <span class="chrysalis-node-url">"pap://local"</span>
+                            <span class="chrysalis-node-tag local">"LOCAL"</span>
+                        </div>
+                        <div class="chrysalis-node-meta">
+                            {move || local_info().map(|i| {
+                                format!("{} agents · {} peers", i.agent_count, i.peer_count)
+                            }).unwrap_or_else(|| format!("{} agents", total_count()))}
+                        </div>
+                        <A href="/browse" attr:class="chrysalis-node-action">"BROWSE →"</A>
                     </div>
 
-                    <Show
-                        when=move || loading.get()
-                        fallback=move || view! {
-                            <div class="fleet-grid">
-                                <For
-                                    each=active_agents
-                                    key=|a| a.content_hash.clone()
-                                    children=move |agent| {
-                                        view! { <AgentCard agent=agent /> }
-                                    }
-                                />
-                            </div>
-                        }
-                    >
-                        <div class="fleet-loading">"Loading agents\u{2026}"</div>
-                    </Show>
-
-                    // ── Catalog agents (TOML-defined, collapsible) ──────────
-                    <Show when=move || { catalog_count() > 0 }>
-                        <div class="fleet-catalog-section">
-                            <div
-                                class="fleet-catalog-header"
-                                on:click=move |_| catalog_open.update(|v| *v = !*v)
-                            >
-                                <span class="fleet-section-title">"CATALOG AGENTS"</span>
-                                <span class="fleet-catalog-count">{move || catalog_count()}</span>
-                                <span class="fleet-catalog-toggle">
-                                    {move || if catalog_open.get() { "▲ COLLAPSE" } else { "▼ SHOW ALL" }}
-                                </span>
-                            </div>
-                            <Show when=move || catalog_open.get()>
-                                <div class="fleet-catalog-grid">
-                                    <For
-                                        each=catalog_agents
-                                        key=|a| a.content_hash.clone()
-                                        children=move |agent| {
-                                            view! { <CatalogRow agent=agent /> }
-                                        }
-                                    />
+                    // Remote bookmarked nodes
+                    <For
+                        each=move || bookmarks.get()
+                        key=|url| url.clone()
+                        children=move |url| {
+                            let url2 = url.clone();
+                            let url3 = url.clone();
+                            view! {
+                                <div class="chrysalis-node-row remote">
+                                    <div class="chrysalis-node-dot remote"
+                                        title="Remote Chrysalis node">
+                                    </div>
+                                    <div class="chrysalis-node-info">
+                                        <span class="chrysalis-node-url">{url.clone()}</span>
+                                        <span class="chrysalis-node-tag remote">"REMOTE"</span>
+                                    </div>
+                                    <div class="chrysalis-node-meta">
+                                        {move || {
+                                            registry_infos.get()
+                                                .into_iter()
+                                                .find(|(u, _)| u == &url2)
+                                                .map(|(_, i)| format!(
+                                                    "{} agents · {} peers",
+                                                    i.agent_count, i.peer_count
+                                                ))
+                                                .unwrap_or_else(|| "Not yet synced".to_string())
+                                        }}
+                                    </div>
+                                    <A
+                                        href=move || format!("/browse?url={}", url3.clone())
+                                        attr:class="chrysalis-node-action"
+                                    >
+                                        "BROWSE →"
+                                    </A>
                                 </div>
+                            }
+                        }
+                    />
+
+                    // ── Connect form ──────────────────────────────────
+                    <div class="chrysalis-connect">
+                        <div class="chrysalis-connect-label">"CONNECT TO NODE"</div>
+                        <div class="chrysalis-connect-row">
+                            <input
+                                type="text"
+                                class="chrysalis-connect-input"
+                                placeholder="pap://hostname or pap+http://hostname:7891"
+                                prop:value=move || connect_input.get()
+                                on:input=move |ev| {
+                                    connect_input.set(
+                                        leptos::prelude::event_target_value(&ev)
+                                    );
+                                }
+                                on:keydown=move |ev| {
+                                    use wasm_bindgen::JsCast;
+                                    let ke: web_sys::KeyboardEvent =
+                                        ev.unchecked_into();
+                                    if ke.key() == "Enter" {
+                                        do_connect(MouseEvent::new("click").unwrap());
+                                    }
+                                }
+                            />
+                            <button
+                                class="chrysalis-connect-btn"
+                                prop:disabled=move || connecting.get()
+                                on:click=do_connect
+                            >
+                                {move || if connecting.get() { "CONNECTING…" } else { "CONNECT" }}
+                            </button>
+                        </div>
+                        <Show when=move || connect_error.get().is_some()>
+                            <div class="chrysalis-connect-error">
+                                {move || connect_error.get().unwrap_or_default()}
+                            </div>
+                        </Show>
+                    </div>
+                </div>
+
+                // ── Right: This-node identity panel ───────────────────
+                <div class="chrysalis-identity">
+                    <div class="chrysalis-panel">
+                        <div class="chrysalis-panel-header">
+                            <svg width="13" height="13" viewBox="0 0 24 24" fill="none"
+                                stroke="currentColor" stroke-width="2">
+                                <circle cx="12" cy="12" r="3"/>
+                                <circle cx="12" cy="12" r="9"/>
+                                <path d="M3.6 9h16.8M3.6 15h16.8"/>
+                                <path d="M12 3c-2.5 3-4 5.5-4 9s1.5 6 4 9"/>
+                                <path d="M12 3c2.5 3 4 5.5 4 9s-1.5 6-4 9"/>
+                            </svg>
+                            "THIS NODE"
+                        </div>
+                        <div class="chrysalis-panel-body">
+                            <Show
+                                when=move || !node_did.get().is_empty()
+                                fallback=move || view! {
+                                    <div class="chrysalis-panel-empty">
+                                        "Tauri bridge unavailable."
+                                    </div>
+                                }
+                            >
+                                <div class="chrysalis-identity-row">
+                                    <div class="chrysalis-identity-label">"IDENTITY"</div>
+                                    <div class="chrysalis-identity-value mono"
+                                        title=move || node_did.get()>
+                                        {move || short_did(&node_did.get())}
+                                    </div>
+                                </div>
+                                <Show when=move || { node_port.get() > 0 }>
+                                    <div class="chrysalis-identity-row">
+                                        <div class="chrysalis-identity-label">"PORT"</div>
+                                        <div class="chrysalis-identity-value mono">
+                                            {move || node_port.get().to_string()}
+                                        </div>
+                                    </div>
+                                </Show>
+                                <Show when=move || !node_addresses.get().is_empty()>
+                                    <div class="chrysalis-identity-row col">
+                                        <div class="chrysalis-identity-label">"SHARE VIA"</div>
+                                        <For
+                                            each=move || node_addresses.get()
+                                            key=|a| a.clone()
+                                            children=|addr| view! {
+                                                <div class="chrysalis-identity-addr mono">
+                                                    {addr}
+                                                </div>
+                                            }
+                                        />
+                                    </div>
+                                </Show>
                             </Show>
                         </div>
-                    </Show>
-                </div>
-
-                <div class="fleet-sidebar">
-                    <div class="fleet-panel">
-                        <div class="fleet-panel-header">
-                            <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
-                                <circle cx="12" cy="12" r="10"/>
-                                <path d="M12 8v4l3 3"/>
-                            </svg>
-                            "CHRYSALIS DROP-INS"
-                        </div>
-                        <div class="fleet-panel-body">
-                            <div class="fleet-dropins-empty">
-                                <p>"No remote Chrysalis nodes connected."</p>
-                                <p>"Browse registries to discover federated agents."</p>
-                            </div>
-                        </div>
                     </div>
                 </div>
+            </div>
+
+            // ── Agents section (collapsible, secondary) ──────────────
+            <div class="chrysalis-agents">
+                <div
+                    class="chrysalis-agents-toggle"
+                    on:click=move |_| agents_open.update(|v| *v = !*v)
+                >
+                    <span class="chrysalis-agents-title">
+                        "AGENT ROSTER — pap://local"
+                    </span>
+                    <div class="chrysalis-agents-pills">
+                        <span class="chrysalis-pill compiled">
+                            {move || active_count().to_string()}
+                            " compiled"
+                        </span>
+                        <span class="chrysalis-pill catalog">
+                            {move || catalog_count().to_string()}
+                            " catalog"
+                        </span>
+                    </div>
+                    <span class="chrysalis-agents-caret">
+                        {move || if agents_open.get() { "▲" } else { "▼" }}
+                    </span>
+                </div>
+
+                <Show when=move || agents_open.get()>
+                    <div class="chrysalis-agents-body">
+                        <Show
+                            when=move || agents_loading.get()
+                            fallback=move || view! {
+                                // Compiled agents
+                                <Show when=move || { active_count() > 0 }>
+                                    <div class="chrysalis-agents-group">"COMPILED"</div>
+                                    <div class="fleet-grid">
+                                        <For
+                                            each=active_agents
+                                            key=|a| a.content_hash.clone()
+                                            children=move |agent| {
+                                                view! { <AgentCard agent=agent /> }
+                                            }
+                                        />
+                                    </div>
+                                </Show>
+                                // Catalog agents (nested collapse)
+                                <Show when=move || { catalog_count() > 0 }>
+                                    <div class="chrysalis-catalog-bar"
+                                        on:click=move |_| {
+                                            catalog_open.update(|v| *v = !*v)
+                                        }
+                                    >
+                                        <span class="chrysalis-agents-group">"CATALOG"</span>
+                                        <span class="chrysalis-pill catalog">
+                                            {move || catalog_count().to_string()}
+                                        </span>
+                                        <span class="fleet-catalog-toggle">
+                                            {move || if catalog_open.get() {
+                                                "▲ COLLAPSE"
+                                            } else {
+                                                "▼ SHOW ALL"
+                                            }}
+                                        </span>
+                                    </div>
+                                    <Show when=move || catalog_open.get()>
+                                        <div class="fleet-catalog-grid">
+                                            <For
+                                                each=catalog_agents
+                                                key=|a| a.content_hash.clone()
+                                                children=move |agent| {
+                                                    view! { <CatalogRow agent=agent /> }
+                                                }
+                                            />
+                                        </div>
+                                    </Show>
+                                </Show>
+                            }
+                        >
+                            <div class="fleet-loading">"Loading agents\u{2026}"</div>
+                        </Show>
+                    </div>
+                </Show>
             </div>
         </div>
     }
 }
 
-/// Compact single-row display for TOML catalog agents.
+// ── Compact row for TOML catalog agents ────────────────────────────────────
+
 #[component]
 fn CatalogRow(agent: AgentInfo) -> impl IntoView {
     let action = agent
@@ -151,25 +504,35 @@ fn CatalogRow(agent: AgentInfo) -> impl IntoView {
     } else {
         "fleet-catalog-live offline"
     };
-
     view! {
         <div class="fleet-catalog-row">
-            <span class={live_class} title=if agent.live { "handler registered" } else { "handler not loaded" }></span>
-            <span class="fleet-catalog-name" title=agent.name.clone()>{agent.name.clone()}</span>
+            <span
+                class={live_class}
+                title=if agent.live { "handler registered" } else { "handler not loaded" }
+            ></span>
+            <span class="fleet-catalog-name" title=agent.name.clone()>
+                {agent.name.clone()}
+            </span>
             <span class="fleet-catalog-action">{action}</span>
         </div>
     }
 }
 
+// ── Agent card (compiled agents) ───────────────────────────────────────────
+
 #[component]
 fn AgentCard(agent: AgentInfo) -> impl IntoView {
-    let short_did = agent.agent_did.as_deref().map(|d| {
-        if d.len() > 20 {
-            format!("{}...{}", &d[..10], &d[d.len()-6..])
-        } else {
-            d.to_string()
-        }
-    }).unwrap_or_else(|| "compiled".to_string());
+    let short_did_val = agent
+        .agent_did
+        .as_deref()
+        .map(|d| {
+            if d.len() > 20 {
+                format!("{}...{}", &d[..10], &d[d.len() - 6..])
+            } else {
+                d.to_string()
+            }
+        })
+        .unwrap_or_else(|| "compiled".to_string());
 
     let action = agent.capabilities.first().cloned().unwrap_or_default();
     let action_label = action.trim_start_matches("schema:").to_string();
@@ -185,14 +548,15 @@ fn AgentCard(agent: AgentInfo) -> impl IntoView {
         <div class="agent-card">
             <div class="agent-card-header">
                 <div class="agent-card-icon">
-                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
+                    <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="1.8">
                         <circle cx="12" cy="8" r="4"/>
                         <path d="M4 20c0-4 3.6-7 8-7s8 3 8 7"/>
                     </svg>
                 </div>
                 <div class="agent-card-info">
                     <div class="agent-card-name">{agent.name.clone()}</div>
-                    <div class="agent-card-did">{short_did}</div>
+                    <div class="agent-card-did">{short_did_val}</div>
                 </div>
                 <span class=source_badge_class>{agent.source.clone()}</span>
             </div>

--- a/apps/papillon/frontend/src/pages/receipts.rs
+++ b/apps/papillon/frontend/src/pages/receipts.rs
@@ -2,207 +2,474 @@ use leptos::prelude::*;
 use wasm_bindgen_futures::spawn_local;
 
 use crate::bridge;
-use papillon_shared::ScenarioRunResult;
+use papillon_shared::db::Episode;
+
+// ── Page ────────────────────────────────────────────────────────────────────
 
 #[component]
 pub fn ReceiptsPage() -> impl IntoView {
-    let runs = RwSignal::new(Vec::<ScenarioRunResult>::new());
-    let selected = RwSignal::new(None::<usize>);
+    let episodes: RwSignal<Vec<Episode>> = RwSignal::new(vec![]);
+    let loading: RwSignal<bool> = RwSignal::new(true);
+    let query: RwSignal<String> = RwSignal::new(String::new());
+    let selected_id: RwSignal<Option<String>> = RwSignal::new(None);
 
+    // ── Load episodes on mount ────────────────────────────────────────────
     Effect::new(move || {
-        if !bridge::tauri_available() {
-            return;
+        if bridge::tauri_available() {
+            spawn_local(async move {
+                #[derive(serde::Serialize)]
+                struct LimitArgs {
+                    limit: Option<usize>,
+                }
+                if let Ok(eps) = bridge::invoke::<LimitArgs, Vec<Episode>>(
+                    "list_recent_episodes",
+                    &LimitArgs { limit: Some(200) },
+                )
+                .await
+                {
+                    episodes.set(eps);
+                }
+                loading.set(false);
+            });
+        } else {
+            loading.set(false);
         }
-        spawn_local(async move {
-            if let Ok(results) =
-                bridge::invoke_no_args::<Vec<ScenarioRunResult>>("list_completed_runs").await
-            {
-                let mut v = results;
-                v.reverse();
-                runs.set(v);
-            }
-        });
     });
 
-    let verified_count = move || {
-        runs.get()
+    // ── Filtered list ────────────────────────────────────────────────────
+    let filtered = move || {
+        let q = query.get().to_lowercase();
+        episodes
+            .get()
+            .into_iter()
+            .filter(|ep| {
+                if q.is_empty() {
+                    return true;
+                }
+                ep.agent_name.to_lowercase().contains(&q)
+                    || ep
+                        .query
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&q)
+                    || ep
+                        .intent_summary
+                        .as_deref()
+                        .unwrap_or("")
+                        .to_lowercase()
+                        .contains(&q)
+                    || ep.action_type.to_lowercase().contains(&q)
+                    || ep.outcome.to_lowercase().contains(&q)
+            })
+            .collect::<Vec<_>>()
+    };
+
+    let total_count = move || episodes.get().len();
+    let filtered_count = move || filtered().len();
+    let success_count = move || {
+        episodes
+            .get()
             .iter()
-            .filter(|r| r.receipt.as_ref().map(|rc| rc.co_signed).unwrap_or(false))
+            .filter(|e| e.outcome == "success")
             .count()
     };
 
+    // ── Selected episode detail ──────────────────────────────────────────
+    let selected_episode = move || {
+        let id = selected_id.get()?;
+        episodes.get().into_iter().find(|e| e.id == id)
+    };
+
     view! {
-        <div class="receipts-page">
-            <div class="receipts-header">
-                <div class="receipts-header-left">
-                    <div class="receipts-header-icon">
-                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.8">
-                            <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
-                            <polyline points="14 2 14 8 20 8"/>
-                            <line x1="9" y1="15" x2="15" y2="15"/>
+        <div class="history-page">
+            // ── Header ──────────────────────────────────────────────────
+            <div class="history-header">
+                <div class="history-header-left">
+                    <div class="history-header-icon">
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none"
+                            stroke="currentColor" stroke-width="1.8">
+                            <polyline points="1 4 1 10 7 10"/>
+                            <path d="M3.51 15a9 9 0 1 0 .49-4.5"/>
+                            <polyline points="12 7 12 12 15 15"/>
                         </svg>
                     </div>
                     <div>
-                        <div class="receipts-title">"RECEIPTS & CO-SIGNED OUTCOMES"</div>
-                        <div class="receipts-subtitle">"Immutable JSON-LD Ledger \u{2022} Provenance Chain \u{2022} Signature Verification"</div>
+                        <div class="history-title">"EPISODE HISTORY"</div>
+                        <div class="history-subtitle">
+                            "Past sessions · Agent interactions · Co-signed receipts"
+                        </div>
                     </div>
                 </div>
-                <div class="receipts-header-right">
-                    <span class="receipts-verified-badge">
-                        <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5"><polyline points="20 6 9 17 4 12"/></svg>
-                        {move || format!("{} VERIFIED", verified_count())}
+                <div class="history-header-right">
+                    <span class="history-stat-badge">
+                        {move || format!("{} total", total_count())}
+                    </span>
+                    <span class="history-stat-badge success">
+                        {move || format!("{} succeeded", success_count())}
                     </span>
                 </div>
             </div>
 
-            <div class="receipts-body">
-                <div class="receipts-list">
+            // ── Search bar ───────────────────────────────────────────────
+            <div class="history-search-bar">
+                <div class="history-search-icon">
+                    <svg width="14" height="14" viewBox="0 0 24 24" fill="none"
+                        stroke="currentColor" stroke-width="2">
+                        <circle cx="11" cy="11" r="8"/>
+                        <line x1="21" y1="21" x2="16.65" y2="16.65"/>
+                    </svg>
+                </div>
+                <input
+                    type="text"
+                    class="history-search-input"
+                    placeholder="Search by query, agent, or action\u{2026}"
+                    prop:value=move || query.get()
+                    on:input=move |ev| query.set(leptos::prelude::event_target_value(&ev))
+                />
+                <Show when=move || !query.get().is_empty()>
+                    <span class="history-search-count">
+                        {move || format!("{} of {}", filtered_count(), total_count())}
+                    </span>
+                </Show>
+            </div>
+
+            // ── Body ─────────────────────────────────────────────────────
+            <div class="history-body">
+                // ── Episode list ─────────────────────────────────────────
+                <div class="history-list">
                     <Show
-                        when=move || !runs.get().is_empty()
-                        fallback=|| view! {
-                            <div class="receipts-empty">
-                                <p>"No receipts yet."</p>
-                                <p style="margin-top: 6px; font-size: 11px; opacity: 0.6;">"Complete a PAP session to generate co-signed receipts."</p>
-                            </div>
+                        when=move || loading.get()
+                        fallback=move || view! {
+                            <Show
+                                when=move || filtered().is_empty()
+                                fallback=move || view! {
+                                    <For
+                                        each=filtered
+                                        key=|ep| ep.id.clone()
+                                        children=move |ep| {
+                                            let id = ep.id.clone();
+                                            let id_click = id.clone();
+                                            let is_selected =
+                                                move || selected_id.get().as_deref() == Some(&id);
+                                            view! {
+                                                <EpisodeRow
+                                                    episode=ep
+                                                    selected=is_selected
+                                                    on_select=move || {
+                                                        selected_id.set(Some(id_click.clone()))
+                                                    }
+                                                />
+                                            }
+                                        }
+                                    />
+                                }
+                            >
+                                <div class="history-empty">
+                                    <svg width="28" height="28" viewBox="0 0 24 24" fill="none"
+                                        stroke="currentColor" stroke-width="1.5"
+                                        style="opacity: 0.2; margin-bottom: 10px;">
+                                        <polyline points="1 4 1 10 7 10"/>
+                                        <path d="M3.51 15a9 9 0 1 0 .49-4.5"/>
+                                        <polyline points="12 7 12 12 15 15"/>
+                                    </svg>
+                                    {move || if query.get().is_empty() {
+                                        "No episodes yet. Use the canvas to start interacting with agents."
+                                    } else {
+                                        "No matches. Try a different search term."
+                                    }}
+                                </div>
+                            </Show>
                         }
                     >
-                        <For
-                            each=move || {
-                                let v: Vec<_> = runs.get().into_iter().enumerate().collect();
-                                v
-                            }
-                            key=|(i, _)| *i
-                            children=move |(i, run)| {
-                                let has_receipt = run.receipt.is_some();
-                                let co_signed = run.receipt.as_ref().map(|r| r.co_signed).unwrap_or(false);
-                                let agent = run.agent_name.clone();
-                                let ts = run.completed_at.clone();
-                                let session_id = run.receipt.as_ref().map(|r| {
-                                    let id = &r.session_id;
-                                    if id.len() > 12 { format!("RCP_{}", &id[..8]) } else { format!("RCP_{}", id) }
-                                }).unwrap_or_default();
-
-                                let is_selected = move || selected.get() == Some(i);
-
-                                view! {
-                                    <div
-                                        class=move || if is_selected() { "receipt-card selected" } else { "receipt-card" }
-                                        on:click=move |_| selected.set(Some(i))
-                                    >
-                                        <div class="receipt-card-top">
-                                            {if co_signed {
-                                                view! { <span class="receipt-verified-label">"✓ VERIFIED"</span> }.into_any()
-                                            } else if has_receipt {
-                                                view! { <span class="receipt-pending-label">"◎ PENDING"</span> }.into_any()
-                                            } else {
-                                                view! { <span class="receipt-unsigned-label">"○ UNSIGNED"</span> }.into_any()
-                                            }}
-                                            <span class="receipt-id">{session_id}</span>
-                                        </div>
-                                        <div class="receipt-agent">{agent}</div>
-                                        <div class="receipt-ts">{ts}</div>
-                                    </div>
-                                }
-                            }
-                        />
+                        <div class="history-loading">"Loading history\u{2026}"</div>
                     </Show>
                 </div>
 
-                <div class="receipts-detail">
-                    {move || {
-                        let idx = selected.get();
-                        let runs_list = runs.get();
-                        match idx.and_then(|i| runs_list.get(i)) {
-                            None => view! {
-                                <div class="receipts-detail-empty">
-                                    <p>"Select a receipt to view details"</p>
-                                </div>
-                            }.into_any(),
-                            Some(run) => {
-                                let receipt = run.receipt.clone();
-                                let agent = run.agent_name.clone();
-                                let ts = run.completed_at.clone();
-                                let co_signed = receipt.as_ref().map(|r| r.co_signed).unwrap_or(false);
-                                let session_id = receipt.as_ref().map(|r| r.session_id.clone()).unwrap_or_default();
-                                let action = receipt.as_ref().map(|r| r.action.clone()).unwrap_or_default();
-                                let props = receipt.as_ref().map(|r| r.property_refs.clone()).unwrap_or_default();
-                                let short_sid = if session_id.len() > 16 {
-                                    format!("{}...{}", &session_id[..8], &session_id[session_id.len()-4..])
-                                } else {
-                                    session_id.clone()
-                                };
-
-                                view! {
-                                    <div class="receipt-detail-panel">
-                                        <div class="receipt-detail-title">"Receipt "{short_sid.clone()}</div>
-                                        <div class="receipt-detail-meta">{agent.clone()}" \u{2022} "{ts.clone()}</div>
-
-                                        <div class="receipt-sig-panel">
-                                            <div class="receipt-sig-header">
-                                                <svg width="14" height="14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 22s8-4 8-10V5l-8-3-8 3v7c0 6 8 10 8 10z"/></svg>
-                                                "SIGNATURE VERIFICATION"
-                                                {if co_signed {
-                                                    view! { <span class="receipt-all-verified">"✓ ALL VERIFIED"</span> }.into_any()
-                                                } else {
-                                                    view! { <span /> }.into_any()
-                                                }}
-                                            </div>
-                                            <div class="receipt-sig-cards">
-                                                <div class="receipt-sig-card">
-                                                    <div class="receipt-sig-role">"PRINCIPAL"</div>
-                                                    <div class="receipt-sig-name">"Primary Owner"</div>
-                                                    <div class="receipt-sig-key">"LOCAL_KEY"</div>
-                                                    {if co_signed {
-                                                        view! { <span class="receipt-sig-ok">"✓ VERIFIED"</span> }.into_any()
-                                                    } else {
-                                                        view! { <span class="receipt-sig-pending">"PENDING"</span> }.into_any()
-                                                    }}
-                                                </div>
-                                                <div class="receipt-sig-card">
-                                                    <div class="receipt-sig-role">"AGENT"</div>
-                                                    <div class="receipt-sig-name">{agent.clone()}</div>
-                                                    <div class="receipt-sig-key">"OPERATOR_KEY"</div>
-                                                    {if co_signed {
-                                                        view! { <span class="receipt-sig-ok">"✓ VERIFIED"</span> }.into_any()
-                                                    } else {
-                                                        view! { <span class="receipt-sig-pending">"PENDING"</span> }.into_any()
-                                                    }}
-                                                </div>
-                                            </div>
-                                        </div>
-
-                                        <div class="receipt-meta-grid">
-                                            <div class="receipt-meta-item">
-                                                <div class="receipt-meta-label">"ACTION"</div>
-                                                <div class="receipt-meta-value">{action.trim_start_matches("schema:").to_string()}</div>
-                                            </div>
-                                            <div class="receipt-meta-item">
-                                                <div class="receipt-meta-label">"SESSION"</div>
-                                                <div class="receipt-meta-value" style="font-size: 11px;">{short_sid}</div>
-                                            </div>
-                                        </div>
-
-                                        {if !props.is_empty() {
-                                            view! {
-                                                <div class="receipt-props-section">
-                                                    <div class="receipt-meta-label">"DISCLOSED PROPERTIES"</div>
-                                                    <div style="display: flex; flex-wrap: wrap; gap: 4px; margin-top: 6px;">
-                                                        {props.iter().map(|p| view! {
-                                                            <span class="agent-cap-tag">{p.clone()}</span>
-                                                        }).collect::<Vec<_>>()}
-                                                    </div>
-                                                </div>
-                                            }.into_any()
-                                        } else {
-                                            view! { <span /> }.into_any()
-                                        }}
-                                    </div>
-                                }.into_any()
-                            }
+                // ── Detail panel ─────────────────────────────────────────
+                <div class="history-detail">
+                    <Show
+                        when=move || selected_episode().is_some()
+                        fallback=|| view! {
+                            <div class="history-detail-empty">
+                                "Select an episode to view details"
+                            </div>
                         }
-                    }}
+                    >
+                        {move || selected_episode().map(|ep| view! {
+                            <EpisodeDetail episode=ep />
+                        })}
+                    </Show>
                 </div>
             </div>
         </div>
+    }
+}
+
+// ── Episode row (list item) ─────────────────────────────────────────────────
+
+#[component]
+fn EpisodeRow(
+    episode: Episode,
+    selected: impl Fn() -> bool + Send + Sync + 'static,
+    on_select: impl Fn() + 'static,
+) -> impl IntoView {
+    let outcome_class = match episode.outcome.as_str() {
+        "success" => "history-outcome success",
+        "failure" => "history-outcome failure",
+        "rejected" => "history-outcome rejected",
+        _ => "history-outcome",
+    };
+    let outcome_label = match episode.outcome.as_str() {
+        "success" => "✓",
+        "failure" => "✗",
+        "rejected" => "⊘",
+        _ => "?",
+    };
+    let action_label = episode
+        .action_type
+        .trim_start_matches("schema:")
+        .to_string();
+    let display_query = episode
+        .query
+        .clone()
+        .or_else(|| episode.intent_summary.clone())
+        .unwrap_or_else(|| format!("{} via {}", action_label, episode.agent_name));
+
+    // Truncate display query for the list
+    let short_query = if display_query.len() > 80 {
+        format!("{}…", &display_query[..77])
+    } else {
+        display_query.clone()
+    };
+
+    // Format timestamp to be readable: drop the T, keep date + time (no subseconds)
+    let ts = episode
+        .recorded_at
+        .replace('T', " ")
+        .split('.')
+        .next()
+        .unwrap_or(&episode.recorded_at)
+        .to_string();
+    let short_ts = ts.chars().take(16).collect::<String>(); // "YYYY-MM-DD HH:MM"
+
+    let duration_s = if episode.duration_ms > 0 {
+        if episode.duration_ms >= 1000 {
+            format!("{:.1}s", episode.duration_ms as f64 / 1000.0)
+        } else {
+            format!("{}ms", episode.duration_ms)
+        }
+    } else {
+        String::new()
+    };
+
+    view! {
+        <div
+            class=move || if selected() { "history-row selected" } else { "history-row" }
+            on:click=move |_| on_select()
+        >
+            <span class=outcome_class title=episode.outcome.clone()>
+                {outcome_label}
+            </span>
+            <div class="history-row-body">
+                <div class="history-row-query">{short_query}</div>
+                <div class="history-row-meta">
+                    <span class="history-row-agent">{episode.agent_name.clone()}</span>
+                    <span class="history-row-sep">"·"</span>
+                    <span class="history-row-action">{action_label}</span>
+                    {if !duration_s.is_empty() {
+                        view! {
+                            <span class="history-row-sep">"·"</span>
+                            <span class="history-row-duration">{duration_s}</span>
+                        }.into_any()
+                    } else {
+                        view! { <span /> }.into_any()
+                    }}
+                </div>
+            </div>
+            <span class="history-row-ts">{short_ts}</span>
+        </div>
+    }
+}
+
+// ── Episode detail panel ────────────────────────────────────────────────────
+
+#[component]
+fn EpisodeDetail(episode: Episode) -> impl IntoView {
+    // Pre-compute all derived strings BEFORE view! so nothing is borrowed inside the macro.
+    let action_label = episode
+        .action_type
+        .trim_start_matches("schema:")
+        .to_string();
+
+    let outcome_class: &'static str = match episode.outcome.as_str() {
+        "success" => "history-detail-outcome success",
+        "failure" => "history-detail-outcome failure",
+        "rejected" => "history-detail-outcome rejected",
+        _ => "history-detail-outcome",
+    };
+    let outcome_text: &'static str = match episode.outcome.as_str() {
+        "success" => "\u{2713} SUCCESS",
+        "failure" => "\u{2717} FAILED",
+        _ => "\u{2298} REJECTED",
+    };
+
+    let disclosure_refs: Vec<String> =
+        serde_json::from_str(&episode.disclosure_refs).unwrap_or_default();
+    let has_refs = !disclosure_refs.is_empty();
+    // StoredValue lets the For-each closure be Fn (callable multiple times) without moving.
+    let refs_stored = StoredValue::new(disclosure_refs);
+
+    let ts = {
+        let base = episode.recorded_at.replace('T', " ");
+        base.split('.').next().unwrap_or("").to_string()
+    };
+
+    let duration_label = if episode.duration_ms > 0 {
+        if episode.duration_ms >= 1000 {
+            format!("{:.2}s", episode.duration_ms as f64 / 1000.0)
+        } else {
+            format!("{} ms", episode.duration_ms)
+        }
+    } else {
+        "\u{2014}".to_string()
+    };
+
+    let (decay_text, decay_cls): (&'static str, &'static str) =
+        match episode.decay_state.as_str() {
+            "active" => ("ACTIVE", "decay-active"),
+            "degraded" => ("DEGRADED", "decay-degraded"),
+            "readonly" => ("READ-ONLY", "decay-readonly"),
+            "suspended" => ("SUSPENDED", "decay-suspended"),
+            _ => ("UNKNOWN", "decay-unknown"),
+        };
+    let decay_span_class = format!("history-decay-badge {decay_cls}");
+
+    // Optional text fields — owned Strings
+    let query_text: Option<String> = episode.query.clone();
+    let intent_text: Option<String> = if episode.query.is_none() {
+        episode.intent_summary.clone()
+    } else {
+        None
+    };
+    let outcome_detail_text: Option<String> = episode.outcome_detail.clone();
+    let result_preview: Option<String> = episode
+        .result_json
+        .as_deref()
+        .map(extract_result_preview);
+
+    let agent_name = episode.agent_name.clone();
+    let session_id = episode.receipt_session_id.clone();
+
+    view! {
+        <div class="history-detail-card">
+            // ── Title ──────────────────────────────────────────────────
+            <div class="history-detail-header">
+                <span class=outcome_class>{outcome_text}</span>
+                <span class=decay_span_class>{decay_text}</span>
+            </div>
+
+            // ── User query ─────────────────────────────────────────────
+            {query_text.map(|q| view! {
+                <div class="history-detail-section">
+                    <div class="history-detail-label">"YOUR QUERY"</div>
+                    <div class="history-detail-query">{q}</div>
+                </div>
+            })}
+
+            {intent_text.map(|s| view! {
+                <div class="history-detail-section">
+                    <div class="history-detail-label">"INTENT"</div>
+                    <div class="history-detail-query">{s}</div>
+                </div>
+            })}
+
+            // ── Agent + action ─────────────────────────────────────────
+            <div class="history-detail-grid">
+                <div class="history-detail-field">
+                    <div class="history-detail-label">"AGENT"</div>
+                    <div class="history-detail-value">{agent_name}</div>
+                </div>
+                <div class="history-detail-field">
+                    <div class="history-detail-label">"ACTION"</div>
+                    <div class="history-detail-value">{action_label}</div>
+                </div>
+                <div class="history-detail-field">
+                    <div class="history-detail-label">"DURATION"</div>
+                    <div class="history-detail-value mono">{duration_label}</div>
+                </div>
+                <div class="history-detail-field">
+                    <div class="history-detail-label">"RECORDED"</div>
+                    <div class="history-detail-value mono">{ts}</div>
+                </div>
+            </div>
+
+            // ── Disclosed properties ───────────────────────────────────
+            <Show when=move || has_refs>
+                <div class="history-detail-section">
+                    <div class="history-detail-label">"DISCLOSED TO AGENT"</div>
+                    <div class="history-detail-tags">
+                        <For
+                            each=move || refs_stored.get_value()
+                            key=|p| p.clone()
+                            children=|prop| view! {
+                                <span class="history-tag disclosed">{prop}</span>
+                            }
+                        />
+                    </div>
+                </div>
+            </Show>
+
+            // ── Outcome detail ─────────────────────────────────────────
+            {outcome_detail_text.map(|d| view! {
+                <div class="history-detail-section">
+                    <div class="history-detail-label">"DETAIL"</div>
+                    <div class="history-detail-note">{d}</div>
+                </div>
+            })}
+
+            // ── Result preview ─────────────────────────────────────────
+            {result_preview.map(|preview| view! {
+                <div class="history-detail-section">
+                    <div class="history-detail-label">"RESULT PREVIEW"</div>
+                    <div class="history-detail-result">{preview}</div>
+                </div>
+            })}
+
+            // ── Session ID ─────────────────────────────────────────────
+            <div class="history-detail-section">
+                <div class="history-detail-label">"SESSION ID"</div>
+                <div class="history-detail-value mono small">{session_id}</div>
+            </div>
+        </div>
+    }
+}
+
+// ── Helper: extract readable text from JSON-LD result ──────────────────────
+
+fn extract_result_preview(json: &str) -> String {
+    let Ok(v) = serde_json::from_str::<serde_json::Value>(json) else {
+        return json.chars().take(200).collect();
+    };
+
+    // Try common schema.org text fields in priority order
+    for key in &["description", "text", "articleBody", "headline", "name"] {
+        if let Some(s) = v.get(key).and_then(|x| x.as_str()) {
+            let trimmed = s.trim();
+            if !trimmed.is_empty() {
+                return if trimmed.len() > 280 {
+                    format!("{}…", &trimmed[..277])
+                } else {
+                    trimmed.to_string()
+                };
+            }
+        }
+    }
+    // Fallback: pretty-print first 280 chars
+    let pretty = serde_json::to_string_pretty(&v).unwrap_or_default();
+    if pretty.len() > 280 {
+        format!("{}…", &pretty[..277])
+    } else {
+        pretty
     }
 }

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -4822,3 +4822,389 @@ body {
     white-space: nowrap;
     flex-shrink: 0;
 }
+
+/* ═══════════════════════════════════════════════════════════════════
+   CHRYSALIS NETWORK PAGE  (dashboard.rs → /fleet route)
+   ═══════════════════════════════════════════════════════════════════ */
+
+/* ── Page shell ──────────────────────────────────────────────────── */
+.chrysalis-page {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    height: 100%;
+    overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────────────────────── */
+.chrysalis-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--sp-md) var(--sp-lg);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    flex-shrink: 0;
+}
+.chrysalis-header-left {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+}
+.chrysalis-header-icon {
+    width: 36px;
+    height: 36px;
+    background: var(--purple-muted);
+    border-radius: var(--r-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--purple);
+    flex-shrink: 0;
+}
+.chrysalis-header-title {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--text-1);
+}
+.chrysalis-header-subtitle {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-3);
+    margin-top: 1px;
+}
+.chrysalis-header-right {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+}
+.chrysalis-node-address {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--teal);
+    background: rgba(46,196,160,0.1);
+    border: 1px solid rgba(46,196,160,0.2);
+    border-radius: var(--r-sm);
+    padding: 3px 8px;
+    letter-spacing: 0.04em;
+}
+
+/* ── Body: two-column layout ─────────────────────────────────────── */
+.chrysalis-body {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 0;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+}
+
+/* ── Left: node/registry list ─────────────────────────────────────── */
+.chrysalis-nodes {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    padding: var(--sp-md) var(--sp-lg);
+    overflow-y: auto;
+    border-right: 1px solid rgba(255,255,255,0.06);
+}
+.chrysalis-section-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--text-3);
+    text-transform: uppercase;
+    margin-bottom: var(--sp-sm);
+    padding-bottom: var(--sp-xs);
+    border-bottom: 1px solid rgba(255,255,255,0.05);
+}
+
+/* ── Node row ─────────────────────────────────────────────────────── */
+.chrysalis-node-row {
+    display: grid;
+    grid-template-columns: 10px 1fr auto auto;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm);
+    border-radius: var(--r-md);
+    margin-bottom: 2px;
+    transition: background 0.15s;
+}
+.chrysalis-node-row:hover { background: rgba(255,255,255,0.03); }
+.chrysalis-node-row.local {
+    background: rgba(108,92,231,0.05);
+    border: 1px solid rgba(108,92,231,0.12);
+}
+.chrysalis-node-row.local:hover { background: rgba(108,92,231,0.08); }
+
+/* Status dot */
+.chrysalis-node-dot {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+.chrysalis-node-dot.local {
+    background: var(--teal);
+    box-shadow: 0 0 6px rgba(46,196,160,0.5);
+}
+.chrysalis-node-dot.remote { background: var(--gold); }
+
+/* Node info */
+.chrysalis-node-info {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xs);
+    min-width: 0;
+}
+.chrysalis-node-url {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.chrysalis-node-tag {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 700;
+    letter-spacing: 0.1em;
+    padding: 1px 5px;
+    border-radius: 3px;
+    flex-shrink: 0;
+}
+.chrysalis-node-tag.local {
+    background: rgba(108,92,231,0.2);
+    color: var(--purple);
+    border: 1px solid rgba(108,92,231,0.3);
+}
+.chrysalis-node-tag.remote {
+    background: rgba(240,160,48,0.12);
+    color: var(--gold);
+    border: 1px solid rgba(240,160,48,0.2);
+}
+.chrysalis-node-meta {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-3);
+    white-space: nowrap;
+}
+.chrysalis-node-action {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    color: var(--purple);
+    text-decoration: none;
+    padding: 3px 8px;
+    border: 1px solid rgba(108,92,231,0.3);
+    border-radius: var(--r-sm);
+    white-space: nowrap;
+    transition: background 0.15s, color 0.15s;
+}
+.chrysalis-node-action:hover {
+    background: var(--purple-muted);
+    color: var(--purple-hover);
+}
+
+/* ── Connect form ─────────────────────────────────────────────────── */
+.chrysalis-connect {
+    margin-top: var(--sp-md);
+    padding-top: var(--sp-md);
+    border-top: 1px solid rgba(255,255,255,0.05);
+}
+.chrysalis-connect-label {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--text-3);
+    margin-bottom: var(--sp-xs);
+}
+.chrysalis-connect-row {
+    display: flex;
+    gap: var(--sp-xs);
+}
+.chrysalis-connect-input {
+    flex: 1;
+    background: var(--bg-3);
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: var(--r-sm);
+    padding: 6px 10px;
+    font-family: var(--font-mono);
+    font-size: 12px;
+    color: var(--text-1);
+    outline: none;
+    transition: border-color 0.15s;
+}
+.chrysalis-connect-input:focus {
+    border-color: var(--purple);
+    box-shadow: 0 0 0 2px var(--purple-glow);
+}
+.chrysalis-connect-input::placeholder { color: var(--text-3); }
+.chrysalis-connect-btn {
+    background: var(--purple);
+    color: #fff;
+    border: none;
+    border-radius: var(--r-sm);
+    padding: 6px 14px;
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    cursor: pointer;
+    white-space: nowrap;
+    transition: background 0.15s;
+}
+.chrysalis-connect-btn:hover:not(:disabled) { background: var(--purple-hover); }
+.chrysalis-connect-btn:disabled { opacity: 0.5; cursor: default; }
+.chrysalis-connect-error {
+    margin-top: var(--sp-xs);
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--coral);
+    background: rgba(232,112,106,0.08);
+    border: 1px solid rgba(232,112,106,0.2);
+    border-radius: var(--r-sm);
+    padding: 5px 10px;
+}
+
+/* ── Right: Identity panel ────────────────────────────────────────── */
+.chrysalis-identity { padding: var(--sp-md); overflow-y: auto; }
+.chrysalis-panel {
+    border: 1px solid rgba(255,255,255,0.08);
+    border-radius: var(--r-md);
+    overflow: hidden;
+}
+.chrysalis-panel-header {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-xs);
+    padding: var(--sp-sm) var(--sp-md);
+    background: rgba(255,255,255,0.03);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--text-3);
+}
+.chrysalis-panel-body { padding: var(--sp-sm) var(--sp-md); }
+.chrysalis-panel-empty {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-3);
+    padding: var(--sp-sm) 0;
+}
+.chrysalis-identity-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--sp-xs);
+    padding: var(--sp-xs) 0;
+    border-bottom: 1px solid rgba(255,255,255,0.04);
+}
+.chrysalis-identity-row:last-child { border-bottom: none; }
+.chrysalis-identity-row.col { flex-direction: column; gap: 4px; }
+.chrysalis-identity-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.1em;
+    color: var(--text-3);
+    min-width: 56px;
+    padding-top: 1px;
+    flex-shrink: 0;
+}
+.chrysalis-identity-value {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--text-1);
+    word-break: break-all;
+}
+.chrysalis-identity-value.mono { color: var(--purple); }
+.chrysalis-identity-addr {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    color: var(--teal);
+    background: rgba(46,196,160,0.07);
+    border: 1px solid rgba(46,196,160,0.15);
+    border-radius: var(--r-sm);
+    padding: 2px 7px;
+    width: 100%;
+    box-sizing: border-box;
+}
+
+/* ── Agent roster (collapsible bottom section) ───────────────────── */
+.chrysalis-agents {
+    flex-shrink: 0;
+    border-top: 1px solid rgba(255,255,255,0.06);
+    background: var(--bg-1);
+}
+.chrysalis-agents-toggle {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) var(--sp-lg);
+    cursor: pointer;
+    user-select: none;
+    transition: background 0.15s;
+}
+.chrysalis-agents-toggle:hover { background: rgba(255,255,255,0.02); }
+.chrysalis-agents-title {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--text-2);
+    flex: 1;
+}
+.chrysalis-agents-pills { display: flex; gap: var(--sp-xs); }
+.chrysalis-pill {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    padding: 2px 7px;
+    border-radius: 10px;
+}
+.chrysalis-pill.compiled {
+    background: rgba(108,92,231,0.15);
+    color: var(--purple);
+    border: 1px solid rgba(108,92,231,0.25);
+}
+.chrysalis-pill.catalog {
+    background: rgba(46,196,160,0.1);
+    color: var(--teal);
+    border: 1px solid rgba(46,196,160,0.2);
+}
+.chrysalis-agents-caret {
+    font-size: 10px;
+    color: var(--text-3);
+    margin-left: var(--sp-xs);
+}
+.chrysalis-agents-body {
+    padding: var(--sp-md) var(--sp-lg);
+    max-height: 50vh;
+    overflow-y: auto;
+}
+.chrysalis-agents-group {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--text-3);
+    margin: var(--sp-sm) 0 var(--sp-xs);
+}
+.chrysalis-catalog-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    margin-top: var(--sp-md);
+    padding: var(--sp-xs) 0;
+    cursor: pointer;
+    border-top: 1px solid rgba(255,255,255,0.05);
+}
+.chrysalis-catalog-bar:hover { opacity: 0.8; }

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -5208,3 +5208,330 @@ body {
     border-top: 1px solid rgba(255,255,255,0.05);
 }
 .chrysalis-catalog-bar:hover { opacity: 0.8; }
+
+/* ═══════════════════════════════════════════════════════════════════
+   EPISODE HISTORY PAGE  (receipts.rs → /receipts route)
+   ═══════════════════════════════════════════════════════════════════ */
+
+.history-page {
+    display: flex;
+    flex-direction: column;
+    height: 100%;
+    overflow: hidden;
+}
+
+/* ── Header ──────────────────────────────────────────────────────── */
+.history-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: var(--sp-md) var(--sp-lg);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    flex-shrink: 0;
+}
+.history-header-left { display: flex; align-items: center; gap: var(--sp-sm); }
+.history-header-icon {
+    width: 34px;
+    height: 34px;
+    background: rgba(46,196,160,0.1);
+    border-radius: var(--r-md);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: var(--teal);
+    flex-shrink: 0;
+}
+.history-title {
+    font-family: var(--font-mono);
+    font-size: 13px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    color: var(--text-1);
+}
+.history-subtitle {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-3);
+    margin-top: 1px;
+}
+.history-header-right { display: flex; align-items: center; gap: var(--sp-xs); }
+.history-stat-badge {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.06em;
+    padding: 3px 8px;
+    border-radius: 10px;
+    background: rgba(255,255,255,0.06);
+    color: var(--text-2);
+    border: 1px solid rgba(255,255,255,0.08);
+}
+.history-stat-badge.success {
+    background: rgba(46,196,160,0.1);
+    color: var(--teal);
+    border-color: rgba(46,196,160,0.2);
+}
+
+/* ── Search bar ──────────────────────────────────────────────────── */
+.history-search-bar {
+    display: flex;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) var(--sp-lg);
+    border-bottom: 1px solid rgba(255,255,255,0.06);
+    flex-shrink: 0;
+}
+.history-search-icon { color: var(--text-3); flex-shrink: 0; }
+.history-search-input {
+    flex: 1;
+    background: transparent;
+    border: none;
+    outline: none;
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-1);
+}
+.history-search-input::placeholder { color: var(--text-3); }
+.history-search-count {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-3);
+    white-space: nowrap;
+}
+
+/* ── Body: master-detail split ───────────────────────────────────── */
+.history-body {
+    display: grid;
+    grid-template-columns: 380px 1fr;
+    flex: 1;
+    min-height: 0;
+    overflow: hidden;
+}
+
+/* ── Episode list (left) ─────────────────────────────────────────── */
+.history-list {
+    border-right: 1px solid rgba(255,255,255,0.06);
+    overflow-y: auto;
+    padding: var(--sp-xs) 0;
+}
+.history-loading {
+    padding: var(--sp-lg);
+    text-align: center;
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-3);
+}
+.history-empty {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    padding: var(--sp-2xl) var(--sp-lg);
+    text-align: center;
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-3);
+    line-height: 1.5;
+}
+
+/* ── Episode row ─────────────────────────────────────────────────── */
+.history-row {
+    display: flex;
+    align-items: flex-start;
+    gap: var(--sp-sm);
+    padding: var(--sp-sm) var(--sp-md);
+    cursor: pointer;
+    transition: background 0.12s;
+    border-bottom: 1px solid rgba(255,255,255,0.03);
+}
+.history-row:hover { background: rgba(255,255,255,0.03); }
+.history-row.selected { background: rgba(108,92,231,0.08); }
+
+.history-outcome {
+    font-family: var(--font-mono);
+    font-size: 12px;
+    font-weight: 700;
+    width: 16px;
+    text-align: center;
+    flex-shrink: 0;
+    margin-top: 2px;
+}
+.history-outcome.success { color: var(--teal); }
+.history-outcome.failure { color: var(--coral); }
+.history-outcome.rejected { color: var(--gold); }
+
+.history-row-body {
+    flex: 1;
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 2px;
+}
+.history-row-query {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-1);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    line-height: 1.4;
+}
+.history-row-meta {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-family: var(--font-body);
+    font-size: 11px;
+    color: var(--text-3);
+}
+.history-row-agent { color: var(--purple); }
+.history-row-sep { opacity: 0.4; }
+.history-row-action { color: var(--text-3); }
+.history-row-duration { color: var(--text-3); font-family: var(--font-mono); font-size: 10px; }
+.history-row-ts {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    color: var(--text-3);
+    white-space: nowrap;
+    flex-shrink: 0;
+    margin-top: 3px;
+}
+
+/* ── Detail panel (right) ────────────────────────────────────────── */
+.history-detail {
+    overflow-y: auto;
+    padding: var(--sp-md);
+}
+.history-detail-empty {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    height: 100%;
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-3);
+}
+
+/* ── Detail card ─────────────────────────────────────────────────── */
+.history-detail-card {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-md);
+    max-width: 640px;
+}
+.history-detail-header { display: flex; align-items: center; gap: var(--sp-sm); }
+
+.history-detail-outcome {
+    font-family: var(--font-mono);
+    font-size: 11px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    padding: 3px 10px;
+    border-radius: var(--r-sm);
+}
+.history-detail-outcome.success {
+    background: rgba(46,196,160,0.12);
+    color: var(--teal);
+    border: 1px solid rgba(46,196,160,0.25);
+}
+.history-detail-outcome.failure {
+    background: rgba(232,112,106,0.12);
+    color: var(--coral);
+    border: 1px solid rgba(232,112,106,0.25);
+}
+.history-detail-outcome.rejected {
+    background: rgba(240,160,48,0.12);
+    color: var(--gold);
+    border: 1px solid rgba(240,160,48,0.25);
+}
+
+.history-decay-badge {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    padding: 2px 7px;
+    border-radius: var(--r-sm);
+}
+.decay-active { background: rgba(46,196,160,0.1); color: var(--teal); border: 1px solid rgba(46,196,160,0.2); }
+.decay-degraded { background: rgba(240,160,48,0.1); color: var(--gold); border: 1px solid rgba(240,160,48,0.2); }
+.decay-readonly { background: rgba(255,255,255,0.06); color: var(--text-3); border: 1px solid rgba(255,255,255,0.1); }
+.decay-suspended { background: rgba(232,112,106,0.1); color: var(--coral); border: 1px solid rgba(232,112,106,0.2); }
+.decay-unknown { background: rgba(255,255,255,0.04); color: var(--text-3); border: 1px solid rgba(255,255,255,0.08); }
+
+.history-detail-section { display: flex; flex-direction: column; gap: 4px; }
+.history-detail-label {
+    font-family: var(--font-mono);
+    font-size: 9px;
+    font-weight: 600;
+    letter-spacing: 0.12em;
+    color: var(--text-3);
+    text-transform: uppercase;
+}
+.history-detail-query {
+    font-family: var(--font-body);
+    font-size: 14px;
+    color: var(--text-1);
+    line-height: 1.5;
+    padding: var(--sp-sm);
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: var(--r-sm);
+}
+.history-detail-value {
+    font-family: var(--font-body);
+    font-size: 13px;
+    color: var(--text-1);
+}
+.history-detail-value.mono { font-family: var(--font-mono); font-size: 12px; color: var(--text-2); }
+.history-detail-value.small { font-size: 10px; color: var(--text-3); word-break: break-all; }
+.history-detail-note {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--coral);
+    background: rgba(232,112,106,0.06);
+    border: 1px solid rgba(232,112,106,0.15);
+    border-radius: var(--r-sm);
+    padding: var(--sp-xs) var(--sp-sm);
+}
+.history-detail-result {
+    font-family: var(--font-body);
+    font-size: 12px;
+    color: var(--text-2);
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+    max-height: 200px;
+    overflow-y: auto;
+    padding: var(--sp-sm);
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.06);
+    border-radius: var(--r-sm);
+    scrollbar-width: thin;
+}
+.history-detail-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--sp-sm);
+}
+.history-detail-field {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    padding: var(--sp-sm);
+    background: rgba(255,255,255,0.02);
+    border: 1px solid rgba(255,255,255,0.05);
+    border-radius: var(--r-sm);
+}
+.history-detail-tags { display: flex; flex-wrap: wrap; gap: 4px; }
+.history-tag {
+    font-family: var(--font-mono);
+    font-size: 10px;
+    padding: 2px 6px;
+    border-radius: 3px;
+}
+.history-tag.disclosed {
+    background: rgba(108,92,231,0.12);
+    color: var(--purple);
+    border: 1px solid rgba(108,92,231,0.2);
+}


### PR DESCRIPTION
## Summary

The `/fleet` page was presenting an "AGENT FLEET" roster with confusing "4 ACTIVE / 311 TOTAL" count badges that didn't reflect the real distinction (compiled vs catalog agents) and gave users no way to act on the information. The primary user need on this page is **connecting to and discovering federated Chrysalis nodes** — not reading agent counts.

- Replaces the `fleet-*` header and body with a new `chrysalis-page` layout
- **CHRYSALIS NETWORK** header shows this node's live pap:// LAN address badge
- **NETWORK NODES** panel lists `pap://local` (always first, teal live-dot, agent/peer counts, `BROWSE →` link) plus any bookmarked remote Chrysalis nodes
- **Connect form** — pap:// URL input calls `navigate_registry` → `add_bookmark`; errors surface inline
- **THIS NODE** right-panel shows the DID, port, and LAN addresses for easy sharing
- **AGENT ROSTER** moves to a collapsible bottom section — still fully accessible but no longer the page's primary focus; agents are organized as "compiled" grid + "catalog" nested collapse (reusing existing `fleet-catalog-*` and `agent-card` CSS)

## Test plan

- [ ] `/fleet` page loads without error; header shows "CHRYSALIS NETWORK"
- [ ] `pap://local` row always present with teal dot, LOCAL badge, agent count, `BROWSE →` link
- [ ] `BROWSE →` navigates to `/browse` registry page
- [ ] Connect form: typing a `pap://` URL and pressing CONNECT calls `navigate_registry`; error message appears on failure
- [ ] THIS NODE panel shows DID, port, and LAN address when running in Tauri desktop
- [ ] AGENT ROSTER section is collapsed by default; expands to show compiled + catalog agents
- [ ] Catalog agents sub-section collapses/expands with its toggle

🤖 Generated with [Claude Code](https://claude.com/claude-code)