### PR TITLE
feat(docs): add Get PAP consulting page and update site nav

### DIFF
--- a/apps/papillon/src/commands/orchestrator.rs
+++ b/apps/papillon/src/commands/orchestrator.rs
@@ -232,11 +232,7 @@ pub async fn download_builtin_model(
         let app_ref = app.clone();
         let mid: std::sync::Arc<str> = model_id.as_str().into();
         crate::inference::download_file(&info.tokenizer_url, &tokenizer_path, move |dl, total| {
-            let pct = if total > 0 {
-                std::cmp::min((dl * 100 / total) as u8, 100)
-            } else {
-                0
-            };
+            let pct = std::cmp::min((dl * 100).checked_div(total).unwrap_or(0) as u8, 100);
             let _ = app_ref.emit(
                 "model_download_progress",
                 ModelDownloadProgress {
@@ -258,11 +254,7 @@ pub async fn download_builtin_model(
         let app_ref = app.clone();
         let mid: std::sync::Arc<str> = model_id.as_str().into();
         crate::inference::download_file(&info.download_url, &model_path, move |dl, total| {
-            let pct = if total > 0 {
-                std::cmp::min((dl * 100 / total) as u8, 100)
-            } else {
-                0
-            };
+            let pct = std::cmp::min((dl * 100).checked_div(total).unwrap_or(0) as u8, 100);
             let _ = app_ref.emit(
                 "model_download_progress",
                 ModelDownloadProgress {

--- a/crates/pap-c/src/lib.rs
+++ b/crates/pap-c/src/lib.rs
@@ -536,13 +536,7 @@ pub extern "C" fn pap_scope_permits(scope: *const PapScope, action: *const c_cha
 #[no_mangle]
 pub extern "C" fn pap_scope_contains(parent: *const PapScope, child: *const PapScope) -> c_int {
     match (unsafe { parent.as_ref() }, unsafe { child.as_ref() }) {
-        (Some(p), Some(c)) => {
-            if p.inner.contains(&c.inner) {
-                1
-            } else {
-                0
-            }
-        }
+        (Some(p), Some(c)) if p.inner.contains(&c.inner) => 1,
         _ => 0,
     }
 }

--- a/docs/chrysalis.html
+++ b/docs/chrysalis.html
@@ -363,6 +363,8 @@
       <li><a href="pap/"><span class="nav-link-icon">pap://</span> PAP</a></li>
       <li><a href="papillon/"><img src="assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
       <li><a href="chrysalis.html" aria-current="page"><img src="assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
+      <li><a href="extension/">Extension</a></li>
+      <li><a href="get-pap.html">Work With Us</a></li>
     </ul>
     <div class="nav-cta">
       <a href="https://github.com/Baur-Software/pap" class="btn btn-outline" target="_blank" rel="noopener" aria-label="View on GitHub">

--- a/docs/extension/index.html
+++ b/docs/extension/index.html
@@ -466,6 +466,8 @@
           <a href="https://github.com/Baur-Software/pap/tree/main/docs/specification.md">PAP Specification</a>
           &middot;
           <a href="https://github.com/Baur-Software/pap/tree/main/apps/papillon-extension">Extension Source</a>
+          &middot;
+          <a href="../get-pap.html">Work With Us</a>
         </p>
       </footer>
     </div>

--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -1,0 +1,687 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Get PAP — Consulting &amp; Implementation by Baur Software</title>
+  <meta name="description" content="PAP is a protocol, not a product. Baur Software works with your team to evaluate, plan, and implement trust-first agentic infrastructure — alongside your existing stack." />
+  <meta property="og:title" content="Get PAP — Consulting &amp; Implementation" />
+  <meta property="og:description" content="PAP is a protocol, not a product. We evaluate your agentic infrastructure and deliver a full implementation with expert engineers and training." />
+  <meta property="og:type" content="website" />
+  <meta property="og:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="Get PAP — Consulting &amp; Implementation" />
+  <meta name="twitter:description" content="PAP is a protocol, not a product. Bring trust-first agentic infrastructure to your stack." />
+  <meta name="twitter:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,300;0,9..40,400;0,9..40,500;0,9..40,600;0,9..40,700;1,9..40,400&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet" />
+  <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400,500,700,900&display=swap" rel="stylesheet" />
+  <style>
+    *, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+    :root {
+      --bg:        #0c0b14;
+      --surface:   #151420;
+      --surface2:  #1f1e2e;
+      --border:    #2c2b40;
+      --border2:   #353455;
+      --indigo:    #6c5ce7;
+      --violet:    #8b7ff5;
+      --teal:      #2ec4a0;
+      --amber:     #f0a030;
+      --coral:     #e8706a;
+      --text:      #eeeef2;
+      --muted:     #9494a8;
+      --faint:     #6a6a80;
+      --radius:    8px;
+      --radius-lg: 12px;
+      scroll-behavior: smooth;
+    }
+    html { font-size: 16px; }
+    body {
+      font-family: 'DM Sans', -apple-system, sans-serif;
+      background: var(--bg);
+      color: var(--text);
+      line-height: 1.6;
+      overflow-x: hidden;
+    }
+    ::selection { background: rgba(108,92,231,.35); }
+    a { color: var(--indigo); text-decoration: none; }
+    a:hover { color: var(--violet); }
+    .container { max-width: 1100px; margin: 0 auto; padding: 0 24px; }
+    .section { padding: 96px 0; }
+    .section-sm { padding: 56px 0; }
+    .divider { height: 1px; background: var(--border); }
+    .gradient-text {
+      background: linear-gradient(135deg, var(--indigo), var(--violet));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .gh-icon { width: 18px; height: 18px; fill: currentColor; }
+
+    /* ─── Nav ─────────────────────────────────────────────────────────── */
+    nav {
+      position: fixed; top: 0; left: 0; right: 0; z-index: 100;
+      background: rgba(12,11,20,.85);
+      backdrop-filter: blur(16px) saturate(1.5);
+      border-bottom: 1px solid var(--border);
+    }
+    .nav-inner {
+      max-width: 1100px; margin: 0 auto; padding: 0 24px;
+      height: 64px; display: flex; align-items: center; justify-content: space-between;
+    }
+    .nav-logo {
+      display: flex; align-items: center; gap: 10px;
+      text-decoration: none; color: var(--text);
+    }
+    .nav-logo img { height: 32px; width: auto; }
+    .nav-wordmark {
+      font-family: 'Satoshi', sans-serif; font-weight: 700; font-size: 1.1rem;
+      letter-spacing: -.02em;
+    }
+    .nav-links {
+      display: flex; align-items: center; gap: 8px; list-style: none;
+    }
+    .nav-links a {
+      color: var(--muted); font-size: .9rem; font-weight: 500;
+      padding: 6px 12px; border-radius: var(--radius);
+      transition: all .15s ease;
+    }
+    .nav-links a:hover { color: var(--text); background: rgba(255,255,255,.05); }
+    .nav-links a[aria-current="page"] { color: var(--text); }
+    .nav-link-icon {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: .65rem; font-weight: 700;
+      background: linear-gradient(135deg, var(--indigo), var(--violet));
+      -webkit-background-clip: text; -webkit-text-fill-color: transparent;
+      background-clip: text;
+    }
+    .nav-link-icon-img { width: 18px; height: 18px; object-fit: contain; vertical-align: middle; }
+    .nav-cta { display: flex; align-items: center; gap: 10px; }
+    .btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 10px 20px; border-radius: var(--radius);
+      font-size: .9rem; font-weight: 600;
+      transition: all .15s ease; cursor: pointer; border: none;
+      font-family: 'DM Sans', sans-serif; text-decoration: none;
+    }
+    .btn-primary {
+      background: var(--indigo); color: #fff;
+    }
+    .btn-primary:hover {
+      background: #5b4bd6; color: #fff; transform: translateY(-1px);
+      box-shadow: 0 8px 24px rgba(108,92,231,.35);
+    }
+    .btn-outline {
+      background: transparent; color: var(--text);
+      border: 1px solid var(--border2);
+    }
+    .btn-outline:hover { border-color: var(--indigo); color: var(--indigo); transform: translateY(-1px); }
+    .btn-lg { padding: 14px 32px; font-size: 1rem; }
+    .btn-work-with-us {
+      background: linear-gradient(135deg, var(--indigo), var(--violet));
+      color: #fff; font-size: .85rem; padding: 8px 18px;
+    }
+    .btn-work-with-us:hover {
+      color: #fff; transform: translateY(-1px);
+      box-shadow: 0 6px 20px rgba(108,92,231,.4);
+    }
+    @media (max-width: 768px) { .nav-links { display: none; } }
+
+    /* ─── Hero ────────────────────────────────────────────────────────── */
+    #hero {
+      min-height: 80vh; display: flex; align-items: center;
+      position: relative; overflow: hidden; padding: 120px 0 80px;
+    }
+    .hero-bg {
+      position: absolute; inset: 0; pointer-events: none; overflow: hidden;
+    }
+    .hero-bg::before {
+      content: '';
+      position: absolute; top: -20%; left: 50%; transform: translateX(-50%);
+      width: 900px; height: 900px;
+      background: radial-gradient(ellipse at center,
+        rgba(108,92,231,.12) 0%, rgba(139,127,245,.06) 45%, transparent 70%);
+      animation: pulse-slow 8s ease-in-out infinite;
+    }
+    @keyframes pulse-slow {
+      0%, 100% { opacity: 1; transform: translateX(-50%) scale(1); }
+      50%       { opacity: .7; transform: translateX(-50%) scale(1.05); }
+    }
+    .hero-content {
+      position: relative; z-index: 1;
+      max-width: 760px;
+    }
+    .hero-eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      background: rgba(108,92,231,.1); border: 1px solid rgba(108,92,231,.2);
+      border-radius: 999px; padding: 5px 14px;
+      font-size: .78rem; font-weight: 600; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--violet);
+      margin-bottom: 28px;
+    }
+    .hero-eyebrow::before {
+      content: '';
+      width: 6px; height: 6px; border-radius: 50%;
+      background: var(--indigo);
+      animation: blink 2s ease-in-out infinite;
+    }
+    @keyframes blink {
+      0%, 100% { opacity: 1; } 50% { opacity: .3; }
+    }
+    #hero h1 {
+      font-family: 'Satoshi', sans-serif;
+      font-size: clamp(2.5rem, 5.5vw, 4rem);
+      font-weight: 900; line-height: 1.08;
+      letter-spacing: -.03em; margin-bottom: 24px;
+    }
+    #hero p.lead {
+      font-size: 1.15rem; color: var(--muted); line-height: 1.75;
+      max-width: 580px; margin-bottom: 40px;
+    }
+    .hero-cta {
+      display: flex; gap: 12px; flex-wrap: wrap;
+    }
+
+    /* ─── Reframe ─────────────────────────────────────────────────────── */
+    #reframe {
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      padding: 72px 0;
+    }
+    .reframe-inner {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 64px; align-items: center;
+    }
+    .reframe-headline {
+      font-family: 'Satoshi', sans-serif;
+      font-size: clamp(1.6rem, 3vw, 2.25rem);
+      font-weight: 800; letter-spacing: -.02em;
+      line-height: 1.2; margin-bottom: 20px;
+    }
+    .reframe-body {
+      color: var(--muted); font-size: 1rem; line-height: 1.8; margin-bottom: 16px;
+    }
+    .reframe-aside {
+      background: var(--surface2);
+      border: 1px solid var(--border);
+      border-left: 3px solid var(--indigo);
+      border-radius: var(--radius-lg);
+      padding: 28px 32px;
+    }
+    .reframe-aside blockquote {
+      font-family: 'Satoshi', sans-serif;
+      font-size: 1.2rem; font-weight: 600;
+      line-height: 1.5; color: var(--text);
+      font-style: italic;
+    }
+    .reframe-aside cite {
+      display: block; margin-top: 14px;
+      font-size: .82rem; color: var(--muted);
+      font-style: normal; font-family: 'JetBrains Mono', monospace;
+    }
+    @media (max-width: 768px) {
+      .reframe-inner { grid-template-columns: 1fr; gap: 40px; }
+    }
+
+    /* ─── Engagement Steps ───────────────────────────────────────────── */
+    #engagement { padding: 96px 0; }
+    .section-header { text-align: center; margin-bottom: 64px; }
+    .section-eyebrow {
+      display: inline-block;
+      font-size: .75rem; font-weight: 700; letter-spacing: .08em;
+      text-transform: uppercase; color: var(--indigo);
+      margin-bottom: 16px;
+    }
+    .section-title {
+      font-family: 'Satoshi', sans-serif;
+      font-size: clamp(1.75rem, 3.5vw, 2.5rem);
+      font-weight: 800; letter-spacing: -.025em;
+      line-height: 1.15; margin-bottom: 16px;
+    }
+    .section-sub {
+      font-size: 1.05rem; color: var(--muted);
+      max-width: 520px; margin: 0 auto; line-height: 1.7;
+    }
+
+    /* Step cards layout */
+    .steps-grid {
+      display: grid;
+      grid-template-columns: repeat(3, 1fr);
+      gap: 24px;
+    }
+    .step-card {
+      background: var(--surface);
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      padding: 32px 28px;
+      position: relative;
+      transition: all .25s ease;
+    }
+    .step-card::before {
+      content: ''; position: absolute; top: 0; left: 0; right: 0;
+      height: 2px; border-radius: var(--radius-lg) var(--radius-lg) 0 0;
+      background: linear-gradient(90deg, var(--indigo), var(--violet));
+      opacity: 0; transition: opacity .25s;
+    }
+    .step-card:hover {
+      border-color: var(--border2);
+      background: var(--surface2);
+      transform: translateY(-4px);
+      box-shadow: 0 16px 48px rgba(0,0,0,.4);
+    }
+    .step-card:hover::before { opacity: 1; }
+    .step-number {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: .7rem; font-weight: 700; letter-spacing: .06em;
+      color: var(--indigo); margin-bottom: 16px;
+      display: flex; align-items: center; gap: 8px;
+    }
+    .step-number::after {
+      content: '';
+      flex: 1; height: 1px; background: var(--border);
+    }
+    .step-icon {
+      width: 48px; height: 48px; border-radius: 12px;
+      display: flex; align-items: center; justify-content: center;
+      font-size: 1.5rem; margin-bottom: 16px;
+      background: rgba(108,92,231,.1); border: 1px solid rgba(108,92,231,.18);
+    }
+    .step-name {
+      font-family: 'Satoshi', sans-serif;
+      font-size: 1.1rem; font-weight: 700; letter-spacing: -.01em;
+      margin-bottom: 10px;
+    }
+    .step-desc {
+      font-size: .9rem; color: var(--muted); line-height: 1.7;
+    }
+    @media (max-width: 900px) {
+      .steps-grid { grid-template-columns: 1fr 1fr; }
+    }
+    @media (max-width: 600px) {
+      .steps-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ─── What's included ─────────────────────────────────────────────── */
+    #included {
+      background: var(--surface);
+      border-top: 1px solid var(--border);
+      border-bottom: 1px solid var(--border);
+      padding: 72px 0;
+    }
+    .included-grid {
+      display: grid; grid-template-columns: 1fr 1fr; gap: 48px; align-items: start;
+    }
+    .included-headline {
+      font-family: 'Satoshi', sans-serif;
+      font-size: clamp(1.5rem, 2.5vw, 2rem);
+      font-weight: 800; letter-spacing: -.02em; line-height: 1.2;
+      margin-bottom: 16px;
+    }
+    .included-sub {
+      color: var(--muted); font-size: .98rem; line-height: 1.75;
+    }
+    .included-list {
+      list-style: none; display: flex; flex-direction: column; gap: 14px;
+    }
+    .included-list li {
+      display: flex; align-items: flex-start; gap: 14px;
+      padding: 16px 20px;
+      background: var(--surface2); border: 1px solid var(--border);
+      border-radius: var(--radius); font-size: .9rem; line-height: 1.6;
+    }
+    .included-check {
+      width: 20px; height: 20px; border-radius: 50%;
+      background: rgba(108,92,231,.15); border: 1px solid rgba(108,92,231,.3);
+      display: flex; align-items: center; justify-content: center;
+      flex-shrink: 0; margin-top: 1px;
+      font-size: .65rem; color: var(--indigo);
+    }
+    .included-list strong { color: var(--text); }
+    .included-list span { color: var(--muted); }
+    @media (max-width: 768px) {
+      .included-grid { grid-template-columns: 1fr; }
+    }
+
+    /* ─── CTA ─────────────────────────────────────────────────────────── */
+    #cta {
+      padding: 96px 0;
+      text-align: center;
+      position: relative; overflow: hidden;
+    }
+    #cta::before {
+      content: '';
+      position: absolute; bottom: -20%; left: 50%; transform: translateX(-50%);
+      width: 700px; height: 700px;
+      background: radial-gradient(ellipse at center,
+        rgba(108,92,231,.08) 0%, transparent 65%);
+      pointer-events: none;
+    }
+    .cta-inner { position: relative; z-index: 1; max-width: 580px; margin: 0 auto; }
+    .cta-badge {
+      display: inline-flex; align-items: center; gap: 8px;
+      background: rgba(108,92,231,.1); border: 1px solid rgba(108,92,231,.25);
+      border-radius: 999px; padding: 5px 14px;
+      font-size: .75rem; font-weight: 700; letter-spacing: .06em;
+      text-transform: uppercase; color: var(--violet);
+      margin-bottom: 24px;
+    }
+    #cta h2 {
+      font-family: 'Satoshi', sans-serif;
+      font-size: clamp(1.8rem, 3.5vw, 2.75rem);
+      font-weight: 900; letter-spacing: -.03em;
+      line-height: 1.15; margin-bottom: 16px;
+    }
+    #cta p {
+      color: var(--muted); font-size: 1.05rem; line-height: 1.7;
+      margin-bottom: 36px;
+    }
+    .cta-buttons {
+      display: flex; gap: 12px; justify-content: center; flex-wrap: wrap;
+    }
+    .btn-cta-primary {
+      background: linear-gradient(135deg, var(--indigo) 0%, var(--violet) 100%);
+      color: #fff; padding: 14px 36px; font-size: 1rem;
+      border-radius: var(--radius); font-weight: 700;
+      box-shadow: 0 4px 20px rgba(108,92,231,.3);
+      transition: all .2s ease; text-decoration: none;
+      display: inline-flex; align-items: center; gap: 8px;
+    }
+    .btn-cta-primary:hover {
+      color: #fff; transform: translateY(-2px);
+      box-shadow: 0 10px 32px rgba(108,92,231,.45);
+    }
+    .cta-reassurance {
+      margin-top: 28px; font-size: .82rem; color: var(--faint);
+      display: flex; align-items: center; justify-content: center; gap: 16px;
+      flex-wrap: wrap;
+    }
+    .cta-reassurance span { display: flex; align-items: center; gap: 5px; }
+
+    /* ─── Footer ──────────────────────────────────────────────────────── */
+    footer {
+      border-top: 1px solid var(--border);
+      padding: 32px 0;
+    }
+    .footer-inner {
+      display: flex; align-items: center; justify-content: space-between;
+      font-size: .8rem; color: var(--faint);
+    }
+    .footer-links { display: flex; gap: 20px; }
+    .footer-links a { color: var(--faint); transition: color .15s; }
+    .footer-links a:hover { color: var(--muted); }
+
+    /* ─── Reveal ──────────────────────────────────────────────────────── */
+    .reveal {
+      opacity: 0; transform: translateY(20px);
+      transition: opacity .55s ease, transform .55s ease;
+    }
+    .reveal.visible { opacity: 1; transform: none; }
+    .reveal-delay-1 { transition-delay: .1s; }
+    .reveal-delay-2 { transition-delay: .2s; }
+    .reveal-delay-3 { transition-delay: .3s; }
+    .reveal-delay-4 { transition-delay: .4s; }
+    .reveal-delay-5 { transition-delay: .5s; }
+  </style>
+</head>
+<body>
+
+<!-- ─── NAV ──────────────────────────────────────────────────────────── -->
+<nav aria-label="Main navigation">
+  <div class="nav-inner">
+    <a href="index.html" class="nav-logo" aria-label="Baur Software">
+      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <span class="nav-wordmark">Baur Software</span>
+    </a>
+    <ul class="nav-links" role="list">
+      <li><a href="pap/"><span class="nav-link-icon">pap://</span> PAP</a></li>
+      <li><a href="papillon/"><img src="assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
+      <li><a href="chrysalis.html"><img src="assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
+      <li><a href="extension/">Extension</a></li>
+      <li><a href="get-pap.html" aria-current="page">Work With Us</a></li>
+    </ul>
+    <div class="nav-cta">
+      <a href="https://baursoftware.com/contact" class="btn btn-work-with-us" target="_blank" rel="noopener">
+        Start a Conversation &#8594;
+      </a>
+    </div>
+  </div>
+</nav>
+
+<!-- ─── HERO ──────────────────────────────────────────────────────────── -->
+<section id="hero" aria-label="Get PAP">
+  <div class="hero-bg" aria-hidden="true"></div>
+  <div class="container">
+    <div class="hero-content">
+      <div class="hero-eyebrow reveal">Consulting &amp; Implementation</div>
+      <h1 class="reveal reveal-delay-1">
+        PAP is a protocol.<br />
+        <span class="gradient-text">Getting it means building it right.</span>
+      </h1>
+      <p class="lead reveal reveal-delay-2">
+        You can't install PAP like a library and call it done. You need to reshape how your
+        infrastructure handles agent trust, data disclosure, and mandate scoping.
+        We're the team that does that with you.
+      </p>
+      <div class="hero-cta reveal reveal-delay-3">
+        <a href="https://baursoftware.com/contact" class="btn btn-primary btn-lg" target="_blank" rel="noopener">
+          Start a Conversation
+        </a>
+        <a href="pap/" class="btn btn-outline btn-lg">Read the Protocol</a>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── REFRAME ───────────────────────────────────────────────────────── -->
+<section id="reframe" aria-label="What PAP is and isn't">
+  <div class="container">
+    <div class="reframe-inner">
+      <div>
+        <h2 class="reframe-headline reveal">
+          Your agents are already running.<br />
+          <span class="gradient-text">Is anyone accountable for what they do?</span>
+        </h2>
+        <p class="reframe-body reveal reveal-delay-1">
+          Most agentic infrastructure today is built on trust assumptions borrowed from human-to-service
+          interactions. An agent calls an API, reads a database, writes a record — and no cryptographic
+          proof of what was authorized, what was disclosed, or who was responsible ever gets created.
+        </p>
+        <p class="reframe-body reveal reveal-delay-2">
+          PAP changes that. It doesn't replace your stack — it adds a trust layer below it.
+          Mandate-scoped delegation, ephemeral session DIDs, selective disclosure, and co-signed receipts
+          mean that every agent action is bounded, verifiable, and attributable to a human principal.
+        </p>
+      </div>
+      <div class="reframe-aside reveal reveal-delay-2">
+        <blockquote>
+          "PAP isn't something you install. It's something you architect. We work with your team from
+          day one — evaluating what you have, planning the transition, and delivering
+          implementations your engineers can understand and extend."
+        </blockquote>
+        <cite>— Baur Software Engineering Team</cite>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── ENGAGEMENT STEPS ──────────────────────────────────────────────── -->
+<section id="engagement" aria-label="Our engagement model">
+  <div class="container">
+    <div class="section-header">
+      <div class="section-eyebrow reveal">How We Work</div>
+      <h2 class="section-title reveal reveal-delay-1">Six phases. One destination.</h2>
+      <p class="section-sub reveal reveal-delay-2">
+        A structured engagement that takes you from your current agentic infrastructure
+        to a production-grade PAP deployment — without a rip-and-replace.
+      </p>
+    </div>
+
+    <div class="steps-grid">
+
+      <div class="step-card reveal">
+        <div class="step-number">01 / EVALUATE</div>
+        <div class="step-icon" aria-hidden="true">&#128270;</div>
+        <div class="step-name">Infrastructure Assessment</div>
+        <p class="step-desc">
+          We start by understanding what you have. Your current agent architecture, API surface,
+          data flows, and trust model are mapped so we know exactly where PAP fits and where
+          the gaps are.
+        </p>
+      </div>
+
+      <div class="step-card reveal reveal-delay-1">
+        <div class="step-number">02 / PLAN</div>
+        <div class="step-icon" aria-hidden="true">&#128196;</div>
+        <div class="step-name">Transition Roadmap</div>
+        <p class="step-desc">
+          We deliver a phased plan that introduces PAP alongside your existing infrastructure.
+          No big bang migrations. Your current systems keep running while the trust layer
+          is built beneath them.
+        </p>
+      </div>
+
+      <div class="step-card reveal reveal-delay-2">
+        <div class="step-number">03 / BUILD</div>
+        <div class="step-icon" aria-hidden="true">&#128736;</div>
+        <div class="step-name">Implementation &amp; Delivery</div>
+        <p class="step-desc">
+          Our developers and architects work directly in your codebase. We deliver
+          PAP integrations, implement the 6-phase handshake, and train your team
+          on what was built as we go.
+        </p>
+      </div>
+
+      <div class="step-card reveal reveal-delay-1">
+        <div class="step-number">04 / TRAIN</div>
+        <div class="step-icon" aria-hidden="true">&#127979;</div>
+        <div class="step-name">Staff Education</div>
+        <p class="step-desc">
+          We run hands-on training covering principal trust architecture, mandate scoping,
+          and agentic prompting. Your team won't just use PAP — they'll understand why
+          every design decision was made.
+        </p>
+      </div>
+
+      <div class="step-card reveal reveal-delay-2">
+        <div class="step-number">05 / REGISTRY</div>
+        <div class="step-icon" aria-hidden="true">&#128193;</div>
+        <div class="step-name">Chrysalis Setup</div>
+        <p class="step-desc">
+          We configure your Chrysalis registry for agent versioning, capability advertising,
+          and agentic workflow management. Agents become discoverable, verifiable assets
+          in a federated network you control.
+        </p>
+      </div>
+
+      <div class="step-card reveal reveal-delay-3">
+        <div class="step-number">06 / INTEGRATE</div>
+        <div class="step-icon" aria-hidden="true">&#127758;</div>
+        <div class="step-name">Papillon &amp; Stack Integration</div>
+        <p class="step-desc">
+          We deploy the Papillon browser, configure <code style="font-family:'JetBrains Mono',monospace;font-size:.85em;color:var(--violet)">pap://</code> URI resolution,
+          and rearchitect data stewardship across your stack — so humans remain in control
+          of every agent interaction from day one.
+        </p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<!-- ─── WHAT'S INCLUDED ───────────────────────────────────────────────── -->
+<section id="included" aria-label="What's included">
+  <div class="container">
+    <div class="included-grid">
+      <div>
+        <div class="section-eyebrow reveal">Every Engagement Includes</div>
+        <h2 class="included-headline reveal reveal-delay-1">
+          Not consulting advice.<br />
+          <span class="gradient-text">Working infrastructure.</span>
+        </h2>
+        <p class="included-sub reveal reveal-delay-2">
+          We don't hand you a report and leave. Every engagement ends with production-quality
+          implementation, trained staff, and infrastructure your team owns — not a dependency on us.
+        </p>
+      </div>
+      <ul class="included-list" aria-label="Included deliverables">
+        <li class="reveal">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>Agentic Infrastructure Audit</strong><br /><span>Full written assessment of current agent trust model, API surface, and disclosure scope with gap analysis.</span></div>
+        </li>
+        <li class="reveal reveal-delay-1">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>Phased Transition Plan</strong><br /><span>Milestone-based roadmap scoped to your team's velocity with zero forced disruption to live systems.</span></div>
+        </li>
+        <li class="reveal reveal-delay-2">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>PAP Reference Implementation</strong><br /><span>Working Rust or bindings-layer integration of the 6-phase handshake, SD-JWT disclosure, and co-signed receipts.</span></div>
+        </li>
+        <li class="reveal reveal-delay-3">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>Chrysalis Registry Deployment</strong><br /><span>Self-hosted or federated agent registry configured for your org's agents, with versioning and capability ads.</span></div>
+        </li>
+        <li class="reveal reveal-delay-4">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>Principal Trust Training</strong><br /><span>Live sessions for engineering and product staff on mandate scoping, data stewardship, and agentic prompting.</span></div>
+        </li>
+        <li class="reveal reveal-delay-5">
+          <span class="included-check" aria-hidden="true">&#10003;</span>
+          <div><strong>Papillon Stack Integration</strong><br /><span>Papillon browser deployment and <code style="font-family:'JetBrains Mono',monospace;font-size:.85em">pap://</code> resolution across your existing web and API stack.</span></div>
+        </li>
+      </ul>
+    </div>
+  </div>
+</section>
+
+<!-- ─── CTA ───────────────────────────────────────────────────────────── -->
+<section id="cta" aria-label="Contact us">
+  <div class="container">
+    <div class="cta-inner">
+      <div class="cta-badge reveal">&#128373; Let's Talk</div>
+      <h2 class="reveal reveal-delay-1">
+        Ready to build<br />
+        <span class="gradient-text">trust-first agentic infrastructure?</span>
+      </h2>
+      <p class="reveal reveal-delay-2">
+        Tell us about your current stack and where you want to go. We'll put together
+        a scoped engagement proposal within a few business days.
+      </p>
+      <div class="cta-buttons reveal reveal-delay-3">
+        <a href="https://baursoftware.com/contact" class="btn-cta-primary" target="_blank" rel="noopener">
+          Start a Conversation &#8594;
+        </a>
+      </div>
+      <div class="cta-reassurance reveal reveal-delay-4">
+        <span>&#128274; No commitment required</span>
+        <span>&#128203; Proposal within 3 business days</span>
+        <span>&#129309; Engagements are scoped to your team</span>
+      </div>
+    </div>
+  </div>
+</section>
+
+<!-- ─── FOOTER ────────────────────────────────────────────────────────── -->
+<footer aria-label="Site footer">
+  <div class="container">
+    <div class="footer-inner">
+      <div>&#169; 2026 Baur Software. Licensed MIT OR Apache-2.0.</div>
+      <div class="footer-links">
+        <a href="https://github.com/Baur-Software/pap" target="_blank" rel="noopener">GitHub</a>
+        <a href="https://github.com/Baur-Software/pap/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+        <a href="https://baursoftware.com/contact" target="_blank" rel="noopener">Contact</a>
+      </div>
+    </div>
+  </div>
+</footer>
+
+<script>
+  const obs = new IntersectionObserver((entries) => {
+    entries.forEach(e => {
+      if (e.isIntersecting) { e.target.classList.add('visible'); obs.unobserve(e.target); }
+    });
+  }, { threshold: 0.08, rootMargin: '0px 0px -30px 0px' });
+  document.querySelectorAll('.reveal').forEach(el => obs.observe(el));
+</script>
+</body>
+</html>

--- a/docs/index.html
+++ b/docs/index.html
@@ -242,6 +242,16 @@
       background: rgba(240,160,48,.1); color: var(--amber);
       border: 1px solid rgba(240,160,48,.2);
     }
+    .product-tag-consulting {
+      background: rgba(108,92,231,.1); color: var(--violet);
+      border: 1px solid rgba(108,92,231,.2);
+    }
+    .product-card-consulting::before {
+      background: linear-gradient(90deg, var(--indigo), var(--violet));
+    }
+    .product-icon-consulting {
+      background: rgba(108,92,231,.12); border: 1px solid rgba(108,92,231,.2);
+    }
     .product-desc {
       font-size: .9rem; color: var(--muted); line-height: 1.65; flex: 1;
     }
@@ -296,6 +306,7 @@
       <li><a href="papillon/"><img src="assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
       <li><a href="chrysalis.html"><img src="assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
       <li><a href="extension/">Extension</a></li>
+      <li><a href="get-pap.html">Work With Us</a></li>
     </ul>
     <div class="nav-cta">
       <a href="https://github.com/Baur-Software/pap" class="btn btn-outline" target="_blank" rel="noopener" aria-label="View on GitHub">
@@ -379,6 +390,17 @@
         <span class="product-link">Get the extension &#8594;</span>
       </a>
 
+      <a href="get-pap.html" class="product-card product-card-consulting reveal reveal-delay-4">
+        <div class="product-icon product-icon-consulting" aria-hidden="true">&#127881;</div>
+        <span class="product-tag product-tag-consulting">Consulting</span>
+        <div class="product-name">Work With Us</div>
+        <p class="product-desc">
+          PAP is a protocol, not a product you install. We work with your team to evaluate your
+          agentic infrastructure, plan the transition, deliver the implementation, and train your staff.
+        </p>
+        <span class="product-link">See how it works &#8594;</span>
+      </a>
+
     </div>
   </div>
 </section>
@@ -391,6 +413,7 @@
       <div class="footer-links">
         <a href="https://github.com/Baur-Software/pap" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/Baur-Software/pap/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener">Contributing</a>
+        <a href="https://baursoftware.com/contact" target="_blank" rel="noopener">Contact</a>
       </div>
     </div>
   </div>

--- a/docs/pap/index.html
+++ b/docs/pap/index.html
@@ -777,6 +777,8 @@
       <li><a href="./" aria-current="page"><span class="nav-link-icon">pap://</span> PAP</a></li>
       <li><a href="../papillon/"><img src="../assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
       <li><a href="../chrysalis.html"><img src="../assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
+      <li><a href="../extension/">Extension</a></li>
+      <li><a href="../get-pap.html">Work With Us</a></li>
     </ul>
     <div class="nav-cta">
       <a href="https://github.com/Baur-Software/pap" class="btn btn-outline" target="_blank" rel="noopener" aria-label="View on GitHub">

--- a/docs/papillon/index.html
+++ b/docs/papillon/index.html
@@ -571,6 +571,8 @@
       <li><a href="../pap/"><span class="nav-link-icon">pap://</span> PAP</a></li>
       <li><a href="./" aria-current="page"><img src="../assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
       <li><a href="../chrysalis.html"><img src="../assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
+      <li><a href="../extension/">Extension</a></li>
+      <li><a href="../get-pap.html">Work With Us</a></li>
     </ul>
     <div class="nav-cta">
       <a href="https://github.com/Baur-Software/pap" class="btn btn-outline" target="_blank" rel="noopener" aria-label="View on GitHub">


### PR DESCRIPTION
## Summary

- Adds `docs/get-pap.html` — a full consulting engagement landing page explaining how organisations bring PAP into their agentic stack via Baur Software
- Covers the six-phase engagement model (Evaluate → Plan → Build → Train → Registry → Integrate) with a primary CTA to `https://baursoftware.com/contact`
- Updates nav on all docs pages (`index`, `chrysalis`, `pap/`, `papillon/`, `extension/`) to surface a **Work With Us** link
- Adds a **Consulting** product card to `index.html` product grid
- Adds a **Contact** footer link to relevant pages

## Motivation

Responds to inbound LinkedIn interest ("how do I get PAP?") with a dedicated page that:
1. Reframes PAP as a protocol requiring expert implementation, not a plug-and-play install
2. Walks prospects through the full 6-step engagement lifecycle
3. Converts visitors to leads via `baursoftware.com/contact`

## Test plan

- [ ] Verify `docs/get-pap.html` renders correctly in browser (dark theme, all 6 step cards, CTA button)
- [ ] Verify "Work With Us" nav link appears and resolves on all updated pages
- [ ] Verify CTA button links to `https://baursoftware.com/contact`
- [ ] Verify GitHub Pages deploy workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)