### PR TITLE
feat(topbar): move Workflow toggle to topbar, replacing status dot

### DIFF
--- a/apps/papillon/frontend/src/components/topbar.rs
+++ b/apps/papillon/frontend/src/components/topbar.rs
@@ -4,21 +4,23 @@ use leptos_router::components::A;
 use wasm_bindgen::closure::Closure;
 use wasm_bindgen::JsCast;
 
-use crate::state::canvas::CanvasState;
+use crate::state::canvas::{CanvasSide, CanvasState};
 use crate::state::catalog::CatalogState;
-use crate::state::orchestrator::OrchestratorState;
-use papillon_shared::OrchestratorStatus;
 
 #[component]
 pub fn TopBar() -> impl IntoView {
     let canvas_state = expect_context::<CanvasState>();
-    let orchestrator = expect_context::<OrchestratorState>();
     let menu_open = RwSignal::new(false);
 
-    let status_class = move || match orchestrator.status.get() {
-        OrchestratorStatus::Ready => "topbar-dot ready",
-        OrchestratorStatus::Downloading { .. } => "topbar-dot working",
-        _ => "topbar-dot agents-only",
+    let is_back = move || canvas_state.canvas_side.get() == CanvasSide::Back;
+    let toggle_side = move |_: leptos::ev::MouseEvent| {
+        canvas_state.canvas_side.update(|s| {
+            *s = if *s == CanvasSide::Front {
+                CanvasSide::Back
+            } else {
+                CanvasSide::Front
+            };
+        });
     };
 
     let toggle_menu = move |_: leptos::ev::MouseEvent| {
@@ -44,9 +46,14 @@ pub fn TopBar() -> impl IntoView {
                 <TopbarPrompt />
             </div>
 
-            // Right zone — subtle status dot only
+            // Right zone — workflow toggle button
             <div class="topbar-end">
-                <div class=status_class title="Orchestrator status" />
+                <button
+                    class="canvas-flip-toggle"
+                    on:click=toggle_side
+                >
+                    {move || if is_back() { "\u{27f3} Rendered" } else { "\u{27f3} Workflow" }}
+                </button>
             </div>
         </header>
 

--- a/apps/papillon/frontend/src/pages/canvas.rs
+++ b/apps/papillon/frontend/src/pages/canvas.rs
@@ -94,30 +94,10 @@ pub fn CanvasPage() -> impl IntoView {
 
     let is_back = move || canvas_state.canvas_side.get() == CanvasSide::Back;
 
-    let toggle_side = move |_| {
-        canvas_state.canvas_side.update(|s| {
-            *s = if *s == CanvasSide::Front {
-                CanvasSide::Back
-            } else {
-                CanvasSide::Front
-            };
-        });
-    };
-
     view! {
         <HitlGate />
 
         <div class="canvas-page">
-            // Flip toggle button — sits above the flipper container.
-            <div class="canvas-flip-toggle-row">
-                <button
-                    class="canvas-flip-toggle"
-                    on:click=toggle_side
-                >
-                    {move || if is_back() { "\u{27f3} Rendered" } else { "\u{27f3} Workflow" }}
-                </button>
-            </div>
-
             // Flip container.
             <div
                 class="canvas-flip-container"

--- a/e2e/tests/app.spec.ts
+++ b/e2e/tests/app.spec.ts
@@ -9,19 +9,19 @@ test.beforeEach(async ({ page }) => {
 // ── Top Bar & App Shell ──────────────────────────────────────
 
 test.describe("App shell", () => {
-  test("renders top bar with brand icon and status dot", async ({ page }) => {
+  test("renders top bar with brand icon and workflow toggle", async ({ page }) => {
     await page.goto("/", { waitUntil: "commit" });
     await waitForApp(page);
     await expect(page.locator(".topbar")).toBeVisible();
     await expect(page.locator(".topbar-brand-icon")).toBeVisible();
-    await expect(page.locator(".topbar-dot")).toBeVisible();
+    await expect(page.locator(".canvas-flip-toggle")).toBeVisible();
   });
 
-  test("shows orchestrator status dot in top bar", async ({ page }) => {
+  test("shows workflow toggle button in top bar right zone", async ({ page }) => {
     await page.goto("/", { waitUntil: "commit" });
     await waitForApp(page);
-    // Mock returns "Ready" → topbar renders .topbar-dot.ready (no text, colour only)
-    await expect(page.locator(".topbar-dot.ready")).toBeVisible();
+    // Status dot replaced by canvas flip-toggle; default label is "⟳ Workflow"
+    await expect(page.locator(".canvas-flip-toggle")).toContainText("Workflow");
   });
 
   test("shows settings link in sidebar", async ({ page }) => {

--- a/e2e/tests/web-standalone.spec.ts
+++ b/e2e/tests/web-standalone.spec.ts
@@ -43,12 +43,13 @@ test.describe("Web standalone: app shell", () => {
     await expect(statusBar).toContainText("Agents only");
   });
 
-  test("top bar shows agents-only orchestrator status dot", async ({ page }) => {
+  test("top bar shows workflow toggle button", async ({ page }) => {
     await page.goto("/", { waitUntil: "commit" });
     await waitForApp(page);
 
-    // Browser mode: Unconfigured → topbar shows .topbar-dot.agents-only (colour dot, no text)
-    await expect(page.locator(".topbar-dot.agents-only")).toBeVisible();
+    // Status dot replaced by the canvas flip-toggle button in the topbar right zone
+    await expect(page.locator(".canvas-flip-toggle")).toBeVisible();
+    await expect(page.locator(".canvas-flip-toggle")).toContainText("Workflow");
   });
 
   test("navigation menu opens and shows links", async ({ page }) => {


### PR DESCRIPTION
## Summary

- Relocates the **⟳ Workflow / ⟳ Rendered** canvas flip-toggle from the canvas page into the TopBar right zone, sitting where the green orchestrator status dot used to live
- Removes the now-redundant `toggle_side` closure and `canvas-flip-toggle-row` wrapper div from `CanvasPage`
- Drops unused `OrchestratorState` / `OrchestratorStatus` imports from `topbar.rs`
- Button reuses the existing `canvas-flip-toggle` CSS class — no style changes needed

## Test plan

- [ ] Launch Papillon; confirm Workflow button appears at the right end of the address bar
- [ ] Click **⟳ Workflow** — canvas flips to the workflow pipeline view, button label changes to **⟳ Rendered**
- [ ] Click **⟳ Rendered** — canvas flips back, label returns to **⟳ Workflow**
- [ ] Verify no green dot remains in the topbar
- [ ] Verify the canvas page no longer renders the old toggle row above the flip container

🤖 Generated with [Claude Code](https://claude.com/claude-code)