### PR TITLE
fix(canvas): prevent chat messages leaking across canvas boundaries

### DIFF
--- a/apps/papillon/frontend/src/components/block_renderer/declarative.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/declarative.rs
@@ -209,6 +209,7 @@ impl BlockRenderer for DeclarativeRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use papillon_shared::FieldMapping;
 
     fn sample_template_config() -> TemplateConfig {
         TemplateConfig {

--- a/apps/papillon/frontend/src/pages/canvas.rs
+++ b/apps/papillon/frontend/src/pages/canvas.rs
@@ -190,10 +190,21 @@ fn CanvasChatThread() -> impl IntoView {
         }
     };
 
+    // Only show messages belonging to the currently active canvas.
+    let active_messages = move || {
+        let active_id = canvas_state.current_canvas_id.get();
+        canvas_state
+            .canvas_messages
+            .get()
+            .into_iter()
+            .filter(|m| active_id.as_deref() == Some(m.canvas_id.as_str()))
+            .collect::<Vec<_>>()
+    };
+
     view! {
         <div class="canvas-chat-thread">
             <For
-                each=move || canvas_state.canvas_messages.get()
+                each=active_messages
                 key=|msg| msg.id.clone()
                 children=move |msg| {
                     let is_user = msg.role == "user";

--- a/apps/papillon/frontend/src/pages/canvas.rs
+++ b/apps/papillon/frontend/src/pages/canvas.rs
@@ -4,7 +4,7 @@ use wasm_bindgen_futures::spawn_local;
 
 use crate::bridge;
 use crate::components::block_renderer::BlockRenderer;
-use crate::state::canvas::{CanvasSide, CanvasState};
+use crate::state::canvas::{filter_messages_by_canvas, CanvasSide, CanvasState};
 
 // ── Canvas outcome synthesis types (mirrors Tauri backend) ────────────────
 
@@ -193,12 +193,10 @@ fn CanvasChatThread() -> impl IntoView {
     // Only show messages belonging to the currently active canvas.
     let active_messages = move || {
         let active_id = canvas_state.current_canvas_id.get();
-        canvas_state
-            .canvas_messages
-            .get()
-            .into_iter()
-            .filter(|m| active_id.as_deref() == Some(m.canvas_id.as_str()))
-            .collect::<Vec<_>>()
+        filter_messages_by_canvas(
+            &canvas_state.canvas_messages.get(),
+            active_id.as_deref(),
+        )
     };
 
     view! {

--- a/apps/papillon/frontend/src/state/canvas.rs
+++ b/apps/papillon/frontend/src/state/canvas.rs
@@ -8,6 +8,7 @@ use crate::bridge;
 use crate::service::PapillonService;
 use crate::state::catalog::CatalogState;
 use crate::state::registry::RegistryState;
+pub use papillon_shared::{filter_messages_by_canvas, merge_canvases_from_records, merge_messages_dedup};
 
 /// Which face of the canvas flipper is visible.
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -804,21 +805,7 @@ impl CanvasState {
                 }
             } else {
                 // Load ALL canvases into the reactive store so the sidebar is complete.
-                canvases.update(|cs| {
-                    for rec in &records {
-                        if cs.iter().any(|c| c.id == rec.id) {
-                            continue;
-                        }
-                        let now = rec.created_at.clone();
-                        cs.push(Canvas {
-                            id: rec.id.clone(),
-                            name: rec.name.clone(),
-                            blocks: Vec::new(),
-                            created_at: now.clone(),
-                            updated_at: now,
-                        });
-                    }
-                });
+                canvases.update(|cs| merge_canvases_from_records(cs, &records));
                 // Activate the first (most recent) canvas if none is already active.
                 let first_id = records[0].id.clone();
                 if current_canvas_id.get_untracked().is_none() {
@@ -890,13 +877,7 @@ impl CanvasState {
                     &serde_json::json!({ "canvasId": cid }),
                 ).await {
                     Ok(msgs) => {
-                        canvas_messages.update(|store| {
-                            for msg in msgs {
-                                if !store.iter().any(|m| m.id == msg.id) {
-                                    store.push(msg);
-                                }
-                            }
-                        });
+                        canvas_messages.update(|store| merge_messages_dedup(store, msgs));
                     }
                     Err(e) => {
                         leptos::logging::warn!("canvas_messages_load failed for {}: {}", cid, e);
@@ -1147,4 +1128,5 @@ mod tests {
         let body: String = input.chars().take(40).collect();
         assert!(result.starts_with(&body));
     }
+
 }

--- a/apps/papillon/frontend/src/state/canvas.rs
+++ b/apps/papillon/frontend/src/state/canvas.rs
@@ -777,7 +777,7 @@ impl CanvasState {
                 }
             };
 
-            let canvas_id: String = if records.is_empty() {
+            let active_canvas_id: String = if records.is_empty() {
                 // Create a default canvas.
                 match crate::bridge::invoke::<_, CanvasRecord>(
                     "canvas_create",
@@ -803,36 +803,39 @@ impl CanvasState {
                     }
                 }
             } else {
-                // Use the first (most recent) canvas; ensure it's in the reactive store.
-                let rec = &records[0];
-                let id = rec.id.clone();
-                let now = rec.created_at.clone();
-                let canvas = Canvas {
-                    id: id.clone(),
-                    name: rec.name.clone(),
-                    blocks: Vec::new(),
-                    created_at: now.clone(),
-                    updated_at: now,
-                };
+                // Load ALL canvases into the reactive store so the sidebar is complete.
                 canvases.update(|cs| {
-                    if !cs.iter().any(|c| c.id == id) {
-                        cs.push(canvas);
+                    for rec in &records {
+                        if cs.iter().any(|c| c.id == rec.id) {
+                            continue;
+                        }
+                        let now = rec.created_at.clone();
+                        cs.push(Canvas {
+                            id: rec.id.clone(),
+                            name: rec.name.clone(),
+                            blocks: Vec::new(),
+                            created_at: now.clone(),
+                            updated_at: now,
+                        });
                     }
                 });
+                // Activate the first (most recent) canvas if none is already active.
+                let first_id = records[0].id.clone();
                 if current_canvas_id.get_untracked().is_none() {
-                    current_canvas_id.set(Some(id.clone()));
+                    current_canvas_id.set(Some(first_id.clone()));
                 }
-                id
+                first_id
             };
 
-            // 2. Load blocks for the active canvas.
+            // 2. Load blocks for the active canvas only (lazy — blocks for other
+            //    canvases are loaded on demand when the user switches to them).
             match crate::bridge::invoke::<_, Vec<papillon_shared::types::CanvasBlockRecord>>(
                 "canvas_blocks_load",
-                &serde_json::json!({ "canvasId": canvas_id }),
+                &serde_json::json!({ "canvasId": active_canvas_id }),
             ).await {
                 Ok(block_records) => {
                     canvases.update(|cs| {
-                        if let Some(canvas) = cs.iter_mut().find(|c| c.id == canvas_id) {
+                        if let Some(canvas) = cs.iter_mut().find(|c| c.id == active_canvas_id) {
                             for rec in block_records {
                                 if canvas.blocks.iter().any(|b| b.id == rec.id) {
                                     continue;
@@ -872,16 +875,32 @@ impl CanvasState {
                 }
             }
 
-            // 3. Load messages for the active canvas.
-            match crate::bridge::invoke::<_, Vec<CanvasMessageRecord>>(
-                "canvas_messages_load",
-                &serde_json::json!({ "canvasId": canvas_id }),
-            ).await {
-                Ok(msgs) => {
-                    canvas_messages.set(msgs);
-                }
-                Err(e) => {
-                    leptos::logging::warn!("canvas_messages_load failed: {}", e);
+            // 3. Load messages for ALL canvases so the per-canvas filter in
+            //    CanvasChatThread has complete data regardless of which canvas
+            //    is active.  Messages are keyed by id so we skip duplicates.
+            let all_canvas_ids: Vec<String> = canvases
+                .get_untracked()
+                .iter()
+                .map(|c| c.id.clone())
+                .collect();
+
+            for cid in all_canvas_ids {
+                match crate::bridge::invoke::<_, Vec<CanvasMessageRecord>>(
+                    "canvas_messages_load",
+                    &serde_json::json!({ "canvasId": cid }),
+                ).await {
+                    Ok(msgs) => {
+                        canvas_messages.update(|store| {
+                            for msg in msgs {
+                                if !store.iter().any(|m| m.id == msg.id) {
+                                    store.push(msg);
+                                }
+                            }
+                        });
+                    }
+                    Err(e) => {
+                        leptos::logging::warn!("canvas_messages_load failed for {}: {}", cid, e);
+                    }
                 }
             }
         });

--- a/crates/papillon-shared/src/canvas_ops.rs
+++ b/crates/papillon-shared/src/canvas_ops.rs
@@ -1,0 +1,354 @@
+//! Pure canvas helper functions.
+//!
+//! All functions in this module are dependency-free (no WASM, no I/O) and
+//! operate only on the shared types defined in `types.rs`.  They are tested
+//! with `cargo test -p papillon-shared` so they run natively without a
+//! browser or WASM runtime.
+
+use crate::types::{Canvas, CanvasMessageRecord, CanvasRecord};
+
+/// Return only the messages whose `canvas_id` matches `active_id`.
+///
+/// Returns an empty `Vec` when `active_id` is `None` or no messages match.
+pub fn filter_messages_by_canvas(
+    messages: &[CanvasMessageRecord],
+    active_id: Option<&str>,
+) -> Vec<CanvasMessageRecord> {
+    match active_id {
+        None => vec![],
+        Some(id) => messages
+            .iter()
+            .filter(|m| m.canvas_id == id)
+            .cloned()
+            .collect(),
+    }
+}
+
+/// Merge `incoming` messages into `store`, skipping any whose `id` is
+/// already present.  Preserves insertion order for new messages.
+pub fn merge_messages_dedup(
+    store: &mut Vec<CanvasMessageRecord>,
+    incoming: Vec<CanvasMessageRecord>,
+) {
+    for msg in incoming {
+        if !store.iter().any(|m| m.id == msg.id) {
+            store.push(msg);
+        }
+    }
+}
+
+/// Merge `records` from the DB into `store`, skipping IDs that are already
+/// present.  New entries are initialised with empty `blocks` so they can be
+/// lazy-loaded later.
+pub fn merge_canvases_from_records(store: &mut Vec<Canvas>, records: &[CanvasRecord]) {
+    for rec in records {
+        if store.iter().any(|c| c.id == rec.id) {
+            continue;
+        }
+        let now = rec.created_at.clone();
+        store.push(Canvas {
+            id: rec.id.clone(),
+            name: rec.name.clone(),
+            blocks: Vec::new(),
+            created_at: now.clone(),
+            updated_at: now,
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::CanvasBlock;
+    use crate::BlockState;
+
+    // ── helpers ───────────────────────────────────────────────────────────────
+
+    fn make_msg(id: &str, canvas_id: &str, content: &str) -> CanvasMessageRecord {
+        CanvasMessageRecord {
+            id: id.to_string(),
+            canvas_id: canvas_id.to_string(),
+            role: "user".to_string(),
+            content: content.to_string(),
+            block_id: None,
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_canvas_record(id: &str, name: &str) -> CanvasRecord {
+        CanvasRecord {
+            id: id.to_string(),
+            name: name.to_string(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_bare_canvas(id: &str, name: &str) -> Canvas {
+        Canvas {
+            id: id.to_string(),
+            name: name.to_string(),
+            blocks: Vec::new(),
+            created_at: "2024-01-01T00:00:00Z".to_string(),
+            updated_at: "2024-01-01T00:00:00Z".to_string(),
+        }
+    }
+
+    fn make_block(id: &str) -> CanvasBlock {
+        CanvasBlock {
+            id: id.to_string(),
+            prompt_id: "p".into(),
+            prompt_text: Some("test".into()),
+            state: BlockState::Resolved,
+            schema_type: None,
+            content: None,
+            linked_block_ids: Vec::new(),
+            agent_did: None,
+            mandate_expires_at: None,
+            preference_guided: false,
+            auto_expand: false,
+            created_at: String::new(),
+            updated_at: String::new(),
+        }
+    }
+
+    // ── filter_messages_by_canvas ─────────────────────────────────────────────
+
+    #[test]
+    fn filter_messages_returns_only_active_canvas_messages() {
+        let msgs = vec![
+            make_msg("m1", "canvas-A", "hello from A"),
+            make_msg("m2", "canvas-B", "hello from B"),
+            make_msg("m3", "canvas-A", "second from A"),
+        ];
+        let result = filter_messages_by_canvas(&msgs, Some("canvas-A"));
+        assert_eq!(result.len(), 2);
+        assert!(result.iter().all(|m| m.canvas_id == "canvas-A"));
+    }
+
+    #[test]
+    fn filter_messages_returns_empty_when_no_active_canvas() {
+        let msgs = vec![make_msg("m1", "canvas-A", "hello")];
+        let result = filter_messages_by_canvas(&msgs, None);
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_messages_returns_empty_when_canvas_has_no_messages() {
+        let msgs = vec![make_msg("m1", "canvas-A", "hello")];
+        let result = filter_messages_by_canvas(&msgs, Some("canvas-B"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_messages_returns_empty_for_empty_store() {
+        let msgs: Vec<CanvasMessageRecord> = vec![];
+        let result = filter_messages_by_canvas(&msgs, Some("canvas-A"));
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn filter_messages_preserves_order() {
+        let msgs = vec![
+            make_msg("m1", "canvas-A", "first"),
+            make_msg("m2", "canvas-A", "second"),
+            make_msg("m3", "canvas-A", "third"),
+        ];
+        let result = filter_messages_by_canvas(&msgs, Some("canvas-A"));
+        assert_eq!(result[0].id, "m1");
+        assert_eq!(result[1].id, "m2");
+        assert_eq!(result[2].id, "m3");
+    }
+
+    #[test]
+    fn filter_messages_with_single_canvas_returns_all_its_messages() {
+        let msgs: Vec<_> = (0..5)
+            .map(|i| make_msg(&format!("m{i}"), "only-canvas", &format!("msg {i}")))
+            .collect();
+        let result = filter_messages_by_canvas(&msgs, Some("only-canvas"));
+        assert_eq!(result.len(), 5);
+    }
+
+    #[test]
+    fn filter_messages_does_not_clone_messages_from_other_canvases() {
+        let msgs = vec![
+            make_msg("m1", "A", "in A"),
+            make_msg("m2", "B", "in B"),
+            make_msg("m3", "C", "in C"),
+        ];
+        let result = filter_messages_by_canvas(&msgs, Some("B"));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].id, "m2");
+    }
+
+    // ── merge_messages_dedup ──────────────────────────────────────────────────
+
+    #[test]
+    fn merge_messages_dedup_adds_new_messages() {
+        let mut store = vec![make_msg("existing", "canvas-A", "already here")];
+        let incoming = vec![
+            make_msg("new-1", "canvas-A", "brand new"),
+            make_msg("new-2", "canvas-A", "also new"),
+        ];
+        merge_messages_dedup(&mut store, incoming);
+        assert_eq!(store.len(), 3);
+    }
+
+    #[test]
+    fn merge_messages_dedup_skips_duplicate_ids() {
+        let mut store = vec![make_msg("dup", "canvas-A", "original")];
+        let incoming = vec![make_msg("dup", "canvas-A", "duplicate — should be skipped")];
+        merge_messages_dedup(&mut store, incoming);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store[0].content, "original");
+    }
+
+    #[test]
+    fn merge_messages_dedup_handles_empty_incoming() {
+        let mut store = vec![make_msg("m1", "canvas-A", "existing")];
+        merge_messages_dedup(&mut store, vec![]);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn merge_messages_dedup_handles_empty_store() {
+        let mut store: Vec<CanvasMessageRecord> = vec![];
+        let incoming = vec![
+            make_msg("m1", "canvas-A", "new"),
+            make_msg("m2", "canvas-A", "also new"),
+        ];
+        merge_messages_dedup(&mut store, incoming);
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn merge_messages_dedup_mixed_new_and_dup() {
+        let mut store = vec![make_msg("keep", "canvas-A", "keep me")];
+        let incoming = vec![
+            make_msg("keep", "canvas-A", "duplicate"),
+            make_msg("add", "canvas-B", "add me"),
+        ];
+        merge_messages_dedup(&mut store, incoming);
+        assert_eq!(store.len(), 2);
+        assert!(store.iter().any(|m| m.id == "keep"));
+        assert!(store.iter().any(|m| m.id == "add"));
+    }
+
+    #[test]
+    fn merge_messages_dedup_preserves_insertion_order_of_new_messages() {
+        let mut store: Vec<CanvasMessageRecord> = vec![];
+        let incoming = vec![
+            make_msg("first", "c", "a"),
+            make_msg("second", "c", "b"),
+            make_msg("third", "c", "c"),
+        ];
+        merge_messages_dedup(&mut store, incoming);
+        assert_eq!(store[0].id, "first");
+        assert_eq!(store[1].id, "second");
+        assert_eq!(store[2].id, "third");
+    }
+
+    // ── merge_canvases_from_records ───────────────────────────────────────────
+
+    #[test]
+    fn merge_canvases_adds_new_records() {
+        let mut store: Vec<Canvas> = vec![];
+        let records = vec![
+            make_canvas_record("c1", "Canvas One"),
+            make_canvas_record("c2", "Canvas Two"),
+        ];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn merge_canvases_skips_existing_ids() {
+        let mut store = vec![make_bare_canvas("c1", "Already There")];
+        let records = vec![
+            make_canvas_record("c1", "Duplicate — skip"),
+            make_canvas_record("c2", "New"),
+        ];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(store.len(), 2);
+        let c1 = store.iter().find(|c| c.id == "c1").unwrap();
+        assert_eq!(c1.name, "Already There"); // original preserved, not overwritten
+    }
+
+    #[test]
+    fn merge_canvases_from_empty_records_leaves_store_unchanged() {
+        let mut store = vec![make_bare_canvas("c1", "Only")];
+        merge_canvases_from_records(&mut store, &[]);
+        assert_eq!(store.len(), 1);
+    }
+
+    #[test]
+    fn merge_canvases_into_empty_store() {
+        let mut store: Vec<Canvas> = vec![];
+        let records = vec![make_canvas_record("c1", "New Canvas")];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(store.len(), 1);
+        assert_eq!(store[0].id, "c1");
+        assert_eq!(store[0].name, "New Canvas");
+        assert!(
+            store[0].blocks.is_empty(),
+            "new canvas must start with no blocks"
+        );
+    }
+
+    #[test]
+    fn merge_canvases_all_duplicates_changes_nothing() {
+        let mut store = vec![make_bare_canvas("c1", "One"), make_bare_canvas("c2", "Two")];
+        let records = vec![
+            make_canvas_record("c1", "One dup"),
+            make_canvas_record("c2", "Two dup"),
+        ];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(store.len(), 2);
+    }
+
+    #[test]
+    fn merge_canvases_preserves_existing_blocks() {
+        let block = make_block("blk");
+        let mut store = vec![Canvas {
+            id: "c1".into(),
+            name: "With Block".into(),
+            blocks: vec![block],
+            created_at: String::new(),
+            updated_at: String::new(),
+        }];
+        // Trying to re-add c1 via records must not wipe out its blocks.
+        let records = vec![make_canvas_record("c1", "c1 from db")];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(
+            store[0].blocks.len(),
+            1,
+            "existing blocks must be preserved"
+        );
+    }
+
+    #[test]
+    fn merge_canvases_new_entries_start_with_no_blocks() {
+        let mut store: Vec<Canvas> = vec![];
+        let records = vec![make_canvas_record("fresh", "Fresh Canvas")];
+        merge_canvases_from_records(&mut store, &records);
+        assert!(
+            store[0].blocks.is_empty(),
+            "lazily-loaded canvas must have empty blocks initially"
+        );
+    }
+
+    #[test]
+    fn merge_canvases_timestamps_come_from_record() {
+        let mut store: Vec<Canvas> = vec![];
+        let records = vec![CanvasRecord {
+            id: "ts-test".into(),
+            name: "Ts".into(),
+            created_at: "2025-06-01T12:00:00Z".to_string(),
+            updated_at: "2025-06-02T08:00:00Z".to_string(),
+        }];
+        merge_canvases_from_records(&mut store, &records);
+        assert_eq!(store[0].created_at, "2025-06-01T12:00:00Z");
+        // updated_at on a freshly-merged canvas is set to created_at (no updater yet)
+        assert_eq!(store[0].updated_at, "2025-06-01T12:00:00Z");
+    }
+}

--- a/crates/papillon-shared/src/lib.rs
+++ b/crates/papillon-shared/src/lib.rs
@@ -1,3 +1,7 @@
+pub mod canvas_ops;
+pub use canvas_ops::{
+    filter_messages_by_canvas, merge_canvases_from_records, merge_messages_dedup,
+};
 pub mod dataset_types;
 pub use dataset_types::{DatasetDiscoveryState, DatasetResult};
 pub mod events;


### PR DESCRIPTION
## Summary

- **Bug fix**: `CanvasChatThread` was rendering all messages from a global flat `Vec<CanvasMessageRecord>` without filtering by `canvas_id` — messages from other canvases appeared as pill bubbles in the active canvas chat thread
- **Data fix**: `load_from_db` now loads all canvases (not just the first) so the sidebar is fully populated, and preloads messages for every canvas with deduplication
- **Unit tests**: Extracted three pure functions into `papillon-shared::canvas_ops` with 21 new tests covering happy path, empty inputs, duplicates, order preservation, and block-preservation invariants

## Changes

- `crates/papillon-shared/src/canvas_ops.rs` — new module with `filter_messages_by_canvas`, `merge_messages_dedup`, `merge_canvases_from_records` + 21 tests
- `apps/papillon/frontend/src/state/canvas.rs` — call-sites updated to use extracted functions; `load_from_db` hydrates all canvases and all canvas messages on startup
- `apps/papillon/frontend/src/pages/canvas.rs` — `CanvasChatThread` filters by active canvas ID
- `apps/papillon/frontend/src/components/block_renderer/declarative.rs` — fix pre-existing missing `FieldMapping` import in test helper

## Test Plan

- [x] `cargo test -p papillon-shared` — 262 tests pass (21 new)
- [x] `cargo check -p papillon` — Tauri backend compiles clean
- [x] `cargo check --target wasm32-unknown-unknown` — WASM frontend compiles clean
- [ ] Switch between canvases in the app — confirm chat thread shows only that canvas's messages