### PR TITLE
feat(federation): implement require_diverse_paths Sybil resistance

### DIFF
--- a/crates/pap-federation/src/error.rs
+++ b/crates/pap-federation/src/error.rs
@@ -44,4 +44,10 @@ pub enum FederationError {
 
     #[error("peer is probationary and cannot vouch: {0}")]
     PeerProbationary(String),
+
+    #[error("vouchers lack diverse trust paths: ancestor {common_ancestor} is shared by {voucher_count} vouchers")]
+    NonDiversePaths {
+        common_ancestor: String,
+        voucher_count: usize,
+    },
 }

--- a/crates/pap-federation/src/lib.rs
+++ b/crates/pap-federation/src/lib.rs
@@ -1115,11 +1115,9 @@ mod tests {
         // Genesis peer: added directly (trust root, no vouchers needed).
         let genesis_key = make_keypair();
         let genesis_did = did_from_key(&genesis_key);
-        let mut genesis_peer =
-            RegistryPeer::new(&genesis_did, "https://genesis.example.com");
+        let mut genesis_peer = RegistryPeer::new(&genesis_did, "https://genesis.example.com");
         genesis_peer.status = PeerStatus::Active;
-        genesis_peer.registered_at =
-            Some((now - chrono::Duration::days(200)).to_rfc3339());
+        genesis_peer.registered_at = Some((now - chrono::Duration::days(200)).to_rfc3339());
         registry.add_peer(genesis_peer);
 
         // Admin peer: registered via genesis vouch, then promoted to Active.
@@ -1143,8 +1141,7 @@ mod tests {
         for i in 0..3usize {
             let leaf_key = make_keypair();
             let leaf_did = did_from_key(&leaf_key);
-            let leaf_peer =
-                RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
+            let leaf_peer = RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
             let vouch = vec![PeerVouch::sign(
                 &admin_did,
                 &leaf_did,
@@ -1165,9 +1162,7 @@ mod tests {
         let cand_peer = RegistryPeer::new(&cand_did, "https://candidate.example.com");
         let vouches: Vec<PeerVouch> = leaf_peers
             .iter()
-            .map(|(k, d)| {
-                PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k)
-            })
+            .map(|(k, d)| PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k))
             .collect();
 
         let result = registry.register_peer_with_vouches(cand_peer, vouches, now);
@@ -1219,14 +1214,12 @@ mod tests {
             let mut genesis_peer =
                 RegistryPeer::new(&genesis_did, format!("https://genesis{i}.example.com"));
             genesis_peer.status = PeerStatus::Active;
-            genesis_peer.registered_at =
-                Some((now - chrono::Duration::days(200)).to_rfc3339());
+            genesis_peer.registered_at = Some((now - chrono::Duration::days(200)).to_rfc3339());
             registry.add_peer(genesis_peer);
 
             let leaf_key = make_keypair();
             let leaf_did = did_from_key(&leaf_key);
-            let leaf_peer =
-                RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
+            let leaf_peer = RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
             let vouch = vec![PeerVouch::sign(
                 &genesis_did,
                 &leaf_did,
@@ -1247,9 +1240,7 @@ mod tests {
         let cand_peer = RegistryPeer::new(&cand_did, "https://candidate.example.com");
         let vouches: Vec<PeerVouch> = leaf_peers
             .iter()
-            .map(|(k, d)| {
-                PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k)
-            })
+            .map(|(k, d)| PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k))
             .collect();
 
         let result = registry.register_peer_with_vouches(cand_peer, vouches, now);

--- a/crates/pap-federation/src/lib.rs
+++ b/crates/pap-federation/src/lib.rs
@@ -687,6 +687,8 @@ mod tests {
             min_age_to_vouch_days: 0,
             probation_days: 30,
             require_diverse_paths: false,
+            path_diversity_hops: 3,
+            max_shared_ancestor_vouchers: 2,
         };
         let mut registry = FederatedRegistry::with_policy(policy);
 
@@ -735,6 +737,8 @@ mod tests {
         assert_eq!(policy.min_age_to_vouch_days, 90);
         assert_eq!(policy.probation_days, 60);
         assert!(policy.require_diverse_paths);
+        assert_eq!(policy.path_diversity_hops, 3);
+        assert_eq!(policy.max_shared_ancestor_vouchers, 2);
     }
 
     #[test]
@@ -745,6 +749,8 @@ mod tests {
             min_age_to_vouch_days: 180,
             probation_days: 90,
             require_diverse_paths: false,
+            path_diversity_hops: 5,
+            max_shared_ancestor_vouchers: 3,
         };
         let json = serde_json::to_string(&policy).unwrap();
         let restored: PeerRegistrationPolicy = serde_json::from_str(&json).unwrap();
@@ -1080,5 +1086,183 @@ mod tests {
         let results = registry.query_local_latest("schema:SearchAction");
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].version, "0.2.0");
+    }
+
+    // =========================================================================
+    // require_diverse_paths tests
+    // =========================================================================
+
+    /// Coordinated cluster attack: all three vouchers share a single intermediate
+    /// ancestor (admin). Registration must be rejected with NonDiversePaths.
+    ///
+    /// Graph:  genesis --vouches--> admin --vouches--> peer_a, peer_b, peer_c
+    ///         peer_a, peer_b, peer_c --vouch--> candidate
+    #[test]
+    fn coordinated_cluster_rejected() {
+        let policy = registry::PeerRegistrationPolicy {
+            min_vouches: 1,
+            vouch_budget_per_year: 10,
+            min_age_to_vouch_days: 0,
+            probation_days: 60,
+            require_diverse_paths: true,
+            path_diversity_hops: 3,
+            max_shared_ancestor_vouchers: 2,
+        };
+        let mut registry = FederatedRegistry::with_policy(policy);
+
+        let now = chrono::Utc::now();
+
+        // Genesis peer: added directly (trust root, no vouchers needed).
+        let genesis_key = make_keypair();
+        let genesis_did = did_from_key(&genesis_key);
+        let mut genesis_peer =
+            RegistryPeer::new(&genesis_did, "https://genesis.example.com");
+        genesis_peer.status = PeerStatus::Active;
+        genesis_peer.registered_at =
+            Some((now - chrono::Duration::days(200)).to_rfc3339());
+        registry.add_peer(genesis_peer);
+
+        // Admin peer: registered via genesis vouch, then promoted to Active.
+        let admin_key = make_keypair();
+        let admin_did = did_from_key(&admin_key);
+        let admin_peer = RegistryPeer::new(&admin_did, "https://admin.example.com");
+        let admin_vouch = vec![PeerVouch::sign(
+            &genesis_did,
+            &admin_did,
+            "2026-01-01T00:00:00Z",
+            "bootstrap",
+            &genesis_key,
+        )];
+        registry
+            .register_peer_with_vouches(admin_peer, admin_vouch, now)
+            .unwrap();
+        registry.promote_peer_to_active(&admin_did);
+
+        // Leaf peers peer_a, peer_b, peer_c: each vouched only by admin.
+        let mut leaf_peers: Vec<(ed25519_dalek::SigningKey, String)> = Vec::new();
+        for i in 0..3usize {
+            let leaf_key = make_keypair();
+            let leaf_did = did_from_key(&leaf_key);
+            let leaf_peer =
+                RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
+            let vouch = vec![PeerVouch::sign(
+                &admin_did,
+                &leaf_did,
+                "2026-02-01T00:00:00Z",
+                "direct",
+                &admin_key,
+            )];
+            registry
+                .register_peer_with_vouches(leaf_peer, vouch, now)
+                .unwrap();
+            registry.promote_peer_to_active(&leaf_did);
+            leaf_peers.push((leaf_key, leaf_did));
+        }
+
+        // Candidate: vouched by all three leaves (which all trace through admin).
+        let cand_key = make_keypair();
+        let cand_did = did_from_key(&cand_key);
+        let cand_peer = RegistryPeer::new(&cand_did, "https://candidate.example.com");
+        let vouches: Vec<PeerVouch> = leaf_peers
+            .iter()
+            .map(|(k, d)| {
+                PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k)
+            })
+            .collect();
+
+        let result = registry.register_peer_with_vouches(cand_peer, vouches, now);
+        assert!(result.is_err(), "expected rejection of coordinated cluster");
+        match result.unwrap_err() {
+            FederationError::NonDiversePaths {
+                common_ancestor,
+                voucher_count,
+            } => {
+                assert_eq!(
+                    common_ancestor, admin_did,
+                    "shared ancestor should be the admin node"
+                );
+                assert!(
+                    voucher_count >= 2,
+                    "at least 2 vouchers must share the common ancestor"
+                );
+            }
+            other => panic!("expected NonDiversePaths, got: {other}"),
+        }
+    }
+
+    /// Diverse graph: each voucher traces to a distinct genesis peer.
+    /// Registration must succeed.
+    ///
+    /// Graph:  genesis_0 --> leaf_0 \
+    ///         genesis_1 --> leaf_1  >-- candidate
+    ///         genesis_2 --> leaf_2 /
+    #[test]
+    fn diverse_paths_accepted() {
+        let policy = registry::PeerRegistrationPolicy {
+            min_vouches: 1,
+            vouch_budget_per_year: 10,
+            min_age_to_vouch_days: 0,
+            probation_days: 60,
+            require_diverse_paths: true,
+            path_diversity_hops: 3,
+            max_shared_ancestor_vouchers: 2,
+        };
+        let mut registry = FederatedRegistry::with_policy(policy);
+
+        let now = chrono::Utc::now();
+
+        // Three independent genesis → leaf chains.
+        let mut leaf_peers: Vec<(ed25519_dalek::SigningKey, String)> = Vec::new();
+        for i in 0..3usize {
+            let genesis_key = make_keypair();
+            let genesis_did = did_from_key(&genesis_key);
+            let mut genesis_peer =
+                RegistryPeer::new(&genesis_did, format!("https://genesis{i}.example.com"));
+            genesis_peer.status = PeerStatus::Active;
+            genesis_peer.registered_at =
+                Some((now - chrono::Duration::days(200)).to_rfc3339());
+            registry.add_peer(genesis_peer);
+
+            let leaf_key = make_keypair();
+            let leaf_did = did_from_key(&leaf_key);
+            let leaf_peer =
+                RegistryPeer::new(&leaf_did, format!("https://leaf{i}.example.com"));
+            let vouch = vec![PeerVouch::sign(
+                &genesis_did,
+                &leaf_did,
+                "2026-01-01T00:00:00Z",
+                "bootstrap",
+                &genesis_key,
+            )];
+            registry
+                .register_peer_with_vouches(leaf_peer, vouch, now)
+                .unwrap();
+            registry.promote_peer_to_active(&leaf_did);
+            leaf_peers.push((leaf_key, leaf_did));
+        }
+
+        // Candidate vouched by all three independent leaves.
+        let cand_key = make_keypair();
+        let cand_did = did_from_key(&cand_key);
+        let cand_peer = RegistryPeer::new(&cand_did, "https://candidate.example.com");
+        let vouches: Vec<PeerVouch> = leaf_peers
+            .iter()
+            .map(|(k, d)| {
+                PeerVouch::sign(d, &cand_did, "2026-03-01T00:00:00Z", "direct", k)
+            })
+            .collect();
+
+        let result = registry.register_peer_with_vouches(cand_peer, vouches, now);
+        assert!(
+            result.is_ok(),
+            "expected diverse-path registration to succeed, got: {:?}",
+            result.unwrap_err()
+        );
+        let registered = registry
+            .peers()
+            .iter()
+            .find(|p| p.did == cand_did)
+            .expect("candidate not found in registry");
+        assert_eq!(registered.status, PeerStatus::Probationary);
     }
 }

--- a/crates/pap-federation/src/registry.rs
+++ b/crates/pap-federation/src/registry.rs
@@ -156,8 +156,7 @@ impl FederatedRegistry {
 
         // 6. Require diverse trust paths if the policy demands it.
         if self.policy.require_diverse_paths {
-            let voucher_dids: Vec<String> =
-                vouches.iter().map(|v| v.voucher_did.clone()).collect();
+            let voucher_dids: Vec<String> = vouches.iter().map(|v| v.voucher_did.clone()).collect();
             self.check_path_diversity(
                 &voucher_dids,
                 self.policy.path_diversity_hops,

--- a/crates/pap-federation/src/registry.rs
+++ b/crates/pap-federation/src/registry.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet, VecDeque};
 
 use chrono::{DateTime, Utc};
 use pap_did::verify_key_from_did;
@@ -6,7 +6,7 @@ use pap_marketplace::{AgentAdvertisement, MarketplaceRegistry};
 use serde::{Deserialize, Serialize};
 
 use crate::error::FederationError;
-use crate::peer::{PeerStatus, PeerVouch, RegistryPeer};
+use crate::peer::{PeerStatus, PeerTrustSignals, PeerVouch, RegistryPeer};
 
 /// Policy configuration for peer registration with vouch-based admission.
 ///
@@ -27,9 +27,14 @@ pub struct PeerRegistrationPolicy {
     pub min_age_to_vouch_days: u64,
     /// Number of days a newly registered peer remains in probation.
     pub probation_days: u64,
-    /// Whether vouchers must have independent trust paths (not yet enforced,
-    /// reserved for future graph-based analysis).
+    /// Whether vouchers must have independent trust paths.
     pub require_diverse_paths: bool,
+    /// How many hops up the vouch graph to search for common ancestors (D).
+    pub path_diversity_hops: u64,
+    /// Reject if any non-genesis intermediate peer appears in this many or more voucher
+    /// ancestor chains (K). With the default of 2, any single shared intermediate node
+    /// among two or more vouchers causes rejection.
+    pub max_shared_ancestor_vouchers: usize,
 }
 
 impl Default for PeerRegistrationPolicy {
@@ -40,6 +45,8 @@ impl Default for PeerRegistrationPolicy {
             min_age_to_vouch_days: 90,
             probation_days: 60,
             require_diverse_paths: true,
+            path_diversity_hops: 3,
+            max_shared_ancestor_vouchers: 2,
         }
     }
 }
@@ -147,7 +154,30 @@ impl FederatedRegistry {
             }
         }
 
-        // All checks passed -- add peer as probationary
+        // 6. Require diverse trust paths if the policy demands it.
+        if self.policy.require_diverse_paths {
+            let voucher_dids: Vec<String> =
+                vouches.iter().map(|v| v.voucher_did.clone()).collect();
+            self.check_path_diversity(
+                &voucher_dids,
+                self.policy.path_diversity_hops,
+                self.policy.max_shared_ancestor_vouchers,
+            )?;
+        }
+
+        // All checks passed -- persist admitted vouches as graph edges, then add as probationary.
+        // The stored vouches are required for future path-diversity checks on subsequent registrations.
+        match &mut peer.trust_signals {
+            Some(ts) => ts.vouches.extend(vouches.iter().cloned()),
+            None => {
+                peer.trust_signals = Some(PeerTrustSignals {
+                    vouches: vouches.clone(),
+                    tee_attestation: None,
+                    operational_history: None,
+                    domain_verification: None,
+                });
+            }
+        }
         peer.status = PeerStatus::Probationary;
         peer.registered_at = Some(now.to_rfc3339());
         self.peers.push(peer);
@@ -168,6 +198,112 @@ impl FederatedRegistry {
             return duration.num_days().max(0) as u64;
         }
         0
+    }
+
+    /// Build a directed vouch graph from stored peer trust signals.
+    ///
+    /// Returns a map from `vouchee_did` → list of `voucher_did`s extracted
+    /// from each peer's `trust_signals.vouches`. Genesis peers (added via
+    /// `add_peer`) have no entry as a key since no vouch record admits them.
+    fn build_vouch_graph(&self) -> HashMap<String, Vec<String>> {
+        let mut graph: HashMap<String, Vec<String>> = HashMap::new();
+        for peer in &self.peers {
+            if let Some(ts) = &peer.trust_signals {
+                for vouch in &ts.vouches {
+                    graph
+                        .entry(vouch.vouchee_did.clone())
+                        .or_default()
+                        .push(vouch.voucher_did.clone());
+                }
+            }
+        }
+        graph
+    }
+
+    /// BFS ancestor traversal of the vouch graph.
+    ///
+    /// Starting from `start_did`, follows parent edges up to `max_hops` levels.
+    /// Returns all reachable ancestor DIDs including `start_did` at hop 0.
+    /// Cycles are handled safely via the `visited` set.
+    fn ancestors_within_hops(
+        start_did: &str,
+        graph: &HashMap<String, Vec<String>>,
+        max_hops: u64,
+    ) -> HashSet<String> {
+        let mut visited: HashSet<String> = HashSet::new();
+        let mut queue: VecDeque<(String, u64)> = VecDeque::new();
+        queue.push_back((start_did.to_string(), 0));
+        while let Some((current, depth)) = queue.pop_front() {
+            if visited.contains(&current) {
+                continue;
+            }
+            visited.insert(current.clone());
+            if depth < max_hops {
+                if let Some(parents) = graph.get(&current) {
+                    for parent in parents {
+                        if !visited.contains(parent) {
+                            queue.push_back((parent.clone(), depth + 1));
+                        }
+                    }
+                }
+            }
+        }
+        visited
+    }
+
+    /// Check that the candidate's vouchers have independent trust paths.
+    ///
+    /// Builds the vouch graph from stored peer trust signals, then BFS-traverses
+    /// up to `hops` levels from each voucher DID. If any non-genesis peer appears
+    /// as an ancestor in `max_shared` or more voucher chains, returns
+    /// `FederationError::NonDiversePaths`.
+    ///
+    /// Genesis peers (those not present as a vouchee in any stored vouch record)
+    /// are excluded from the count — all paths eventually converge at trust roots
+    /// and counting them would produce false rejections in small networks.
+    fn check_path_diversity(
+        &self,
+        voucher_dids: &[String],
+        hops: u64,
+        max_shared: usize,
+    ) -> Result<(), FederationError> {
+        let graph = self.build_vouch_graph();
+
+        // Genesis set: peers whose DID does not appear as a vouchee in any stored vouch.
+        let genesis: HashSet<&str> = self
+            .peers
+            .iter()
+            .filter(|p| !graph.contains_key(&p.did))
+            .map(|p| p.did.as_str())
+            .collect();
+
+        // Compute ancestor sets for each voucher.
+        let ancestor_chains: Vec<HashSet<String>> = voucher_dids
+            .iter()
+            .map(|v| Self::ancestors_within_hops(v, &graph, hops))
+            .collect();
+
+        // Count how many chains each non-genesis ancestor appears in.
+        let mut ancestor_count: HashMap<String, usize> = HashMap::new();
+        for chain in &ancestor_chains {
+            for ancestor in chain {
+                if !genesis.contains(ancestor.as_str()) {
+                    *ancestor_count.entry(ancestor.clone()).or_insert(0) += 1;
+                }
+            }
+        }
+
+        // Reject if any non-genesis ancestor is shared by >= max_shared chains.
+        for (ancestor, count) in &ancestor_count {
+            if *count >= max_shared {
+                return Err(FederationError::NonDiversePaths {
+                    common_ancestor: ancestor.clone(),
+                    voucher_count: *count,
+                });
+            }
+        }
+
+        Ok(())
     }
 
     /// List known peers.
@@ -326,5 +462,18 @@ impl FederatedRegistry {
 impl Default for FederatedRegistry {
     fn default() -> Self {
         Self::new()
+    }
+}
+
+#[cfg(test)]
+impl FederatedRegistry {
+    /// Promote a peer from Probationary to Active by DID (test-only).
+    ///
+    /// The `peers` field is private; this escape hatch allows tests to graduate
+    /// intermediate peers so they can vouch for subsequent registrations.
+    pub(crate) fn promote_peer_to_active(&mut self, did: &str) {
+        if let Some(p) = self.peers.iter_mut().find(|p| p.did == did) {
+            p.status = PeerStatus::Active;
+        }
     }
 }

--- a/crates/pap-federation/src/registry.rs
+++ b/crates/pap-federation/src/registry.rs
@@ -31,9 +31,9 @@ pub struct PeerRegistrationPolicy {
     pub require_diverse_paths: bool,
     /// How many hops up the vouch graph to search for common ancestors (D).
     pub path_diversity_hops: u64,
-    /// Reject if any non-genesis intermediate peer appears in this many or more voucher
-    /// ancestor chains (K). With the default of 2, any single shared intermediate node
-    /// among two or more vouchers causes rejection.
+    /// Reject if any non-genesis, non-voucher intermediate peer appears in this many or
+    /// more voucher ancestor chains (K). Minimum useful value: 1 (reject any shared
+    /// intermediate). Default: 2. Higher values allow more ancestry overlap.
     pub max_shared_ancestor_vouchers: usize,
 }
 
@@ -282,24 +282,33 @@ impl FederatedRegistry {
             .map(|v| Self::ancestors_within_hops(v, &graph, hops))
             .collect();
 
-        // Count how many chains each non-genesis ancestor appears in.
+        // Count how many chains each non-genesis, non-voucher intermediate appears in.
+        // Voucher DIDs are excluded because each voucher naturally appears in its own BFS
+        // result (depth 0); counting them would make K=1 reject all non-genesis vouchers.
+        let voucher_set: HashSet<&str> = voucher_dids.iter().map(|s| s.as_str()).collect();
         let mut ancestor_count: HashMap<String, usize> = HashMap::new();
         for chain in &ancestor_chains {
             for ancestor in chain {
-                if !genesis.contains(ancestor.as_str()) {
+                if !genesis.contains(ancestor.as_str()) && !voucher_set.contains(ancestor.as_str())
+                {
                     *ancestor_count.entry(ancestor.clone()).or_insert(0) += 1;
                 }
             }
         }
 
-        // Reject if any non-genesis ancestor is shared by >= max_shared chains.
-        for (ancestor, count) in &ancestor_count {
-            if *count >= max_shared {
-                return Err(FederationError::NonDiversePaths {
-                    common_ancestor: ancestor.clone(),
-                    voucher_count: *count,
-                });
-            }
+        // Deterministic error: pick the most-shared violating ancestor (highest count,
+        // then lexicographically smallest DID for stable output on ties).
+        let violating = ancestor_count
+            .iter()
+            .filter(|(_, &count)| count >= max_shared)
+            .max_by(|(a_did, &a_count), (b_did, &b_count)| {
+                a_count.cmp(&b_count).then_with(|| b_did.cmp(a_did))
+            });
+        if let Some((ancestor, count)) = violating {
+            return Err(FederationError::NonDiversePaths {
+                common_ancestor: ancestor.clone(),
+                voucher_count: *count,
+            });
         }
 
         Ok(())


### PR DESCRIPTION
## Summary

Implements the `require_diverse_paths` field in `PeerRegistrationPolicy` that was previously a TODO placeholder. This closes the coordinated-cluster attack vector in the vouch-based Sybil resistance model.

**Attack being closed:** A small number of colluding long-standing peers can vouch for each other in a tight subgraph (e.g. `genesis → admin → peer_a, peer_b, peer_c`) and then collectively vouch for an attacker peer. The 3-vouch minimum, 90-day age gate, and 60-day probation are all satisfied — but all vouchers trace ancestry through a single intermediate node.

**Algorithm (BFS ancestor-diversity):**
1. Build a directed vouch graph from stored `peer.trust_signals.vouches` (vouchee → [voucher, ...])
2. For each of the N vouchers of the candidate, BFS upward through the graph up to `path_diversity_hops` (D=3) levels, collecting ancestor DIDs
3. Count how many voucher ancestor-chains contain each non-genesis intermediate peer
4. If any non-genesis peer appears in `max_shared_ancestor_vouchers` (K=2) or more chains → `FederationError::NonDiversePaths`
5. Genesis peers (added via `add_peer()`, no vouch record as vouchee) are excluded — counting trust roots would cause false rejections in small networks

**Critical fix bundled:** `register_peer_with_vouches` previously validated but discarded vouches. They are now persisted in `peer.trust_signals.vouches` so future registrations can traverse the vouch graph.

## Changes

- `crates/pap-federation/src/error.rs` — `NonDiversePaths { common_ancestor, voucher_count }` error variant
- `crates/pap-federation/src/registry.rs` — two new `PeerRegistrationPolicy` fields (`path_diversity_hops: u64`, `max_shared_ancestor_vouchers: usize`), three new private methods (`build_vouch_graph`, `ancestors_within_hops`, `check_path_diversity`), vouch persistence, diversity gate wired into `register_peer_with_vouches`
- `crates/pap-federation/src/lib.rs` — two new unit tests, existing struct-literal and assertion updates

## New Policy Fields

| Field | Default | Meaning |
|---|---|---|
| `path_diversity_hops` | 3 | How many hops up the vouch graph to search (D) |
| `max_shared_ancestor_vouchers` | 2 | Reject if any non-genesis node appears in K+ chains |

Set `require_diverse_paths: false` to preserve previous behavior for custom policies.

## Test Plan

- [x] `coordinated_cluster_rejected` — `genesis → admin → peer_a/b/c`, candidate vouched by a/b/c → rejects with `NonDiversePaths { common_ancestor: admin_did, voucher_count: 3 }`
- [x] `diverse_paths_accepted` — three independent genesis chains, candidate vouched by each leaf → succeeds, status `Probationary`
- [x] All 133 existing pap-federation tests pass
- [x] `cargo clippy -p pap-federation -- -D warnings` clean
- [x] `cargo fmt --all` idempotent after rebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)