### PR TITLE
ci: build registry Docker image once, share via artifact

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,41 @@ jobs:
           path: apps/papillon/frontend/dist/
           retention-days: 1
 
+  build-registry-image:
+    name: Build registry Docker image
+    runs-on: ubuntu-latest
+    needs: [changes]
+    if: |
+      always() &&
+      (needs.changes.result == 'skipped' || needs.changes.outputs.e2e == 'true')
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build registry image (with GHA layer cache)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: apps/registry/Dockerfile
+          target: runtime
+          push: false
+          load: true
+          tags: pap-registry:ci
+          cache-from: type=gha,scope=pap-registry-ci
+          cache-to: type=gha,scope=pap-registry-ci,mode=max
+
+      - name: Export image as compressed tarball
+        run: docker save pap-registry:ci | zstd -T0 -3 -o /tmp/pap-registry-ci.tar.zst
+
+      - name: Upload registry image artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: pap-registry-ci-image
+          path: /tmp/pap-registry-ci.tar.zst
+          retention-days: 1
+
   bench:
     name: Benchmark (regression gate)
     runs-on: ubuntu-latest
@@ -447,33 +482,25 @@ jobs:
   chrysalis-e2e-tier2:
     name: E2E Tier 2 (Chrysalis functional tests)
     runs-on: ubuntu-latest
-    needs: [changes, build-wasm]
+    needs: [changes, build-wasm, build-registry-image]
     if: |
       always() &&
       (needs.changes.result == 'skipped' || needs.changes.outputs.e2e == 'true') &&
-      needs.build-wasm.result == 'success'
+      needs.build-wasm.result == 'success' &&
+      needs.build-registry-image.result == 'success'
     env:
       CHRYSALIS_PORT: "7890"
     steps:
       - uses: actions/checkout@v6
 
-      - name: Install system dependencies
-        run: sudo apt-get update && sudo apt-get install -y pkg-config libssl-dev libpq-dev curl
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Build Chrysalis registry image
-        uses: docker/build-push-action@v7
+      - name: Download registry image artifact
+        uses: actions/download-artifact@v8
         with:
-          context: .
-          file: apps/registry/Dockerfile
-          target: runtime
-          push: false
-          load: true
-          tags: pap-registry:ci
-          cache-from: type=gha,scope=pap-registry-ci
-          cache-to: type=gha,scope=pap-registry-ci,mode=max
+          name: pap-registry-ci-image
+          path: /tmp
+
+      - name: Load registry image
+        run: zstd -d /tmp/pap-registry-ci.tar.zst --stdout | docker load
 
       - name: Start Chrysalis registry (no-TLS, plain HTTP)
         run: |


### PR DESCRIPTION
## Problem

\`type=gha\` Docker layer cache was hitting correctly (all layers \`CACHED\`) but the GHA cache API throttles at ~8MB/s. Downloading hundreds of MB of compiled Rust binary layers back to the runner was still taking **8-10 minutes** per run.

## Solution

Same artifact-sharing pattern already used for the WASM frontend build:

1. New **\`build-registry-image\`** job builds \`apps/registry/Dockerfile\` once, compresses with \`docker save | zstd\`, uploads via \`actions/upload-artifact\` (blob storage ~100-200MB/s). Keeps \`type=gha\` layer cache so the \`cargo leptos build --release\` step stays incrementally cached.
2. **\`chrysalis-e2e-tier2\`** downloads the tarball (~30-60s) and \`docker load\`s it — no Rust toolchain, no Docker build.

\`build-registry-image\` runs in parallel with \`build-wasm\` so no serial dependency is added to the critical path.

## Expected impact
- E2E Tier 2 Docker step: **~8-10m to ~30-60s** per run
- Total CI wall-clock: **~15m to ~6-7m** projected

## Test plan
- [ ] All checks green
- [ ] E2E Tier 2 completes without a Docker build step (just download + load)
- [ ] Timing confirms fast Docker load step

🤖 Generated with [Claude Code](https://claude.com/claude-code)