### PR TITLE
docs: update Work With Us hero copy — reflect open-source SDKs

### DIFF
--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -459,8 +459,9 @@
         <span class="gradient-text">Getting it means building it right.</span>
       </h1>
       <p class="lead reveal reveal-delay-2">
-        You can't install PAP like a library and call it done. You need to reshape how your
-        infrastructure handles agent trust, data disclosure, and mandate scoping.
+        You can build with PAP now — it's open source, with SDKs for Rust, TypeScript, Python, C, C#, and Java.
+        Have the experts with you to build it for adoption: reshaping how your infrastructure handles agent trust,
+        data disclosure, and mandate scoping at scale.
         We're the team that does that with you.
       </p>
       <div class="hero-cta reveal reveal-delay-3">

--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -460,8 +460,8 @@
       </h1>
       <p class="lead reveal reveal-delay-2">
         You can build with PAP now — it's open source, with SDKs for Rust, TypeScript, Python, C, C#, and Java.
-        Have the experts with you to build it for adoption: reshaping how your infrastructure handles agent trust,
-        data disclosure, and mandate scoping at scale.
+        When you're ready to deploy it at scale, bring the experts who built it: we help teams integrate agent trust,
+        selective disclosure, and mandate scoping into production infrastructure.
         We're the team that does that with you.
       </p>
       <div class="hero-cta reveal reveal-delay-3">


### PR DESCRIPTION
## Summary

- Removes the line "You can't install PAP like a library and call it done" — we do have SDKs (Rust, TypeScript, Python, C, C#, Java)
- Reframes the value prop: **you can build with PAP now** (open source, multi-language), bring Baur Software for adoption-scale integration

## Change

**Before:**
> You can't install PAP like a library and call it done. You need to reshape how your infrastructure handles agent trust, data disclosure, and mandate scoping. We're the team that does that with you.

**After:**
> You can build with PAP now — it's open source, with SDKs for Rust, TypeScript, Python, C, C#, and Java. Have the experts with you to build it for adoption: reshaping how your infrastructure handles agent trust, data disclosure, and mandate scoping at scale. We're the team that does that with you.

## Test plan
- [ ] Single HTML file change, no logic
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)