### PR TITLE
chore: CI timing test — registry image artifact

### DIFF
--- a/crates/pap-core/src/lib.rs
+++ b/crates/pap-core/src/lib.rs
@@ -1,4 +1,4 @@
-//! Core protocol primitives for the Principal Agent Protocol.
+//! Core protocol primitives for the Principal Agent Protocol (PAP).
 //!
 //! - `scope` — Schema.org action references, deny-by-default, disclosure sets
 //! - `mandate` — hierarchical delegation with chain verification and decay


### PR DESCRIPTION
Triggers full CI pipeline (code + e2e path filters) to benchmark the registry image artifact approach from PR #314. Should show E2E Tier 2 completing in ~2-3m instead of ~11m.