### PR TITLE
ci: GHA Docker layer cache for registry builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,6 +132,12 @@ jobs:
           cache-on-failure: true
       - name: Install cargo-binstall
         uses: cargo-bins/cargo-binstall@main
+      - name: Cache wasm-pack binary
+        uses: actions/cache@v4
+        with:
+          path: ~/.cargo/bin/wasm-pack
+          key: wasm-pack-${{ runner.os }}-${{ hashFiles('crates/pap-wasm/Cargo.lock') }}
+          restore-keys: wasm-pack-${{ runner.os }}-
       - name: Install wasm-pack
         run: cargo binstall wasm-pack --no-confirm
       - uses: actions/setup-node@v4
@@ -458,12 +464,16 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build Chrysalis registry image
-        run: |
-          docker build \
-            -f apps/registry/Dockerfile \
-            --target runtime \
-            -t pap-registry:ci \
-            .
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: apps/registry/Dockerfile
+          target: runtime
+          push: false
+          load: true
+          tags: pap-registry:ci
+          cache-from: type=gha,scope=pap-registry-ci
+          cache-to: type=gha,scope=pap-registry-ci,mode=max
 
       - name: Start Chrysalis registry (no-TLS, plain HTTP)
         run: |


### PR DESCRIPTION
## Summary

- **`chrysalis-e2e-tier2`**: The raw `docker build` (no caching) is the current 13-minute CI bottleneck — it runs `cargo leptos build --release` inside Docker from scratch on every push. Replaced with `docker/build-push-action@v6` using `type=gha,mode=max` layer caching. After the first warm run, the expensive Rust compile step will be a cache hit and the rebuild will take ~30s instead of ~13m.
- **`build-extension`**: Added `actions/cache@v4` for the `wasm-pack` binary (keyed on `crates/pap-wasm/Cargo.lock`), saving ~30s on the `cargo binstall wasm-pack` install step on every run.

Note: the `chrysalis-e2e` job already uses `docker/build-push-action@v6` with GHA cache (`scope=chrysalis-ci`) — this PR brings `chrysalis-e2e-tier2` to the same standard.

## Test plan
- [ ] PR CI run completes green (first run primes the cache)
- [ ] Merge to main, trigger a second CI run — `chrysalis-e2e-tier2` Docker build step should show cache hits and drop from ~13m to ~1m
- [ ] `build-extension` wasm-pack install step hits cache on second run

🤖 Generated with [Claude Code](https://claude.com/claude-code)