### PR TITLE
feat: WASM agent registry — embed catalog + IndexedDB persistence for Papillon browser build

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4929,12 +4929,18 @@ name = "papillon-shared"
 version = "0.8.2"
 dependencies = [
  "chrono",
+ "ed25519-dalek",
  "js-sys",
  "pap-agents",
+ "pap-did",
+ "pap-federation",
+ "pap-marketplace",
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
+ "toml 0.8.23",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4930,6 +4930,7 @@ version = "0.8.2"
 dependencies = [
  "chrono",
  "ed25519-dalek",
+ "getrandom 0.2.17",
  "js-sys",
  "pap-agents",
  "pap-did",

--- a/apps/papillon/frontend/Cargo.lock
+++ b/apps/papillon/frontend/Cargo.lock
@@ -271,8 +271,8 @@ dependencies = [
  "convert_case 0.6.0",
  "pathdiff",
  "serde_core",
- "toml",
- "winnow",
+ "toml 1.0.7+spec-1.1.0",
+ "winnow 1.0.0",
 ]
 
 [[package]]
@@ -763,6 +763,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "html-escape"
@@ -1291,6 +1297,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "pap-federation"
+version = "0.8.2"
+dependencies = [
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "hex",
+ "pap-core",
+ "pap-did",
+ "pap-marketplace",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "urlencoding",
+ "uuid",
+]
+
+[[package]]
+name = "pap-marketplace"
+version = "0.8.2"
+dependencies = [
+ "base64",
+ "chrono",
+ "ed25519-dalek",
+ "pap-core",
+ "pap-did",
+ "semver",
+ "serde",
+ "serde_json",
+ "sha2",
+ "thiserror 2.0.18",
+ "uuid",
+]
+
+[[package]]
 name = "pap-proto"
 version = "0.8.2"
 dependencies = [
@@ -1317,9 +1359,15 @@ name = "papillon-shared"
 version = "0.8.2"
 dependencies = [
  "chrono",
+ "ed25519-dalek",
  "js-sys",
+ "pap-did",
+ "pap-federation",
+ "pap-marketplace",
  "serde",
  "serde_json",
+ "sha2",
+ "toml 0.8.23",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",
@@ -1342,6 +1390,7 @@ dependencies = [
  "leptos_router",
  "pap-core",
  "pap-did",
+ "pap-marketplace",
  "pap-proto",
  "papillon-shared",
  "serde",
@@ -1785,6 +1834,15 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde_spanned"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
@@ -2061,15 +2119,36 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml"
 version = "1.0.7+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dd28d57d8a6f6e458bc0b8784f8fdcc4b99a437936056fa122cb234f18656a96"
 dependencies = [
  "serde_core",
- "serde_spanned",
- "toml_datetime",
+ "serde_spanned 1.0.4",
+ "toml_datetime 1.0.1+spec-1.1.0",
  "toml_parser",
- "winnow",
+ "winnow 1.0.0",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -2082,13 +2161,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned 0.6.9",
+ "toml_datetime 0.6.11",
+ "toml_write",
+ "winnow 0.7.15",
+]
+
+[[package]]
 name = "toml_parser"
 version = "1.0.10+spec-1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7df25b4befd31c4816df190124375d5a20c6b6921e2cad937316de3fccd63420"
 dependencies = [
- "winnow",
+ "winnow 1.0.0",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "typed-builder"
@@ -2155,6 +2254,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf8-width"
@@ -2432,6 +2537,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/apps/papillon/frontend/Cargo.toml
+++ b/apps/papillon/frontend/Cargo.toml
@@ -13,6 +13,7 @@ papillon-shared = { path = "../../../crates/papillon-shared", default-features =
 pap-did = { path = "../../../crates/pap-did", features = ["wasm"] }
 pap-core = { path = "../../../crates/pap-core" }
 pap-proto = { path = "../../../crates/pap-proto", features = ["wasm"] }
+pap-marketplace = { path = "../../../crates/pap-marketplace" }
 ed25519-dalek = { version = "2", features = ["rand_core", "zeroize"] }
 leptos = { version = "0.8", features = ["csr"] }
 leptos_router = "0.8"

--- a/apps/papillon/frontend/src/service/web_service.rs
+++ b/apps/papillon/frontend/src/service/web_service.rs
@@ -2,20 +2,24 @@
 //!
 //! This implementation provides a fallback for running Papillon in a pure
 //! WebAssembly environment without Tauri. It delegates to WebIdentityService
-//! for identity/profile management (Ed25519 keypairs in IndexedDB) and returns
-//! stub errors for operations that require backend compute.
+//! for identity/profile management (Ed25519 keypairs in IndexedDB) and wires
+//! agent/registry operations to `WasmAgentRegistry` backed by IndexedDB.
 //!
 //! # Design
 //!
 //! - **Identity & profiles**: Backed by `WebIdentityService` using `pap-did`
 //!   for Ed25519 keypair generation and IndexedDB for seed persistence
+//! - **Registry**: Backed by `WasmAgentRegistry` (IndexedDB) with the default
+//!   catalog seeded on first open
 //! - **Stub implementations**: Operations requiring backend logic (orchestrator,
-//!   registry discovery, scenario execution) return errors or sensible defaults
+//!   scenario execution) return errors or sensible defaults
 //! - **No IPC overhead**: Direct database access provides lower latency
 
 use std::sync::Mutex;
 
 use pap_did::PrincipalKeypair;
+#[cfg(feature = "wasm")]
+use papillon_shared::WasmAgentRegistry;
 
 use super::web_identity::WebIdentityService;
 use super::{AgentProfileInfo, PapillonService};
@@ -25,22 +29,62 @@ use papillon_shared::{
 };
 use serde_json::Value;
 
+/// The built-in local registry URL recognised as "this device's registry".
+#[cfg(feature = "wasm")]
+const LOCAL_REGISTRY_URL: &str = "pap://local";
+
 /// Service implementation for pure WASM environments with IndexedDB.
 ///
-/// Holds a `WebIdentityService` for identity/profile management. Uses
-/// `std::sync::Mutex` (not `RefCell`) to satisfy `Send + Sync` bounds
-/// required by `PapillonService`. This is safe because WASM is
-/// single-threaded — the mutex never actually contends.
+/// Holds a `WebIdentityService` for identity/profile management and a
+/// `WasmAgentRegistry` for local agent storage. Uses `std::sync::Mutex`
+/// (not `RefCell`) to satisfy `Send + Sync` bounds required by
+/// `PapillonService`. This is safe because WASM is single-threaded —
+/// the mutex never actually contends.
 pub struct WebService {
     identity: Mutex<WebIdentityService>,
+    #[cfg(feature = "wasm")]
+    registry: Mutex<WasmAgentRegistry>,
 }
 
 impl WebService {
-    /// Initialize the web service by loading profiles from IndexedDB.
+    /// Initialize the web service by loading profiles from IndexedDB and
+    /// seeding the default agent catalog.
     pub async fn new() -> Result<Self, String> {
         let identity = WebIdentityService::load().await?;
+
+        #[cfg(feature = "wasm")]
+        let registry = {
+            // On real wasm32 targets, open() awaits the IndexedDB promise.
+            // On native (--features wasm tests), new_empty() provides a
+            // synchronous in-memory alternative that is used instead.
+            #[cfg(target_arch = "wasm32")]
+            let mut reg = WasmAgentRegistry::open("papillon-agents")
+                .await
+                .map_err(|e| format!("Failed to open agent registry: {e}"))?;
+
+            #[cfg(not(target_arch = "wasm32"))]
+            let mut reg = WasmAgentRegistry::new_empty("papillon-agents")
+                .map_err(|e| format!("Failed to create agent registry: {e}"))?;
+
+            // seed_default_catalog is async on wasm32, sync on native.
+            // Both paths are handled via cfg — the return value (seeded count)
+            // is discarded; failures are soft-errors logged by the registry.
+            #[cfg(target_arch = "wasm32")]
+            reg.seed_default_catalog()
+                .await
+                .map_err(|e| format!("Failed to seed agent catalog: {e}"))?;
+
+            #[cfg(not(target_arch = "wasm32"))]
+            reg.seed_default_catalog()
+                .map_err(|e| format!("Failed to seed agent catalog: {e}"))?;
+
+            reg
+        };
+
         Ok(Self {
             identity: Mutex::new(identity),
+            #[cfg(feature = "wasm")]
+            registry: Mutex::new(registry),
         })
     }
 
@@ -48,7 +92,42 @@ impl WebService {
     pub fn empty() -> Self {
         Self {
             identity: Mutex::new(WebIdentityService::empty()),
+            #[cfg(feature = "wasm")]
+            registry: Mutex::new(
+                WasmAgentRegistry::new_empty("papillon-agents-empty")
+                    .unwrap_or_else(|_| {
+                        // new_empty can only fail if the in-memory DB itself can't be
+                        // created — essentially unreachable. Fall back silently.
+                        WasmAgentRegistry::new_empty("papillon-agents-fallback")
+                            .expect("fallback empty registry must succeed")
+                    }),
+            ),
         }
+    }
+}
+
+/// Convert an `AgentAdvertisement` into the frontend-facing `AgentInfo` DTO.
+///
+/// Mirrors the `ad_to_info` helper in `apps/papillon/src/commands/registry.rs`
+/// for the Tauri path, keeping the two representations in sync.
+#[cfg(feature = "wasm")]
+fn ad_to_info(ad: &pap_marketplace::AgentAdvertisement) -> AgentInfo {
+    AgentInfo {
+        name: ad.name.clone(),
+        provider_name: ad.provider.name.clone(),
+        provider_did: ad.provider.did.clone(),
+        capabilities: ad.capability.clone(),
+        object_types: ad.object_types.clone(),
+        requires_disclosure: ad.requires_disclosure.clone(),
+        returns: ad.returns.clone(),
+        content_hash: ad.hash(),
+        endpoint: None,
+        agent_did: None,
+        source: "catalog".to_owned(),
+        published_to: vec![],
+        // Catalog agents are seeded locally and are directly invocable.
+        live: true,
+        category: "general".to_owned(),
     }
 }
 
@@ -152,14 +231,52 @@ impl PapillonService for WebService {
     // REGISTRY & AGENTS
     // ============================================================================
 
-    async fn navigate_registry(&self, _url: &str) -> Result<RegistryInfo, String> {
-        // Registry discovery requires network access and TOFU bootstrap.
-        Err("WebService: navigate_registry not yet implemented (requires network)".into())
+    async fn navigate_registry(&self, url: &str) -> Result<RegistryInfo, String> {
+        #[cfg(feature = "wasm")]
+        {
+            let registry = self
+                .registry
+                .lock()
+                .map_err(|e| format!("registry lock: {e}"))?;
+            return Ok(RegistryInfo {
+                url: if url.is_empty() || url == LOCAL_REGISTRY_URL {
+                    LOCAL_REGISTRY_URL.to_owned()
+                } else {
+                    url.to_owned()
+                },
+                agent_count: registry.agent_count(),
+                // WASM runs locally — no federation peers.
+                peer_count: 0,
+            });
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            let _ = url;
+            Err("WebService: navigate_registry requires wasm feature".into())
+        }
     }
 
-    async fn list_registry_agents(&self, _registry_url: &str) -> Result<Vec<AgentInfo>, String> {
-        // Requires network access to fetch agents from registry.
-        Err("WebService: list_registry_agents not yet implemented (requires network)".into())
+    async fn list_registry_agents(&self, registry_url: &str) -> Result<Vec<AgentInfo>, String> {
+        #[cfg(feature = "wasm")]
+        {
+            let registry = self
+                .registry
+                .lock()
+                .map_err(|e| format!("registry lock: {e}"))?;
+            // If the caller passes a schema: action prefix, filter by action;
+            // otherwise return all agents in the local catalog.
+            let ads = if registry_url.starts_with("schema:") {
+                registry.query_by_action(registry_url)
+            } else {
+                registry.list_agents()
+            };
+            return Ok(ads.iter().map(ad_to_info).collect());
+        }
+        #[cfg(not(feature = "wasm"))]
+        {
+            let _ = registry_url;
+            Err("WebService: list_registry_agents requires wasm feature".into())
+        }
     }
 
     // ============================================================================
@@ -213,6 +330,10 @@ impl PapillonService for WebService {
                 identity.switch_profile(&first.id).await?;
             }
         }
+
+        // The registry catalog was seeded in new(). initialize() is called
+        // post-construction, so no additional seeding is required here.
+
         Ok(())
     }
 

--- a/apps/papillon/frontend/src/service/web_service.rs
+++ b/apps/papillon/frontend/src/service/web_service.rs
@@ -67,16 +67,23 @@ impl WebService {
                 .map_err(|e| format!("Failed to create agent registry: {e}"))?;
 
             // seed_default_catalog is async on wasm32, sync on native.
-            // Both paths are handled via cfg — the return value (seeded count)
-            // is discarded; failures are soft-errors logged by the registry.
+            // Seeding failure is a soft-error — the registry remains usable
+            // (empty) and the user can still interact with the app.
             #[cfg(target_arch = "wasm32")]
-            reg.seed_default_catalog()
-                .await
-                .map_err(|e| format!("Failed to seed agent catalog: {e}"))?;
+            if let Err(e) = reg.seed_default_catalog().await {
+                web_sys::console::warn_1(
+                    &format!(
+                        "WebService: catalog seeding failed (continuing with empty registry): {e}"
+                    )
+                    .into(),
+                );
+            }
 
             #[cfg(not(target_arch = "wasm32"))]
-            reg.seed_default_catalog()
-                .map_err(|e| format!("Failed to seed agent catalog: {e}"))?;
+            if let Err(_e) = reg.seed_default_catalog() {
+                // Suppress unused-variable warning in tests; the failure is non-fatal.
+                let _ = ();
+            }
 
             reg
         };
@@ -94,13 +101,10 @@ impl WebService {
             identity: Mutex::new(WebIdentityService::empty()),
             #[cfg(feature = "wasm")]
             registry: Mutex::new(
+                // new_empty can only fail if the in-memory DB itself can't be
+                // created — essentially unreachable on any supported platform.
                 WasmAgentRegistry::new_empty("papillon-agents-empty")
-                    .unwrap_or_else(|_| {
-                        // new_empty can only fail if the in-memory DB itself can't be
-                        // created — essentially unreachable. Fall back silently.
-                        WasmAgentRegistry::new_empty("papillon-agents-fallback")
-                            .expect("fallback empty registry must succeed")
-                    }),
+                    .expect("in-memory registry must succeed"),
             ),
         }
     }
@@ -123,6 +127,9 @@ fn ad_to_info(ad: &pap_marketplace::AgentAdvertisement) -> AgentInfo {
         content_hash: ad.hash(),
         endpoint: None,
         agent_did: None,
+        // "catalog" is the correct value for agents seeded from the embedded catalog.
+        // Note: the Tauri registry.rs ad_to_info currently uses "" — that's a known gap
+        // in the native implementation, not the correct behavior.
         source: "catalog".to_owned(),
         published_to: vec![],
         // Catalog agents are seeded locally and are directly invocable.
@@ -234,26 +241,28 @@ impl PapillonService for WebService {
     async fn navigate_registry(&self, url: &str) -> Result<RegistryInfo, String> {
         #[cfg(feature = "wasm")]
         {
+            // WASM supports only the local registry; remote federation is not yet implemented.
+            // Return an error for any non-local URL rather than silently serving local data.
+            const LOCAL_URLS: &[&str] = &["", "pap://local", "local"];
+            if !LOCAL_URLS.iter().any(|&u| u == url.trim()) {
+                return Err(format!(
+                    "WebService: remote registry navigation not supported in WASM \
+                     (url: '{url}'); only the local agent catalog is available"
+                ));
+            }
             let registry = self
                 .registry
                 .lock()
                 .map_err(|e| format!("registry lock: {e}"))?;
             return Ok(RegistryInfo {
-                url: if url.is_empty() || url == LOCAL_REGISTRY_URL {
-                    LOCAL_REGISTRY_URL.to_owned()
-                } else {
-                    url.to_owned()
-                },
+                url: LOCAL_REGISTRY_URL.to_owned(),
                 agent_count: registry.agent_count(),
                 // WASM runs locally — no federation peers.
                 peer_count: 0,
             });
         }
         #[cfg(not(feature = "wasm"))]
-        {
-            let _ = url;
-            Err("WebService: navigate_registry requires wasm feature".into())
-        }
+        Err("WebService: navigate_registry not available without wasm feature".into())
     }
 
     async fn list_registry_agents(&self, registry_url: &str) -> Result<Vec<AgentInfo>, String> {
@@ -263,8 +272,9 @@ impl PapillonService for WebService {
                 .registry
                 .lock()
                 .map_err(|e| format!("registry lock: {e}"))?;
-            // If the caller passes a schema: action prefix, filter by action;
-            // otherwise return all agents in the local catalog.
+            // NOTE: `registry_url` is overloaded here: if it starts with "schema:", it is treated
+            // as a Schema.org action type for capability filtering; otherwise it is treated as a
+            // registry URL (only "pap://local" or empty is supported in WASM).
             let ads = if registry_url.starts_with("schema:") {
                 registry.query_by_action(registry_url)
             } else {

--- a/crates/pap-agents/Cargo.toml
+++ b/crates/pap-agents/Cargo.toml
@@ -37,8 +37,8 @@ candle-transformers = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
 
 [build-dependencies]
-toml = "0.8"
-serde_json = "1"
+toml = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 pap-credential-store = { workspace = true, features = ["testing"] }

--- a/crates/pap-agents/Cargo.toml
+++ b/crates/pap-agents/Cargo.toml
@@ -36,6 +36,10 @@ candle-core = { workspace = true, optional = true }
 candle-transformers = { workspace = true, optional = true }
 tokenizers = { workspace = true, optional = true }
 
+[build-dependencies]
+toml = "0.8"
+serde_json = "1"
+
 [dev-dependencies]
 pap-credential-store = { workspace = true, features = ["testing"] }
 rand = { workspace = true }

--- a/crates/pap-agents/build.rs
+++ b/crates/pap-agents/build.rs
@@ -70,6 +70,10 @@ fn load_toml_as_json(
     catalog_root: &std::path::Path,
     path: &std::path::Path,
 ) -> Option<serde_json::Value> {
+    // Emit a per-file rerun directive so Cargo rebuilds when any individual
+    // TOML file changes, not just when the directory mtime changes.
+    println!("cargo:rerun-if-changed={}", path.display());
+
     let raw = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {

--- a/crates/pap-agents/build.rs
+++ b/crates/pap-agents/build.rs
@@ -91,9 +91,9 @@ fn load_toml_as_json(
 
     // Inject fields that DynamicAgentDef requires but catalog TOMLs omit.
     if let Some(obj) = json_val.as_object_mut() {
-        // `source` — always "Catalog" for embedded catalog entries.
-        obj.entry("source")
-            .or_insert_with(|| serde_json::Value::String("Catalog".to_string()));
+        // `source` — always "Catalog" for embedded catalog entries; overwrite unconditionally
+        // so a TOML that accidentally sets source="UserCreated" doesn't leak through.
+        obj.insert("source".into(), serde_json::Value::String("Catalog".to_string()));
 
         // `catalog_path` — relative path from catalog root, forward-slash separators.
         let rel = path
@@ -138,7 +138,9 @@ fn toml_to_json(val: toml::Value) -> serde_json::Value {
     match val {
         toml::Value::String(s) => serde_json::Value::String(s),
         toml::Value::Integer(i) => serde_json::Value::Number(i.into()),
-        toml::Value::Float(f) => serde_json::json!(f),
+        toml::Value::Float(f) => serde_json::Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
         toml::Value::Boolean(b) => serde_json::Value::Bool(b),
         toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
         toml::Value::Array(arr) => {

--- a/crates/pap-agents/build.rs
+++ b/crates/pap-agents/build.rs
@@ -1,0 +1,155 @@
+//! Build script for pap-agents.
+//!
+//! Walks all `*.toml` files under `catalog/`, converts each to a JSON object
+//! (via `toml::Value` → `serde_json::Value` so no struct duplication is
+//! needed), and writes them as a JSON array to `$OUT_DIR/catalog.json`.
+//!
+//! The output is embedded at compile time by `src/catalog.rs`
+//! (`default_catalog()`) using `include_str!`, making the catalog available
+//! in WASM builds without any filesystem access at runtime.
+
+use std::path::PathBuf;
+
+fn main() {
+    // Tell Cargo to re-run this script whenever the catalog changes.
+    println!("cargo:rerun-if-changed=catalog/");
+
+    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
+        .expect("CARGO_MANIFEST_DIR must be set by Cargo");
+    let catalog_dir = PathBuf::from(&manifest_dir).join("catalog");
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo");
+    let out_path = PathBuf::from(&out_dir).join("catalog.json");
+
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    collect_toml_entries(&catalog_dir, &catalog_dir, &mut entries);
+
+    let json = serde_json::to_string(&entries)
+        .expect("failed to serialize catalog entries to JSON");
+    std::fs::write(&out_path, json)
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", out_path.display()));
+
+    eprintln!(
+        "[build] wrote {} catalog entries to {}",
+        entries.len(),
+        out_path.display()
+    );
+}
+
+fn collect_toml_entries(
+    catalog_root: &std::path::Path,
+    dir: &std::path::Path,
+    out: &mut Vec<serde_json::Value>,
+) {
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            eprintln!("[build] cannot read directory {}: {e}", dir.display());
+            return;
+        }
+    };
+
+    let mut paths: Vec<std::path::PathBuf> = read_dir
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    // Sort for deterministic output order.
+    paths.sort();
+
+    for path in paths {
+        if path.is_dir() {
+            collect_toml_entries(catalog_root, &path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+            if let Some(val) = load_toml_as_json(catalog_root, &path) {
+                out.push(val);
+            }
+        }
+    }
+}
+
+fn load_toml_as_json(
+    catalog_root: &std::path::Path,
+    path: &std::path::Path,
+) -> Option<serde_json::Value> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[build] cannot read {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    let toml_val: toml::Value = match toml::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[build] parse error in {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    // Convert TOML value tree → serde_json::Value.
+    let mut json_val = toml_to_json(toml_val);
+
+    // Inject fields that DynamicAgentDef requires but catalog TOMLs omit.
+    if let Some(obj) = json_val.as_object_mut() {
+        // `source` — always "Catalog" for embedded catalog entries.
+        obj.entry("source")
+            .or_insert_with(|| serde_json::Value::String("Catalog".to_string()));
+
+        // `catalog_path` — relative path from catalog root, forward-slash separators.
+        let rel = path
+            .strip_prefix(catalog_root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        obj.entry("catalog_path")
+            .or_insert_with(|| serde_json::Value::String(rel));
+
+        // Fields with empty defaults that DynamicAgentDef expects.
+        obj.entry("agent_did").or_insert(serde_json::Value::Null);
+        obj.entry("operator_key_seed")
+            .or_insert(serde_json::Value::Null);
+        obj.entry("published_to")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("created_at")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("updated_at")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("llm_instructions")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("subagents")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("object_types")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("requires_disclosure")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("returns")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("configurable_properties")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("version")
+            .or_insert_with(|| serde_json::Value::String("0.1.0".to_string()));
+    }
+
+    Some(json_val)
+}
+
+/// Recursively convert a [`toml::Value`] to a [`serde_json::Value`].
+fn toml_to_json(val: toml::Value) -> serde_json::Value {
+    match val {
+        toml::Value::String(s) => serde_json::Value::String(s),
+        toml::Value::Integer(i) => serde_json::Value::Number(i.into()),
+        toml::Value::Float(f) => serde_json::json!(f),
+        toml::Value::Boolean(b) => serde_json::Value::Bool(b),
+        toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+        toml::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(toml_to_json).collect())
+        }
+        toml::Value::Table(tbl) => {
+            let map = tbl
+                .into_iter()
+                .map(|(k, v)| (k, toml_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}

--- a/crates/pap-agents/build.rs
+++ b/crates/pap-agents/build.rs
@@ -14,8 +14,8 @@ fn main() {
     // Tell Cargo to re-run this script whenever the catalog changes.
     println!("cargo:rerun-if-changed=catalog/");
 
-    let manifest_dir = std::env::var("CARGO_MANIFEST_DIR")
-        .expect("CARGO_MANIFEST_DIR must be set by Cargo");
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo");
     let catalog_dir = PathBuf::from(&manifest_dir).join("catalog");
     let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo");
     let out_path = PathBuf::from(&out_dir).join("catalog.json");
@@ -23,8 +23,8 @@ fn main() {
     let mut entries: Vec<serde_json::Value> = Vec::new();
     collect_toml_entries(&catalog_dir, &catalog_dir, &mut entries);
 
-    let json = serde_json::to_string(&entries)
-        .expect("failed to serialize catalog entries to JSON");
+    let json =
+        serde_json::to_string(&entries).expect("failed to serialize catalog entries to JSON");
     std::fs::write(&out_path, json)
         .unwrap_or_else(|e| panic!("failed to write {}: {e}", out_path.display()));
 
@@ -48,10 +48,7 @@ fn collect_toml_entries(
         }
     };
 
-    let mut paths: Vec<std::path::PathBuf> = read_dir
-        .flatten()
-        .map(|e| e.path())
-        .collect();
+    let mut paths: Vec<std::path::PathBuf> = read_dir.flatten().map(|e| e.path()).collect();
     // Sort for deterministic output order.
     paths.sort();
 
@@ -97,7 +94,10 @@ fn load_toml_as_json(
     if let Some(obj) = json_val.as_object_mut() {
         // `source` — always "Catalog" for embedded catalog entries; overwrite unconditionally
         // so a TOML that accidentally sets source="UserCreated" doesn't leak through.
-        obj.insert("source".into(), serde_json::Value::String("Catalog".to_string()));
+        obj.insert(
+            "source".into(),
+            serde_json::Value::String("Catalog".to_string()),
+        );
 
         // `catalog_path` — relative path from catalog root, forward-slash separators.
         let rel = path
@@ -151,10 +151,7 @@ fn toml_to_json(val: toml::Value) -> serde_json::Value {
             serde_json::Value::Array(arr.into_iter().map(toml_to_json).collect())
         }
         toml::Value::Table(tbl) => {
-            let map = tbl
-                .into_iter()
-                .map(|(k, v)| (k, toml_to_json(v)))
-                .collect();
+            let map = tbl.into_iter().map(|(k, v)| (k, toml_to_json(v))).collect();
             serde_json::Value::Object(map)
         }
     }

--- a/crates/pap-agents/src/catalog.rs
+++ b/crates/pap-agents/src/catalog.rs
@@ -44,7 +44,8 @@ struct CatalogEntry {
 #[cfg(target_arch = "wasm32")]
 pub fn default_catalog() -> Vec<DynamicAgentDef> {
     const CATALOG_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/catalog.json"));
-    serde_json::from_str(CATALOG_JSON).unwrap_or_default()
+    serde_json::from_str(CATALOG_JSON)
+        .expect("embedded catalog.json failed to deserialize — re-run build.rs to regenerate")
 }
 
 pub fn load_catalog(catalog_dir: &Path) -> Vec<DynamicAgentDef> {
@@ -185,6 +186,23 @@ mod tests {
                 "action '{}' in '{}' does not start with 'schema:'",
                 def.action,
                 def.name
+            );
+        }
+    }
+
+    #[test]
+    fn embedded_catalog_deserializes() {
+        const CATALOG_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/catalog.json"));
+        let defs: Vec<DynamicAgentDef> = serde_json::from_str(CATALOG_JSON)
+            .expect("embedded catalog.json must deserialize without error");
+        assert!(defs.len() >= 300, "expected 300+ entries, got {}", defs.len());
+        // Verify source field is always Catalog
+        for def in &defs {
+            assert!(
+                matches!(def.source, DynamicAgentSource::Catalog),
+                "expected source=Catalog for {}, got {:?}",
+                def.name,
+                def.source
             );
         }
     }

--- a/crates/pap-agents/src/catalog.rs
+++ b/crates/pap-agents/src/catalog.rs
@@ -195,7 +195,11 @@ mod tests {
         const CATALOG_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/catalog.json"));
         let defs: Vec<DynamicAgentDef> = serde_json::from_str(CATALOG_JSON)
             .expect("embedded catalog.json must deserialize without error");
-        assert!(defs.len() >= 300, "expected 300+ entries, got {}", defs.len());
+        assert!(
+            defs.len() >= 300,
+            "expected 300+ entries, got {}",
+            defs.len()
+        );
         // Verify source field is always Catalog
         for def in &defs {
             assert!(

--- a/crates/pap-agents/src/catalog.rs
+++ b/crates/pap-agents/src/catalog.rs
@@ -36,6 +36,17 @@ struct CatalogEntry {
     configurable_properties: Vec<serde_json::Value>,
 }
 
+/// Returns the embedded default catalog for WASM builds (no filesystem required).
+///
+/// The catalog JSON is baked into the binary at compile time by `build.rs`,
+/// which walks `catalog/**/*.toml` and serialises every entry as a JSON array
+/// compatible with [`DynamicAgentDef`]'s serde shape.
+#[cfg(target_arch = "wasm32")]
+pub fn default_catalog() -> Vec<DynamicAgentDef> {
+    const CATALOG_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/catalog.json"));
+    serde_json::from_str(CATALOG_JSON).unwrap_or_default()
+}
+
 pub fn load_catalog(catalog_dir: &Path) -> Vec<DynamicAgentDef> {
     let mut defs = Vec::new();
     collect_toml_files(catalog_dir, catalog_dir, &mut defs);

--- a/crates/pap-agents/src/lib.rs
+++ b/crates/pap-agents/src/lib.rs
@@ -33,9 +33,9 @@ pub mod selection;
 pub mod session_store;
 mod simple;
 
-pub use catalog::load_catalog;
 #[cfg(target_arch = "wasm32")]
 pub use catalog::default_catalog;
+pub use catalog::load_catalog;
 pub use dynamic::{
     is_local_llm_url, is_safe_url, DynamicAgentDef, DynamicAgentSource, HttpEndpointConfig,
     HttpMethod,

--- a/crates/pap-agents/src/lib.rs
+++ b/crates/pap-agents/src/lib.rs
@@ -34,6 +34,8 @@ pub mod session_store;
 mod simple;
 
 pub use catalog::load_catalog;
+#[cfg(target_arch = "wasm32")]
+pub use catalog::default_catalog;
 pub use dynamic::{
     is_local_llm_url, is_safe_url, DynamicAgentDef, DynamicAgentSource, HttpEndpointConfig,
     HttpMethod,

--- a/crates/papillon-shared/Cargo.toml
+++ b/crates/papillon-shared/Cargo.toml
@@ -42,6 +42,9 @@ pap-federation = { workspace = true, default-features = false, optional = true }
 pap-did = { workspace = true, optional = true }
 ed25519-dalek = { workspace = true, optional = true }
 sha2 = { workspace = true, optional = true }
+# getrandom with `js` feature is required for wasm32-unknown-unknown so that
+# rand/ed25519-dalek can generate random numbers via the Web Crypto API.
+getrandom = { workspace = true, optional = true }
 
 [dev-dependencies]
 tempfile = "3"
@@ -59,6 +62,8 @@ wasm = [
     # WasmAgentRegistry deps — included here so tests run under `--features wasm`
     # on native as well as in actual wasm32 browser builds.
     "pap-marketplace", "pap-federation", "pap-did", "ed25519-dalek", "sha2",
+    # getrandom/js enables Web Crypto API for random number generation on wasm32
+    "getrandom/js",
 ]
 
 [lints]

--- a/crates/papillon-shared/Cargo.toml
+++ b/crates/papillon-shared/Cargo.toml
@@ -16,7 +16,7 @@ uuid = { workspace = true }
 # Database abstraction - feature gated
 rusqlite = { version = "0.32", features = ["bundled", "serde_json"], optional = true }
 
-# WASM/IndexedDB dependencies - feature gated
+# WASM/IndexedDB browser-binding dependencies - feature gated
 wasm-bindgen = { version = "0.2", optional = true }
 js-sys = { version = "0.3", optional = true }
 web-sys = { version = "0.3", optional = true, features = [
@@ -29,14 +29,37 @@ web-sys = { version = "0.3", optional = true, features = [
 ] }
 wasm-bindgen-futures = { version = "0.4", optional = true }
 
+# WasmAgentRegistry dependencies — WASM-compatible crates that also compile on
+# native (for tests).  Tied to the `wasm` feature rather than a target gate so
+# that `cargo test -p papillon-shared --features wasm` works without a browser.
+#
+# pap-agents is intentionally absent: it has unconditional reqwest::blocking +
+# tokio deps that do not compile for wasm32-unknown-unknown.
+pap-marketplace = { workspace = true, optional = true }
+# Use default-features=false so pap-federation's native server/TLS code is
+# excluded.  On real wasm32 builds the "wasm" feature is added explicitly.
+pap-federation = { workspace = true, default-features = false, optional = true }
+pap-did = { workspace = true, optional = true }
+ed25519-dalek = { workspace = true, optional = true }
+sha2 = { workspace = true, optional = true }
+
 [dev-dependencies]
 tempfile = "3"
+
+[build-dependencies]
+toml = { workspace = true }
+serde_json = { workspace = true }
 
 # Feature flags
 [features]
 default = ["native"]
 native = ["rusqlite", "pap-agents"]
-wasm = ["wasm-bindgen", "js-sys", "web-sys", "wasm-bindgen-futures", "uuid/js"]
+wasm = [
+    "wasm-bindgen", "js-sys", "web-sys", "wasm-bindgen-futures", "uuid/js",
+    # WasmAgentRegistry deps — included here so tests run under `--features wasm`
+    # on native as well as in actual wasm32 browser builds.
+    "pap-marketplace", "pap-federation", "pap-did", "ed25519-dalek", "sha2",
+]
 
 [lints]
 workspace = true

--- a/crates/papillon-shared/build.rs
+++ b/crates/papillon-shared/build.rs
@@ -55,10 +55,7 @@ fn collect_toml_entries(
         }
     };
 
-    let mut paths: Vec<std::path::PathBuf> = read_dir
-        .flatten()
-        .map(|e| e.path())
-        .collect();
+    let mut paths: Vec<std::path::PathBuf> = read_dir.flatten().map(|e| e.path()).collect();
     paths.sort();
 
     for path in paths {
@@ -153,10 +150,7 @@ fn toml_to_json(val: toml::Value) -> serde_json::Value {
             serde_json::Value::Array(arr.into_iter().map(toml_to_json).collect())
         }
         toml::Value::Table(tbl) => {
-            let map = tbl
-                .into_iter()
-                .map(|(k, v)| (k, toml_to_json(v)))
-                .collect();
+            let map = tbl.into_iter().map(|(k, v)| (k, toml_to_json(v))).collect();
             serde_json::Value::Object(map)
         }
     }

--- a/crates/papillon-shared/build.rs
+++ b/crates/papillon-shared/build.rs
@@ -1,0 +1,159 @@
+//! Build script for papillon-shared.
+//!
+//! Generates `$OUT_DIR/catalog.json` for the WASM registry by walking the
+//! shared catalog under `../pap-agents/catalog/`.  The output is embedded at
+//! compile time by `src/wasm_registry.rs` via `include_str!`.
+//!
+//! This mirrors the logic in `pap-agents/build.rs` but runs from the
+//! `papillon-shared` crate so it can be included in WASM builds without
+//! pulling in the pap-agents crate (which has native-only deps).
+
+use std::path::PathBuf;
+
+fn main() {
+    let manifest_dir =
+        std::env::var("CARGO_MANIFEST_DIR").expect("CARGO_MANIFEST_DIR must be set by Cargo");
+    // Walk up two levels: papillon-shared → crates → workspace root → pap-agents/catalog
+    let catalog_dir = PathBuf::from(&manifest_dir)
+        .join("..")
+        .join("pap-agents")
+        .join("catalog");
+
+    // Tell Cargo to re-run this script whenever the catalog changes.
+    println!("cargo:rerun-if-changed={}", catalog_dir.display());
+
+    let out_dir = std::env::var("OUT_DIR").expect("OUT_DIR must be set by Cargo");
+    let out_path = PathBuf::from(&out_dir).join("catalog.json");
+
+    let mut entries: Vec<serde_json::Value> = Vec::new();
+    if catalog_dir.exists() {
+        collect_toml_entries(&catalog_dir, &catalog_dir, &mut entries);
+    }
+
+    let json =
+        serde_json::to_string(&entries).expect("failed to serialize catalog entries to JSON");
+    std::fs::write(&out_path, &json)
+        .unwrap_or_else(|e| panic!("failed to write {}: {e}", out_path.display()));
+
+    eprintln!(
+        "[papillon-shared build] wrote {} catalog entries to {}",
+        entries.len(),
+        out_path.display()
+    );
+}
+
+fn collect_toml_entries(
+    catalog_root: &std::path::Path,
+    dir: &std::path::Path,
+    out: &mut Vec<serde_json::Value>,
+) {
+    let read_dir = match std::fs::read_dir(dir) {
+        Ok(rd) => rd,
+        Err(e) => {
+            eprintln!("[build] cannot read directory {}: {e}", dir.display());
+            return;
+        }
+    };
+
+    let mut paths: Vec<std::path::PathBuf> = read_dir
+        .flatten()
+        .map(|e| e.path())
+        .collect();
+    paths.sort();
+
+    for path in paths {
+        if path.is_dir() {
+            collect_toml_entries(catalog_root, &path, out);
+        } else if path.extension().and_then(|s| s.to_str()) == Some("toml") {
+            if let Some(val) = load_toml_as_json(catalog_root, &path) {
+                out.push(val);
+            }
+        }
+    }
+}
+
+fn load_toml_as_json(
+    catalog_root: &std::path::Path,
+    path: &std::path::Path,
+) -> Option<serde_json::Value> {
+    let raw = match std::fs::read_to_string(path) {
+        Ok(s) => s,
+        Err(e) => {
+            eprintln!("[build] cannot read {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    let toml_val: toml::Value = match toml::from_str(&raw) {
+        Ok(v) => v,
+        Err(e) => {
+            eprintln!("[build] parse error in {}: {e}", path.display());
+            return None;
+        }
+    };
+
+    let mut json_val = toml_to_json(toml_val);
+
+    if let Some(obj) = json_val.as_object_mut() {
+        obj.insert(
+            "source".into(),
+            serde_json::Value::String("Catalog".to_string()),
+        );
+
+        let rel = path
+            .strip_prefix(catalog_root)
+            .unwrap_or(path)
+            .to_string_lossy()
+            .replace('\\', "/");
+        obj.entry("catalog_path")
+            .or_insert_with(|| serde_json::Value::String(rel));
+
+        obj.entry("agent_did").or_insert(serde_json::Value::Null);
+        obj.entry("operator_key_seed")
+            .or_insert(serde_json::Value::Null);
+        obj.entry("published_to")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("created_at")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("updated_at")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("llm_instructions")
+            .or_insert_with(|| serde_json::Value::String(String::new()));
+        obj.entry("subagents")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("object_types")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("requires_disclosure")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("returns")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("configurable_properties")
+            .or_insert_with(|| serde_json::Value::Array(vec![]));
+        obj.entry("version")
+            .or_insert_with(|| serde_json::Value::String("0.1.0".to_string()));
+    }
+
+    Some(json_val)
+}
+
+fn toml_to_json(val: toml::Value) -> serde_json::Value {
+    match val {
+        toml::Value::String(s) => serde_json::Value::String(s),
+        toml::Value::Integer(i) => serde_json::Value::Number(i.into()),
+        toml::Value::Float(f) => serde_json::Number::from_f64(f)
+            .map(serde_json::Value::Number)
+            .unwrap_or(serde_json::Value::Null),
+        toml::Value::Boolean(b) => serde_json::Value::Bool(b),
+        toml::Value::Datetime(dt) => serde_json::Value::String(dt.to_string()),
+        toml::Value::Array(arr) => {
+            serde_json::Value::Array(arr.into_iter().map(toml_to_json).collect())
+        }
+        toml::Value::Table(tbl) => {
+            let map = tbl
+                .into_iter()
+                .map(|(k, v)| (k, toml_to_json(v)))
+                .collect();
+            serde_json::Value::Object(map)
+        }
+    }
+}

--- a/crates/papillon-shared/build.rs
+++ b/crates/papillon-shared/build.rs
@@ -76,6 +76,10 @@ fn load_toml_as_json(
     catalog_root: &std::path::Path,
     path: &std::path::Path,
 ) -> Option<serde_json::Value> {
+    // Emit a per-file rerun directive so Cargo rebuilds when any individual
+    // TOML file changes, not just when the directory mtime changes.
+    println!("cargo:rerun-if-changed={}", path.display());
+
     let raw = match std::fs::read_to_string(path) {
         Ok(s) => s,
         Err(e) => {
@@ -109,8 +113,8 @@ fn load_toml_as_json(
             .or_insert_with(|| serde_json::Value::String(rel));
 
         obj.entry("agent_did").or_insert(serde_json::Value::Null);
-        obj.entry("operator_key_seed")
-            .or_insert(serde_json::Value::Null);
+        // operator_key_seed is intentionally omitted — it is marked #[serde(skip)]
+        // on WasmDynamicAgentDef and is always re-derived from `name` at runtime.
         obj.entry("published_to")
             .or_insert_with(|| serde_json::Value::Array(vec![]));
         obj.entry("created_at")

--- a/crates/papillon-shared/src/db/indexed_db.rs
+++ b/crates/papillon-shared/src/db/indexed_db.rs
@@ -27,7 +27,7 @@ use crate::types::Template;
 
 /// Current snapshot format version. Bump when the schema changes so
 /// `restore_state` can detect and migrate old snapshots.
-const SNAPSHOT_VERSION: u64 = 1;
+const SNAPSHOT_VERSION: u64 = 2;
 
 /// IndexedDB-backed database that persists all operations.
 ///
@@ -160,6 +160,27 @@ impl IndexedDbDatabase {
             }
         }
 
+        // v2+: agent defs stored as {"name": <name>, "json": <raw-json>} objects
+        if let Some(agents) = state.get("agents").and_then(|v| v.as_array()) {
+            for (_i, val) in agents.iter().enumerate() {
+                let name = val.get("name").and_then(|v| v.as_str());
+                let json = val.get("json").and_then(|v| v.as_str());
+                match (name, json) {
+                    (Some(n), Some(j)) => self.inner.upsert_agent_def(n, j)?,
+                    _ => {
+                        #[cfg(target_arch = "wasm32")]
+                        web_sys::console::warn_1(
+                            &format!(
+                                "papillon: skipping corrupt agent_def[{}]: missing name or json",
+                                _i
+                            )
+                            .into(),
+                        );
+                    }
+                }
+            }
+        }
+
         Ok(())
     }
 
@@ -173,12 +194,24 @@ impl IndexedDbDatabase {
             .map(|(k, v)| (k, serde_json::Value::String(v)))
             .collect();
 
+        // Serialise agent defs as an array of {name, json} objects so they
+        // round-trip without any dependency on the pap-agents crate.
+        let agents_array: Vec<serde_json::Value> = self
+            .inner
+            .list_all_agent_defs()?
+            .into_iter()
+            .map(|(name, json)| {
+                serde_json::json!({ "name": name, "json": json })
+            })
+            .collect();
+
         let state = serde_json::json!({
             "version": SNAPSHOT_VERSION,
             "episodes": self.inner.list_all_episodes()?,
             "profiles": self.inner.list_agent_profiles()?,
             "settings": settings_map,
             "templates": self.inner.list_all_templates()?,
+            "agents": agents_array,
         });
 
         serde_json::to_string(&state).map_err(|e| DbError(format!("serialize: {e}")))
@@ -346,6 +379,28 @@ impl DatabaseOps for IndexedDbDatabase {
     fn apply_retention_policy(&self) -> Result<super::RetentionStats, DbError> {
         self.inner.apply_retention_policy()
     }
+
+    // ── Dynamic Agent Def CRUD ────────────────────────────────────────────────
+
+    fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
+        self.inner.upsert_agent_def(name, json)?;
+        self.persist_to_storage()?;
+        Ok(())
+    }
+
+    fn list_agent_defs(&self) -> Result<Vec<String>, DbError> {
+        self.inner.list_agent_defs()
+    }
+
+    fn get_agent_def(&self, name: &str) -> Result<Option<String>, DbError> {
+        self.inner.get_agent_def(name)
+    }
+
+    fn delete_agent_def(&self, name: &str) -> Result<(), DbError> {
+        self.inner.delete_agent_def(name)?;
+        self.persist_to_storage()?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -440,8 +495,11 @@ mod tests {
         let json_str = db.build_snapshot_json().unwrap();
         let state: serde_json::Value = serde_json::from_str(&json_str).unwrap();
 
-        // Verify version field is present
-        assert_eq!(state.get("version").and_then(|v| v.as_u64()), Some(1));
+        // Verify version field reflects the current SNAPSHOT_VERSION (2)
+        assert_eq!(
+            state.get("version").and_then(|v| v.as_u64()),
+            Some(SNAPSHOT_VERSION)
+        );
 
         // Create a fresh database and restore
         let db2 = IndexedDbDatabase::new_with_persistence("test-db-2").unwrap();
@@ -495,5 +553,92 @@ mod tests {
             Some("alice".to_string())
         );
         assert_eq!(db_b.get_setting("owner").unwrap(), Some("bob".to_string()));
+    }
+
+    // ── agent def delegation tests ────────────────────────────────────────────
+
+    #[test]
+    fn test_idb_upsert_and_get_agent_def() {
+        let db = IndexedDbDatabase::new_with_persistence("test-agent-defs").unwrap();
+        let json = r#"{"name":"weather","description":"Weather agent"}"#;
+        db.upsert_agent_def("weather", json).unwrap();
+
+        assert_eq!(db.get_agent_def("weather").unwrap(), Some(json.to_string()));
+    }
+
+    #[test]
+    fn test_idb_list_agent_defs() {
+        let db = IndexedDbDatabase::new_with_persistence("test-list-defs").unwrap();
+        db.upsert_agent_def("a", r#"{"name":"a"}"#).unwrap();
+        db.upsert_agent_def("b", r#"{"name":"b"}"#).unwrap();
+
+        let defs = db.list_agent_defs().unwrap();
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[test]
+    fn test_idb_delete_agent_def() {
+        let db = IndexedDbDatabase::new_with_persistence("test-del-defs").unwrap();
+        db.upsert_agent_def("weather", r#"{"name":"weather"}"#)
+            .unwrap();
+        db.delete_agent_def("weather").unwrap();
+
+        assert_eq!(db.get_agent_def("weather").unwrap(), None);
+        assert_eq!(db.list_agent_defs().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_idb_agent_defs_snapshot_round_trip() {
+        let db = IndexedDbDatabase::new_with_persistence("test-snap-defs").unwrap();
+        let json = r#"{"name":"weather","description":"Weather agent"}"#;
+        db.upsert_agent_def("weather", json).unwrap();
+
+        // Build + inspect snapshot
+        let snapshot_str = db.build_snapshot_json().unwrap();
+        let snapshot: serde_json::Value = serde_json::from_str(&snapshot_str).unwrap();
+
+        // Version must be 2
+        assert_eq!(
+            snapshot.get("version").and_then(|v| v.as_u64()),
+            Some(2)
+        );
+
+        // "agents" array must contain our entry
+        let agents = snapshot.get("agents").and_then(|v| v.as_array()).unwrap();
+        assert_eq!(agents.len(), 1);
+        assert_eq!(agents[0].get("name").and_then(|v| v.as_str()), Some("weather"));
+        assert_eq!(agents[0].get("json").and_then(|v| v.as_str()), Some(json));
+
+        // Restore into a fresh db and verify
+        let db2 = IndexedDbDatabase::new_with_persistence("test-snap-defs-2").unwrap();
+        db2.restore_state(&snapshot).unwrap();
+
+        assert_eq!(
+            db2.get_agent_def("weather").unwrap(),
+            Some(json.to_string())
+        );
+    }
+
+    #[test]
+    fn test_idb_restore_state_tolerates_corrupt_agent_defs() {
+        let state = serde_json::json!({
+            "version": 2,
+            "episodes": [],
+            "profiles": [],
+            "settings": {},
+            "templates": [],
+            "agents": [
+                {"name": "good", "json": r#"{"name":"good"}"#},
+                {"corrupt": true},
+                {"name": "missing_json"},
+            ],
+        });
+
+        let db = IndexedDbDatabase::new_with_persistence("test-corrupt-defs").unwrap();
+        db.restore_state(&state).unwrap();
+
+        // Only "good" has both name and json fields
+        assert_eq!(db.list_agent_defs().unwrap().len(), 1);
+        assert!(db.get_agent_def("good").unwrap().is_some());
     }
 }

--- a/crates/papillon-shared/src/db/indexed_db.rs
+++ b/crates/papillon-shared/src/db/indexed_db.rs
@@ -202,9 +202,7 @@ impl IndexedDbDatabase {
             .inner
             .list_all_agent_defs()?
             .into_iter()
-            .map(|(name, json)| {
-                serde_json::json!({ "name": name, "json": json })
-            })
+            .map(|(name, json)| serde_json::json!({ "name": name, "json": json }))
             .collect();
 
         let state = serde_json::json!({
@@ -600,15 +598,15 @@ mod tests {
         let snapshot: serde_json::Value = serde_json::from_str(&snapshot_str).unwrap();
 
         // Version must be 2
-        assert_eq!(
-            snapshot.get("version").and_then(|v| v.as_u64()),
-            Some(2)
-        );
+        assert_eq!(snapshot.get("version").and_then(|v| v.as_u64()), Some(2));
 
         // "agents" array must contain our entry
         let agents = snapshot.get("agents").and_then(|v| v.as_array()).unwrap();
         assert_eq!(agents.len(), 1);
-        assert_eq!(agents[0].get("name").and_then(|v| v.as_str()), Some("weather"));
+        assert_eq!(
+            agents[0].get("name").and_then(|v| v.as_str()),
+            Some("weather")
+        );
         assert_eq!(agents[0].get("json").and_then(|v| v.as_str()), Some(json));
 
         // Restore into a fresh db and verify

--- a/crates/papillon-shared/src/db/indexed_db.rs
+++ b/crates/papillon-shared/src/db/indexed_db.rs
@@ -106,6 +106,8 @@ impl IndexedDbDatabase {
     fn restore_state(&self, state: &serde_json::Value) -> Result<(), DbError> {
         // Check snapshot version (if missing, assume v1 — the first version)
         let _version = state.get("version").and_then(|v| v.as_u64()).unwrap_or(1);
+        // v1 snapshots have no "agents" key — key absence is sufficient for backward
+        // compat; no branching on _version is needed.
 
         if let Some(episodes) = state.get("episodes").and_then(|v| v.as_array()) {
             for (_i, val) in episodes.iter().enumerate() {

--- a/crates/papillon-shared/src/db/mod.rs
+++ b/crates/papillon-shared/src/db/mod.rs
@@ -346,6 +346,24 @@ pub trait DatabaseOps: Send + Sync {
     /// Delete a saved pipeline by id. No-op if not found.
     #[cfg(feature = "native")]
     fn delete_saved_pipeline(&self, id: &str) -> Result<(), DbError>;
+
+    // ── Dynamic Agent Def CRUD (available on all targets) ────────────────────
+    // Uses a (name, json_string) interface to avoid a hard dependency on
+    // pap-agents in the wasm feature set.  Callers are responsible for
+    // serialising/deserialising the JSON string to/from their preferred type.
+
+    /// Insert or replace a dynamic agent definition, keyed by name.
+    /// `json` must be a valid JSON string representing the full definition.
+    fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError>;
+
+    /// Return the raw JSON strings for all stored agent definitions.
+    fn list_agent_defs(&self) -> Result<Vec<String>, DbError>;
+
+    /// Return the raw JSON string for a single agent definition, or `None`.
+    fn get_agent_def(&self, name: &str) -> Result<Option<String>, DbError>;
+
+    /// Remove an agent definition by name.  No-op if the name is not found.
+    fn delete_agent_def(&self, name: &str) -> Result<(), DbError>;
 }
 
 /// A preference signal recording which agent was selected for a given

--- a/crates/papillon-shared/src/db/native.rs
+++ b/crates/papillon-shared/src/db/native.rs
@@ -1914,6 +1914,9 @@ impl DatabaseOps for NativeDatabase {
     // ── Dynamic Agent Def CRUD ────────────────────────────────────────────────
 
     fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
+        // Validate JSON is well-formed before storing
+        serde_json::from_str::<serde_json::Value>(json)
+            .map_err(|e| DbError(format!("upsert_agent_def: invalid JSON for '{}': {e}", name)))?;
         let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
         conn.execute(
             "INSERT OR REPLACE INTO agent_defs (name, json) VALUES (?1, ?2)",
@@ -1926,7 +1929,7 @@ impl DatabaseOps for NativeDatabase {
     fn list_agent_defs(&self) -> Result<Vec<String>, DbError> {
         let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
         let mut stmt = conn
-            .prepare("SELECT json FROM agent_defs")
+            .prepare("SELECT json FROM agent_defs ORDER BY name")
             .map_err(|e| DbError(format!("db prepare agent_defs: {e}")))?;
         let rows = stmt
             .query_map([], |row| row.get::<_, String>(0))

--- a/crates/papillon-shared/src/db/native.rs
+++ b/crates/papillon-shared/src/db/native.rs
@@ -321,6 +321,19 @@ impl NativeDatabase {
             [],
         );
 
+        // Dynamic agent definitions persisted as raw JSON blobs. This is a
+        // separate table from `agents` so that user-managed lightweight defs
+        // (name + JSON) can round-trip without requiring all the columns of
+        // the full agents table.
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS agent_defs (
+                name TEXT PRIMARY KEY,
+                json TEXT NOT NULL
+            )",
+            [],
+        )
+        .map_err(|e| DbError(format!("db migrate agent_defs: {e}")))?;
+
         Ok(())
     }
 
@@ -1897,6 +1910,54 @@ impl DatabaseOps for NativeDatabase {
             .map_err(|e| DbError(format!("db delete saved_pipeline: {e}")))?;
         Ok(())
     }
+
+    // ── Dynamic Agent Def CRUD ────────────────────────────────────────────────
+
+    fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
+        let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
+        conn.execute(
+            "INSERT OR REPLACE INTO agent_defs (name, json) VALUES (?1, ?2)",
+            params![name, json],
+        )
+        .map_err(|e| DbError(format!("db upsert agent_def: {e}")))?;
+        Ok(())
+    }
+
+    fn list_agent_defs(&self) -> Result<Vec<String>, DbError> {
+        let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
+        let mut stmt = conn
+            .prepare("SELECT json FROM agent_defs")
+            .map_err(|e| DbError(format!("db prepare agent_defs: {e}")))?;
+        let rows = stmt
+            .query_map([], |row| row.get::<_, String>(0))
+            .map_err(|e| DbError(format!("db query agent_defs: {e}")))?;
+        let mut defs = Vec::new();
+        for row in rows {
+            defs.push(row.map_err(|e| DbError(format!("db row agent_def: {e}")))?);
+        }
+        Ok(defs)
+    }
+
+    fn get_agent_def(&self, name: &str) -> Result<Option<String>, DbError> {
+        let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
+        conn.query_row(
+            "SELECT json FROM agent_defs WHERE name = ?1",
+            params![name],
+            |row| row.get::<_, String>(0),
+        )
+        .optional()
+        .map_err(|e| DbError(format!("db get agent_def: {e}")))
+    }
+
+    fn delete_agent_def(&self, name: &str) -> Result<(), DbError> {
+        let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
+        conn.execute(
+            "DELETE FROM agent_defs WHERE name = ?1",
+            params![name],
+        )
+        .map_err(|e| DbError(format!("db delete agent_def: {e}")))?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
@@ -3090,5 +3151,65 @@ mod tests {
         let db = test_db();
         // Deleting an id that does not exist must not error.
         db.delete_saved_pipeline("does-not-exist").unwrap();
+    }
+
+    // ── agent_defs table tests ────────────────────────────────────────────────
+
+    #[test]
+    fn agent_def_upsert_and_get() {
+        let db = test_db();
+        let json = r#"{"name":"weather","description":"Weather agent"}"#;
+        db.upsert_agent_def("weather", json).unwrap();
+
+        let result = db.get_agent_def("weather").unwrap();
+        assert_eq!(result, Some(json.to_string()));
+    }
+
+    #[test]
+    fn agent_def_upsert_replaces_existing() {
+        let db = test_db();
+        db.upsert_agent_def("weather", r#"{"name":"weather","v":1}"#)
+            .unwrap();
+        db.upsert_agent_def("weather", r#"{"name":"weather","v":2}"#)
+            .unwrap();
+
+        let result = db.get_agent_def("weather").unwrap().unwrap();
+        assert!(result.contains("\"v\":2"), "expected v=2 but got {result}");
+    }
+
+    #[test]
+    fn agent_def_get_missing_returns_none() {
+        let db = test_db();
+        assert_eq!(db.get_agent_def("nonexistent").unwrap(), None);
+    }
+
+    #[test]
+    fn agent_def_list_returns_all() {
+        let db = test_db();
+        db.upsert_agent_def("agent-a", r#"{"name":"agent-a"}"#)
+            .unwrap();
+        db.upsert_agent_def("agent-b", r#"{"name":"agent-b"}"#)
+            .unwrap();
+
+        let defs = db.list_agent_defs().unwrap();
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[test]
+    fn agent_def_delete_removes_entry() {
+        let db = test_db();
+        db.upsert_agent_def("weather", r#"{"name":"weather"}"#)
+            .unwrap();
+        db.delete_agent_def("weather").unwrap();
+
+        assert_eq!(db.get_agent_def("weather").unwrap(), None);
+        assert_eq!(db.list_agent_defs().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn agent_def_delete_nonexistent_is_noop() {
+        let db = test_db();
+        // Must not return an error when the name doesn't exist.
+        db.delete_agent_def("nonexistent").unwrap();
     }
 }

--- a/crates/papillon-shared/src/db/native.rs
+++ b/crates/papillon-shared/src/db/native.rs
@@ -1915,8 +1915,12 @@ impl DatabaseOps for NativeDatabase {
 
     fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
         // Validate JSON is well-formed before storing
-        serde_json::from_str::<serde_json::Value>(json)
-            .map_err(|e| DbError(format!("upsert_agent_def: invalid JSON for '{}': {e}", name)))?;
+        serde_json::from_str::<serde_json::Value>(json).map_err(|e| {
+            DbError(format!(
+                "upsert_agent_def: invalid JSON for '{}': {e}",
+                name
+            ))
+        })?;
         let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
         conn.execute(
             "INSERT OR REPLACE INTO agent_defs (name, json) VALUES (?1, ?2)",
@@ -1954,11 +1958,8 @@ impl DatabaseOps for NativeDatabase {
 
     fn delete_agent_def(&self, name: &str) -> Result<(), DbError> {
         let conn = self.conn.lock().map_err(|e| DbError(e.to_string()))?;
-        conn.execute(
-            "DELETE FROM agent_defs WHERE name = ?1",
-            params![name],
-        )
-        .map_err(|e| DbError(format!("db delete agent_def: {e}")))?;
+        conn.execute("DELETE FROM agent_defs WHERE name = ?1", params![name])
+            .map_err(|e| DbError(format!("db delete agent_def: {e}")))?;
         Ok(())
     }
 }

--- a/crates/papillon-shared/src/db/wasm.rs
+++ b/crates/papillon-shared/src/db/wasm.rs
@@ -20,6 +20,7 @@
 
 use super::{AgentProfile, DatabaseOps, DbError, Episode};
 use crate::types::Template;
+use std::collections::HashMap;
 use std::sync::{Arc, Mutex};
 
 /// WASM database implementation with in-memory storage.
@@ -35,6 +36,8 @@ pub struct WasmDatabase {
     settings: Arc<Mutex<Vec<(String, String)>>>,
     /// In-memory template store
     templates: Arc<Mutex<Vec<Template>>>,
+    /// In-memory dynamic agent definition store (name → raw JSON string)
+    agent_defs: Arc<Mutex<HashMap<String, String>>>,
 }
 
 impl WasmDatabase {
@@ -45,6 +48,7 @@ impl WasmDatabase {
             agent_profiles: Arc::new(Mutex::new(Vec::new())),
             settings: Arc::new(Mutex::new(Vec::new())),
             templates: Arc::new(Mutex::new(Vec::new())),
+            agent_defs: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 
@@ -74,6 +78,15 @@ impl WasmDatabase {
             .map_err(|e| DbError(format!("db lock: {e}")))?;
         Ok(episodes.clone())
     }
+
+    /// Return all (name, json) agent def pairs (for persistence serialization).
+    pub fn list_all_agent_defs(&self) -> Result<Vec<(String, String)>, DbError> {
+        let defs = self
+            .agent_defs
+            .lock()
+            .map_err(|e| DbError(format!("db lock: {e}")))?;
+        Ok(defs.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+    }
 }
 
 impl Default for WasmDatabase {
@@ -83,6 +96,7 @@ impl Default for WasmDatabase {
             agent_profiles: Arc::new(Mutex::new(Vec::new())),
             settings: Arc::new(Mutex::new(Vec::new())),
             templates: Arc::new(Mutex::new(Vec::new())),
+            agent_defs: Arc::new(Mutex::new(HashMap::new())),
         })
     }
 }
@@ -433,6 +447,42 @@ impl DatabaseOps for WasmDatabase {
     fn apply_retention_policy(&self) -> Result<super::RetentionStats, DbError> {
         // In-memory WASM store: no persistence, nothing to compact.
         Ok(super::RetentionStats::default())
+    }
+
+    // ── Dynamic Agent Def CRUD ────────────────────────────────────────────────
+
+    fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
+        let mut defs = self
+            .agent_defs
+            .lock()
+            .map_err(|e| DbError(format!("db lock: {e}")))?;
+        defs.insert(name.to_string(), json.to_string());
+        Ok(())
+    }
+
+    fn list_agent_defs(&self) -> Result<Vec<String>, DbError> {
+        let defs = self
+            .agent_defs
+            .lock()
+            .map_err(|e| DbError(format!("db lock: {e}")))?;
+        Ok(defs.values().cloned().collect())
+    }
+
+    fn get_agent_def(&self, name: &str) -> Result<Option<String>, DbError> {
+        let defs = self
+            .agent_defs
+            .lock()
+            .map_err(|e| DbError(format!("db lock: {e}")))?;
+        Ok(defs.get(name).cloned())
+    }
+
+    fn delete_agent_def(&self, name: &str) -> Result<(), DbError> {
+        let mut defs = self
+            .agent_defs
+            .lock()
+            .map_err(|e| DbError(format!("db lock: {e}")))?;
+        defs.remove(name);
+        Ok(())
     }
 }
 
@@ -1032,6 +1082,74 @@ mod tests {
         let db = WasmDatabase::new().unwrap();
         let result = db.set_template_enabled("nonexistent", false);
         assert!(result.is_err());
+    }
+
+    // ── agent def tests ───────────────────────────────────────────────────────
+
+    #[test]
+    fn test_upsert_and_get_agent_def() {
+        let db = WasmDatabase::new().unwrap();
+        let json = r#"{"name":"weather","description":"Weather agent"}"#;
+        db.upsert_agent_def("weather", json).unwrap();
+
+        let result = db.get_agent_def("weather").unwrap();
+        assert_eq!(result, Some(json.to_string()));
+    }
+
+    #[test]
+    fn test_upsert_agent_def_overwrites() {
+        let db = WasmDatabase::new().unwrap();
+        db.upsert_agent_def("weather", r#"{"name":"weather","v":1}"#)
+            .unwrap();
+        db.upsert_agent_def("weather", r#"{"name":"weather","v":2}"#)
+            .unwrap();
+
+        let result = db.get_agent_def("weather").unwrap().unwrap();
+        assert!(result.contains("\"v\":2"));
+    }
+
+    #[test]
+    fn test_get_agent_def_not_found() {
+        let db = WasmDatabase::new().unwrap();
+        assert_eq!(db.get_agent_def("nonexistent").unwrap(), None);
+    }
+
+    #[test]
+    fn test_list_agent_defs() {
+        let db = WasmDatabase::new().unwrap();
+        db.upsert_agent_def("agent-a", r#"{"name":"agent-a"}"#)
+            .unwrap();
+        db.upsert_agent_def("agent-b", r#"{"name":"agent-b"}"#)
+            .unwrap();
+
+        let defs = db.list_agent_defs().unwrap();
+        assert_eq!(defs.len(), 2);
+    }
+
+    #[test]
+    fn test_delete_agent_def() {
+        let db = WasmDatabase::new().unwrap();
+        db.upsert_agent_def("weather", r#"{"name":"weather"}"#)
+            .unwrap();
+        db.delete_agent_def("weather").unwrap();
+        assert_eq!(db.get_agent_def("weather").unwrap(), None);
+        assert_eq!(db.list_agent_defs().unwrap().len(), 0);
+    }
+
+    #[test]
+    fn test_delete_agent_def_noop_if_missing() {
+        let db = WasmDatabase::new().unwrap();
+        // Should not return an error even though the key doesn't exist
+        db.delete_agent_def("nonexistent").unwrap();
+    }
+
+    #[test]
+    fn test_list_all_agent_defs_helper() {
+        let db = WasmDatabase::new().unwrap();
+        db.upsert_agent_def("x", r#"{"name":"x"}"#).unwrap();
+        let pairs = db.list_all_agent_defs().unwrap();
+        assert_eq!(pairs.len(), 1);
+        assert_eq!(pairs[0].0, "x");
     }
 
     #[test]

--- a/crates/papillon-shared/src/db/wasm.rs
+++ b/crates/papillon-shared/src/db/wasm.rs
@@ -85,7 +85,9 @@ impl WasmDatabase {
             .agent_defs
             .lock()
             .map_err(|e| DbError(format!("db lock: {e}")))?;
-        Ok(defs.iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        let mut pairs: Vec<(&String, &String)> = defs.iter().collect();
+        pairs.sort_by_key(|(k, _)| k.as_str());
+        Ok(pairs.into_iter().map(|(k, v)| (k.clone(), v.clone())).collect())
     }
 }
 
@@ -452,6 +454,9 @@ impl DatabaseOps for WasmDatabase {
     // ── Dynamic Agent Def CRUD ────────────────────────────────────────────────
 
     fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
+        // Validate JSON is well-formed before storing
+        serde_json::from_str::<serde_json::Value>(json)
+            .map_err(|e| DbError(format!("upsert_agent_def: invalid JSON for '{}': {e}", name)))?;
         let mut defs = self
             .agent_defs
             .lock()
@@ -464,8 +469,10 @@ impl DatabaseOps for WasmDatabase {
         let defs = self
             .agent_defs
             .lock()
-            .map_err(|e| DbError(format!("db lock: {e}")))?;
-        Ok(defs.values().cloned().collect())
+            .map_err(|e| DbError(format!("agent_defs lock: {e}")))?;
+        let mut pairs: Vec<(&String, &String)> = defs.iter().collect();
+        pairs.sort_by_key(|(k, _)| k.as_str());
+        Ok(pairs.into_iter().map(|(_, v)| v.clone()).collect())
     }
 
     fn get_agent_def(&self, name: &str) -> Result<Option<String>, DbError> {

--- a/crates/papillon-shared/src/db/wasm.rs
+++ b/crates/papillon-shared/src/db/wasm.rs
@@ -87,7 +87,10 @@ impl WasmDatabase {
             .map_err(|e| DbError(format!("db lock: {e}")))?;
         let mut pairs: Vec<(&String, &String)> = defs.iter().collect();
         pairs.sort_by_key(|(k, _)| k.as_str());
-        Ok(pairs.into_iter().map(|(k, v)| (k.clone(), v.clone())).collect())
+        Ok(pairs
+            .into_iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect())
     }
 }
 
@@ -455,8 +458,12 @@ impl DatabaseOps for WasmDatabase {
 
     fn upsert_agent_def(&self, name: &str, json: &str) -> Result<(), DbError> {
         // Validate JSON is well-formed before storing
-        serde_json::from_str::<serde_json::Value>(json)
-            .map_err(|e| DbError(format!("upsert_agent_def: invalid JSON for '{}': {e}", name)))?;
+        serde_json::from_str::<serde_json::Value>(json).map_err(|e| {
+            DbError(format!(
+                "upsert_agent_def: invalid JSON for '{}': {e}",
+                name
+            ))
+        })?;
         let mut defs = self
             .agent_defs
             .lock()

--- a/crates/papillon-shared/src/lib.rs
+++ b/crates/papillon-shared/src/lib.rs
@@ -36,6 +36,17 @@ pub mod personal_context;
 #[cfg(feature = "native")]
 pub use personal_context::PersonalContext;
 
+/// WASM-safe local agent registry backed by IndexedDB.
+///
+/// Compiled when the `wasm` feature is enabled (both in browser WASM builds and
+/// in native test runs with `--features wasm`).  Provides
+/// [`wasm_registry::WasmAgentRegistry`] which mirrors what the desktop
+/// `AppState::with_db()` does for catalog seeding and agent discovery.
+#[cfg(feature = "wasm")]
+pub mod wasm_registry;
+#[cfg(feature = "wasm")]
+pub use wasm_registry::{WasmAgentRegistry, WasmDynamicAgentDef};
+
 pub use events::*;
 pub use json_ld_query::JsonLdQuery;
 pub use template_gen::generate_template_from_json_ld;

--- a/crates/papillon-shared/src/wasm_registry.rs
+++ b/crates/papillon-shared/src/wasm_registry.rs
@@ -212,11 +212,8 @@ impl WasmAgentRegistry {
                         Err(_e) => {
                             #[cfg(target_arch = "wasm32")]
                             web_sys::console::warn_1(
-                                &format!(
-                                    "papillon: skipping agent with bad advertisement: {}",
-                                    _e
-                                )
-                                .into(),
+                                &format!("papillon: skipping agent with bad advertisement: {}", _e)
+                                    .into(),
                             );
                         }
                     }
@@ -305,10 +302,8 @@ impl WasmAgentRegistry {
             return Ok(0);
         }
 
-        let catalog_defs: Vec<WasmDynamicAgentDef> =
-            serde_json::from_str(CATALOG_JSON).map_err(|e| {
-                format!("failed to deserialize embedded catalog.json: {e}")
-            })?;
+        let catalog_defs: Vec<WasmDynamicAgentDef> = serde_json::from_str(CATALOG_JSON)
+            .map_err(|e| format!("failed to deserialize embedded catalog.json: {e}"))?;
 
         let mut count = 0usize;
 
@@ -329,11 +324,7 @@ impl WasmAgentRegistry {
                 Err(_e) => {
                     #[cfg(target_arch = "wasm32")]
                     web_sys::console::warn_1(
-                        &format!(
-                            "papillon: skipping catalog agent '{}': {}",
-                            def.name, _e
-                        )
-                        .into(),
+                        &format!("papillon: skipping catalog agent '{}': {}", def.name, _e).into(),
                     );
                     continue;
                 }
@@ -345,11 +336,8 @@ impl WasmAgentRegistry {
                 Err(_e) => {
                     #[cfg(target_arch = "wasm32")]
                     web_sys::console::warn_1(
-                        &format!(
-                            "papillon: failed to serialize agent '{}': {}",
-                            def.name, _e
-                        )
-                        .into(),
+                        &format!("papillon: failed to serialize agent '{}': {}", def.name, _e)
+                            .into(),
                     );
                     continue;
                 }
@@ -359,11 +347,7 @@ impl WasmAgentRegistry {
             if let Err(_e) = self.db.upsert_agent_def(&def.name, &json) {
                 #[cfg(target_arch = "wasm32")]
                 web_sys::console::warn_1(
-                    &format!(
-                        "papillon: failed to persist agent '{}': {:?}",
-                        def.name, _e
-                    )
-                    .into(),
+                    &format!("papillon: failed to persist agent '{}': {:?}", def.name, _e).into(),
                 );
                 continue;
             }
@@ -459,10 +443,7 @@ mod tests {
             "DID should start with did:key: — got: {}",
             ad.provider.did
         );
-        assert!(
-            ad.signature.is_some(),
-            "advertisement must be signed"
-        );
+        assert!(ad.signature.is_some(), "advertisement must be signed");
         assert_eq!(ad.name, "Test Agent");
     }
 
@@ -479,8 +460,8 @@ mod tests {
 
     #[test]
     fn new_empty_registry_has_zero_agents() {
-        let registry = WasmAgentRegistry::new_empty("test-empty")
-            .expect("new_empty should succeed");
+        let registry =
+            WasmAgentRegistry::new_empty("test-empty").expect("new_empty should succeed");
         assert_eq!(registry.agent_count(), 0);
         assert!(registry.list_agents().is_empty());
     }
@@ -491,8 +472,7 @@ mod tests {
         // in-memory registry — this lets us test the seeding logic without an
         // async runtime or browser IndexedDB.
         let catalog_defs: Vec<WasmDynamicAgentDef> =
-            serde_json::from_str(CATALOG_JSON)
-                .expect("embedded catalog.json must deserialize");
+            serde_json::from_str(CATALOG_JSON).expect("embedded catalog.json must deserialize");
 
         assert!(
             catalog_defs.len() >= 300,
@@ -518,8 +498,8 @@ mod tests {
 
     #[test]
     fn seed_default_catalog_returns_nonzero_count_on_fresh_db() {
-        let mut reg = WasmAgentRegistry::new_empty("test-seed-fresh")
-            .expect("new_empty should succeed");
+        let mut reg =
+            WasmAgentRegistry::new_empty("test-seed-fresh").expect("new_empty should succeed");
         let count = reg
             .seed_default_catalog()
             .expect("seed should succeed on fresh db");
@@ -540,8 +520,8 @@ mod tests {
     #[test]
     fn seed_default_catalog_is_idempotent() {
         // Seed once — verify count, then seed again and verify Ok(0).
-        let mut reg = WasmAgentRegistry::new_empty("test-seed-idem")
-            .expect("new_empty should succeed");
+        let mut reg =
+            WasmAgentRegistry::new_empty("test-seed-idem").expect("new_empty should succeed");
 
         let first = reg
             .seed_default_catalog()
@@ -567,13 +547,11 @@ mod tests {
     fn seed_default_catalog_idempotent_via_db() {
         // Simulate idempotency via pre-populated DB: if the DB already has
         // entries, seed_default_catalog must return Ok(0) immediately.
-        let db = IndexedDbDatabase::new_with_persistence("test-idem")
-            .expect("db creation failed");
+        let db = IndexedDbDatabase::new_with_persistence("test-idem").expect("db creation failed");
         db.upsert_agent_def("existing", r#"{"name":"existing"}"#)
             .expect("upsert should succeed");
 
-        let mut reg = WasmAgentRegistry::from_db(db)
-            .expect("from_db should succeed");
+        let mut reg = WasmAgentRegistry::from_db(db).expect("from_db should succeed");
 
         let count = reg
             .seed_default_catalog()
@@ -685,9 +663,8 @@ mod tests {
 
     #[test]
     fn catalog_json_deserializes_to_wasm_defs() {
-        let defs: Vec<WasmDynamicAgentDef> =
-            serde_json::from_str(CATALOG_JSON)
-                .expect("embedded catalog.json must deserialize to WasmDynamicAgentDef");
+        let defs: Vec<WasmDynamicAgentDef> = serde_json::from_str(CATALOG_JSON)
+            .expect("embedded catalog.json must deserialize to WasmDynamicAgentDef");
         assert!(
             defs.len() >= 300,
             "expected 300+ defs in catalog, got {}",
@@ -705,8 +682,8 @@ mod tests {
 
     #[test]
     fn catalog_json_has_required_keys() {
-        let entries: Vec<serde_json::Value> = serde_json::from_str(CATALOG_JSON)
-            .expect("catalog.json must be valid JSON array");
+        let entries: Vec<serde_json::Value> =
+            serde_json::from_str(CATALOG_JSON).expect("catalog.json must be valid JSON array");
         assert!(!entries.is_empty(), "catalog must have entries");
         let first = &entries[0];
         for key in &["name", "provider", "action", "description"] {

--- a/crates/papillon-shared/src/wasm_registry.rs
+++ b/crates/papillon-shared/src/wasm_registry.rs
@@ -79,7 +79,12 @@ pub struct WasmDynamicAgentDef {
     pub llm_instructions: String,
     #[serde(default)]
     pub subagents: Vec<String>,
-    #[serde(skip_serializing_if = "Option::is_none")]
+    /// Deterministic operator key seed — derived on the fly from `name` via
+    /// SHA-256 and **never persisted** to IndexedDB.  Storing a raw signing-key
+    /// seed in the browser database would be a plaintext private-key leak;
+    /// since catalog seeds are fully deterministic (SHA-256 of agent name) they
+    /// can always be re-derived at runtime without any loss of functionality.
+    #[serde(skip)]
     pub operator_key_seed: Option<[u8; 32]>,
     #[serde(default)]
     pub published_to: Vec<String>,
@@ -185,11 +190,23 @@ impl WasmAgentRegistry {
         for json_str in raw_defs {
             match serde_json::from_str::<WasmDynamicAgentDef>(&json_str) {
                 Ok(def) => {
+                    #[cfg(target_arch = "wasm32")]
+                    let def_name = def.name.clone();
                     match def.to_signed_advertisement() {
                         Ok(ad) => {
-                            // Ignore AlreadyRegistered — can happen if DB has
-                            // duplicate entries from a previous interrupted seed.
-                            let _ = registry.register_local(ad);
+                            // Warn on duplicate — can happen if DB has duplicate
+                            // entries from a previous interrupted seed.
+                            if let Err(e) = registry.register_local(ad) {
+                                #[cfg(target_arch = "wasm32")]
+                                web_sys::console::warn_1(
+                                    &format!(
+                                        "WasmAgentRegistry: skipping duplicate agent '{}': {:?}",
+                                        def_name, e
+                                    )
+                                    .into(),
+                                );
+                                let _ = e;
+                            }
                             defs.push(def);
                         }
                         Err(_e) => {
@@ -252,6 +269,14 @@ impl WasmAgentRegistry {
     /// Returns the count of agents successfully seeded, or `Ok(0)` when
     /// already seeded.
     ///
+    /// **Partial-seeding behaviour**: this method skips seeding entirely when
+    /// *any* agents are already present in the database (it checks
+    /// `list_agent_defs().is_empty()`).  If a prior seeding run was
+    /// interrupted mid-way, the missing agents will **not** be backfilled
+    /// automatically — the check is presence-based, not count-based.  To force
+    /// a full reseed, clear all existing agents first (a `clear_agents()` helper
+    /// is not yet implemented; for now, drop and recreate the IndexedDB store).
+    ///
     /// In browser builds this method is `async` because it awaits IndexedDB
     /// persistence; on the native-feature path (tests) it is synchronous.
     #[cfg(target_arch = "wasm32")]
@@ -289,8 +314,9 @@ impl WasmAgentRegistry {
 
         for mut def in catalog_defs {
             // Derive deterministic operator keypair from name.
+            // NOTE: operator_key_seed is intentionally not persisted (marked
+            // #[serde(skip)]) — it is always re-derived from `name` at runtime.
             let seed: [u8; 32] = Sha256::digest(def.name.as_bytes()).into();
-            def.operator_key_seed = Some(seed);
 
             // Derive the DID from the seed and store it on the def.
             let signing_key = SigningKey::from_bytes(&seed);
@@ -673,6 +699,21 @@ mod tests {
                 "action '{}' in '{}' must start with 'schema:'",
                 def.action,
                 def.name
+            );
+        }
+    }
+
+    #[test]
+    fn catalog_json_has_required_keys() {
+        let entries: Vec<serde_json::Value> = serde_json::from_str(CATALOG_JSON)
+            .expect("catalog.json must be valid JSON array");
+        assert!(!entries.is_empty(), "catalog must have entries");
+        let first = &entries[0];
+        for key in &["name", "provider", "action", "description"] {
+            assert!(
+                first.get(key).is_some(),
+                "catalog entry missing required key: {}",
+                key
             );
         }
     }

--- a/crates/papillon-shared/src/wasm_registry.rs
+++ b/crates/papillon-shared/src/wasm_registry.rs
@@ -1,0 +1,679 @@
+//! WASM-safe local agent registry backed by IndexedDB.
+//!
+//! [`WasmAgentRegistry`] is the WASM equivalent of the desktop
+//! `AppState::with_db()` catalog-seeding path.  It wraps
+//! [`IndexedDbDatabase`] and maintains an in-memory list of
+//! [`AgentAdvertisement`]s and their raw [`WasmDynamicAgentDef`] payloads.
+//!
+//! The full `pap-agents` crate is intentionally excluded here because it has
+//! unconditional `reqwest::blocking` + `tokio` dependencies that do not
+//! compile for `wasm32-unknown-unknown`.  All functionality needed by the
+//! WASM registry is replicated using only WASM-compatible crates:
+//!
+//! * [`pap_marketplace::AgentAdvertisement`] — the advertisement type
+//! * [`pap_federation::FederatedRegistry`] — in-memory index
+//! * [`pap_did::public_key_to_did`] + `ed25519-dalek` + `sha2` — DID derivation
+//!
+//! # Catalog seeding
+//!
+//! Agent definitions are baked into the binary at compile time via
+//! `build.rs` → `$OUT_DIR/catalog.json`.  On first open,
+//! [`WasmAgentRegistry::seed_default_catalog`] iterates every entry,
+//! derives a deterministic Ed25519 keypair (SHA-256 of the agent name as
+//! the seed), signs an [`AgentAdvertisement`], and stores the raw JSON in
+//! IndexedDB.  Subsequent calls are idempotent — if agents already exist in
+//! the DB the method returns `Ok(0)` immediately.
+//!
+//! # Test strategy
+//!
+//! The module compiles on native when the `wasm` feature is enabled, so
+//! all synchronous tests run under `cargo test -p papillon-shared --features wasm`.
+//! The browser-async path ([`WasmAgentRegistry::open`] and
+//! [`WasmAgentRegistry::seed_default_catalog`]) is gated
+//! `#[cfg(target_arch = "wasm32")]`; tests for those paths exercise the
+//! underlying logic synchronously via [`WasmAgentRegistry::new_empty`] and
+//! direct DB manipulation.
+
+use crate::db::indexed_db::IndexedDbDatabase;
+use crate::db::DatabaseOps;
+use ed25519_dalek::SigningKey;
+use pap_did::public_key_to_did;
+use pap_federation::FederatedRegistry;
+use pap_marketplace::AgentAdvertisement;
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+
+// ── Embedded catalog ─────────────────────────────────────────────────────────
+
+/// Embedded catalog JSON generated at compile time from `crates/pap-agents/catalog/**/*.toml`.
+const CATALOG_JSON: &str = include_str!(concat!(env!("OUT_DIR"), "/catalog.json"));
+
+// ── WasmDynamicAgentDef ──────────────────────────────────────────────────────
+
+/// Minimal agent definition used inside [`WasmAgentRegistry`].
+///
+/// This mirrors the fields of `pap_agents::DynamicAgentDef` that are needed
+/// to build a signed [`AgentAdvertisement`].  It is intentionally a separate
+/// type so that `papillon-shared` does not need to depend on `pap-agents`
+/// (which has native-only dependencies) in WASM builds.
+///
+/// The struct is fully serializable so it round-trips through IndexedDB JSON.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct WasmDynamicAgentDef {
+    #[serde(default)]
+    pub agent_did: Option<String>,
+    pub schema_version: u32,
+    #[serde(default = "default_version")]
+    pub version: String,
+    pub name: String,
+    pub provider: String,
+    pub description: String,
+    pub action: String,
+    #[serde(default)]
+    pub object_types: Vec<String>,
+    #[serde(default)]
+    pub requires_disclosure: Vec<String>,
+    #[serde(default)]
+    pub returns: Vec<String>,
+    #[serde(default)]
+    pub llm_instructions: String,
+    #[serde(default)]
+    pub subagents: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub operator_key_seed: Option<[u8; 32]>,
+    #[serde(default)]
+    pub published_to: Vec<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub catalog_path: Option<String>,
+    #[serde(default)]
+    pub configurable_properties: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub created_at: String,
+    #[serde(default)]
+    pub updated_at: String,
+    // Accept unknown fields from the full DynamicAgentDef (e.g. `source`, `endpoint`)
+    // without causing deserialization failures.
+    #[serde(flatten)]
+    pub extra: std::collections::HashMap<String, serde_json::Value>,
+}
+
+fn default_version() -> String {
+    "0.1.0".to_string()
+}
+
+impl WasmDynamicAgentDef {
+    /// Derive a deterministic [`SigningKey`] for this agent by hashing its name
+    /// with SHA-256, then build a signed [`AgentAdvertisement`].
+    ///
+    /// The same agent name always produces the same DID, making this suitable
+    /// for idempotent catalog seeding across reinstalls.
+    pub fn to_signed_advertisement(&self) -> Result<AgentAdvertisement, String> {
+        let seed_bytes: [u8; 32] = Sha256::digest(self.name.as_bytes()).into();
+        let signing_key = SigningKey::from_bytes(&seed_bytes);
+        let operator_did = public_key_to_did(&signing_key.verifying_key());
+
+        let mut ad = AgentAdvertisement::new(
+            &self.name,
+            &self.provider,
+            &operator_did,
+            vec![self.action.clone()],
+            self.object_types.clone(),
+            self.requires_disclosure.clone(),
+            self.returns.clone(),
+        );
+        ad.ttl_min = 3600;
+        if !self.version.is_empty() {
+            ad = ad.with_version(&self.version);
+        }
+        if !self.configurable_properties.is_empty() {
+            ad = ad.with_configurable_properties(self.configurable_properties.clone());
+        }
+
+        ad.sign(&signing_key)
+            .map_err(|e| format!("Failed to sign '{}': {e}", self.name))?;
+        Ok(ad)
+    }
+}
+
+// ── WasmAgentRegistry ────────────────────────────────────────────────────────
+
+/// WASM-safe local agent registry backed by IndexedDB.
+///
+/// On creation the registry is empty.  Call [`WasmAgentRegistry::open`] to
+/// open the database and load existing definitions, then optionally call
+/// [`WasmAgentRegistry::seed_default_catalog`] on first launch to populate
+/// the embedded catalog.
+///
+/// The in-memory state is rebuilt from the database on every `open` call and
+/// is ephemeral (not persisted separately — the source of truth is IndexedDB).
+pub struct WasmAgentRegistry {
+    db: IndexedDbDatabase,
+    /// In-memory federation registry for fast query.
+    registry: FederatedRegistry,
+    /// Raw definitions (preserved for inspection and re-seeding).
+    defs: Vec<WasmDynamicAgentDef>,
+}
+
+impl WasmAgentRegistry {
+    // ── Constructors ─────────────────────────────────────────────────────────
+
+    /// Open the IndexedDB database and rebuild the in-memory registry from any
+    /// previously stored agent definitions.
+    ///
+    /// This is the primary entry-point for production (browser) use.
+    /// Only available on `wasm32` targets — use [`Self::new_empty`] in tests.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn open(db_name: &str) -> Result<Self, String> {
+        let db = IndexedDbDatabase::open(db_name)
+            .await
+            .map_err(|e| format!("IndexedDbDatabase::open failed: {}", e.0))?;
+
+        Self::load_from_db(db)
+    }
+
+    /// Internal: build a [`WasmAgentRegistry`] from an already-opened database,
+    /// loading all stored agent defs into the in-memory registry.
+    fn load_from_db(db: IndexedDbDatabase) -> Result<Self, String> {
+        let mut registry = FederatedRegistry::new();
+        let mut defs = Vec::new();
+
+        // Load all stored agent defs and rebuild in-memory registry.
+        let raw_defs = db
+            .list_agent_defs()
+            .map_err(|e| format!("list_agent_defs failed: {}", e.0))?;
+
+        for json_str in raw_defs {
+            match serde_json::from_str::<WasmDynamicAgentDef>(&json_str) {
+                Ok(def) => {
+                    match def.to_signed_advertisement() {
+                        Ok(ad) => {
+                            // Ignore AlreadyRegistered — can happen if DB has
+                            // duplicate entries from a previous interrupted seed.
+                            let _ = registry.register_local(ad);
+                            defs.push(def);
+                        }
+                        Err(_e) => {
+                            #[cfg(target_arch = "wasm32")]
+                            web_sys::console::warn_1(
+                                &format!(
+                                    "papillon: skipping agent with bad advertisement: {}",
+                                    _e
+                                )
+                                .into(),
+                            );
+                        }
+                    }
+                }
+                Err(_e) => {
+                    #[cfg(target_arch = "wasm32")]
+                    web_sys::console::warn_1(
+                        &format!("papillon: skipping corrupt agent def: {}", _e).into(),
+                    );
+                }
+            }
+        }
+
+        Ok(Self { db, registry, defs })
+    }
+
+    /// Synchronous constructor — creates an empty in-memory database **without**
+    /// loading from IndexedDB.  Intended for tests and non-browser contexts.
+    pub fn new_empty(db_name: &str) -> Result<Self, String> {
+        let db = IndexedDbDatabase::new_with_persistence(db_name)
+            .map_err(|e| format!("new_with_persistence failed: {}", e.0))?;
+        Ok(Self {
+            db,
+            registry: FederatedRegistry::new(),
+            defs: Vec::new(),
+        })
+    }
+
+    /// Synchronous constructor that opens an in-memory DB **and** loads any
+    /// pre-populated agent defs.  Useful for non-browser integration tests.
+    pub fn from_db(db: IndexedDbDatabase) -> Result<Self, String> {
+        Self::load_from_db(db)
+    }
+
+    // ── Catalog seeding ───────────────────────────────────────────────────────
+
+    /// Seed the embedded default catalog into the database if it has not been
+    /// seeded yet.
+    ///
+    /// The operation is idempotent: if any agent definitions already exist in
+    /// the database the method returns `Ok(0)` immediately without touching
+    /// any existing data.
+    ///
+    /// For each catalog entry the method:
+    /// 1. Derives a deterministic SHA-256 seed from the agent name.
+    /// 2. Signs an [`AgentAdvertisement`] with that seed.
+    /// 3. Stores the serialised definition via `upsert_agent_def`.
+    /// 4. Registers the advertisement in the in-memory [`FederatedRegistry`].
+    ///
+    /// Returns the count of agents successfully seeded, or `Ok(0)` when
+    /// already seeded.
+    ///
+    /// In browser builds this method is `async` because it awaits IndexedDB
+    /// persistence; on the native-feature path (tests) it is synchronous.
+    #[cfg(target_arch = "wasm32")]
+    pub async fn seed_default_catalog(&mut self) -> Result<usize, String> {
+        self.seed_default_catalog_inner()
+    }
+
+    /// Synchronous seeding for non-browser contexts (tests, CLI tools).
+    ///
+    /// Identical logic to the `async` version — the `async` wrapper exists
+    /// only to satisfy the browser call-site convention.
+    #[cfg(not(target_arch = "wasm32"))]
+    pub fn seed_default_catalog(&mut self) -> Result<usize, String> {
+        self.seed_default_catalog_inner()
+    }
+
+    /// Core seeding logic — shared by both the async (wasm32) and sync (native)
+    /// public methods.
+    fn seed_default_catalog_inner(&mut self) -> Result<usize, String> {
+        // Idempotency check — if any defs already exist, skip seeding.
+        let existing = self
+            .db
+            .list_agent_defs()
+            .map_err(|e| format!("list_agent_defs failed: {}", e.0))?;
+        if !existing.is_empty() {
+            return Ok(0);
+        }
+
+        let catalog_defs: Vec<WasmDynamicAgentDef> =
+            serde_json::from_str(CATALOG_JSON).map_err(|e| {
+                format!("failed to deserialize embedded catalog.json: {e}")
+            })?;
+
+        let mut count = 0usize;
+
+        for mut def in catalog_defs {
+            // Derive deterministic operator keypair from name.
+            let seed: [u8; 32] = Sha256::digest(def.name.as_bytes()).into();
+            def.operator_key_seed = Some(seed);
+
+            // Derive the DID from the seed and store it on the def.
+            let signing_key = SigningKey::from_bytes(&seed);
+            let did = public_key_to_did(&signing_key.verifying_key());
+            def.agent_did = Some(did);
+
+            // Build and sign advertisement.
+            let ad = match def.to_signed_advertisement() {
+                Ok(ad) => ad,
+                Err(_e) => {
+                    #[cfg(target_arch = "wasm32")]
+                    web_sys::console::warn_1(
+                        &format!(
+                            "papillon: skipping catalog agent '{}': {}",
+                            def.name, _e
+                        )
+                        .into(),
+                    );
+                    continue;
+                }
+            };
+
+            // Serialize def to JSON.
+            let json = match serde_json::to_string(&def) {
+                Ok(j) => j,
+                Err(_e) => {
+                    #[cfg(target_arch = "wasm32")]
+                    web_sys::console::warn_1(
+                        &format!(
+                            "papillon: failed to serialize agent '{}': {}",
+                            def.name, _e
+                        )
+                        .into(),
+                    );
+                    continue;
+                }
+            };
+
+            // Persist to database.
+            if let Err(_e) = self.db.upsert_agent_def(&def.name, &json) {
+                #[cfg(target_arch = "wasm32")]
+                web_sys::console::warn_1(
+                    &format!(
+                        "papillon: failed to persist agent '{}': {:?}",
+                        def.name, _e
+                    )
+                    .into(),
+                );
+                continue;
+            }
+
+            // Register in in-memory registry.
+            // register_local returns Err if the DID is already present (two catalog
+            // entries that hash to the same DID, or a re-seed attempt).
+            // We persist the definition regardless so it survives reload, but only
+            // count the agent if it was newly registered.
+            let newly_registered = self.registry.register_local(ad).is_ok();
+            self.defs.push(def);
+            if newly_registered {
+                count += 1;
+            }
+        }
+
+        Ok(count)
+    }
+
+    // ── Query methods ─────────────────────────────────────────────────────────
+
+    /// Return all registered agent advertisements.
+    pub fn list_agents(&self) -> Vec<AgentAdvertisement> {
+        self.registry.all_advertisements().to_owned()
+    }
+
+    /// Return advertisements for agents that can handle the given Schema.org
+    /// action type (e.g. `"schema:SearchAction"`).
+    pub fn query_by_action(&self, action: &str) -> Vec<AgentAdvertisement> {
+        self.registry
+            .query_local(action)
+            .into_iter()
+            .cloned()
+            .collect()
+    }
+
+    /// Return the number of agents currently registered in memory.
+    pub fn agent_count(&self) -> usize {
+        self.registry.len()
+    }
+
+    /// Return a reference to the raw agent definitions held in memory.
+    pub fn defs(&self) -> &[WasmDynamicAgentDef] {
+        &self.defs
+    }
+
+    /// Access the underlying database (for episode/settings persistence).
+    pub fn db(&self) -> &IndexedDbDatabase {
+        &self.db
+    }
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── WasmDynamicAgentDef helpers ───────────────────────────────────────────
+
+    fn make_def(name: &str) -> WasmDynamicAgentDef {
+        WasmDynamicAgentDef {
+            agent_did: None,
+            schema_version: 1,
+            version: "0.1.0".to_string(),
+            name: name.to_string(),
+            provider: "Test".to_string(),
+            description: "test".to_string(),
+            action: "schema:SearchAction".to_string(),
+            object_types: vec![],
+            requires_disclosure: vec![],
+            returns: vec![],
+            llm_instructions: String::new(),
+            subagents: vec![],
+            operator_key_seed: None,
+            published_to: vec![],
+            catalog_path: None,
+            configurable_properties: vec![],
+            created_at: String::new(),
+            updated_at: String::new(),
+            extra: Default::default(),
+        }
+    }
+
+    #[test]
+    fn to_signed_advertisement_produces_valid_did() {
+        let def = make_def("Test Agent");
+        let ad = def
+            .to_signed_advertisement()
+            .expect("should produce advertisement");
+        assert!(
+            ad.provider.did.starts_with("did:key:"),
+            "DID should start with did:key: — got: {}",
+            ad.provider.did
+        );
+        assert!(
+            ad.signature.is_some(),
+            "advertisement must be signed"
+        );
+        assert_eq!(ad.name, "Test Agent");
+    }
+
+    #[test]
+    fn to_signed_advertisement_is_deterministic() {
+        let def = make_def("Deterministic Agent");
+        let ad1 = def.to_signed_advertisement().unwrap();
+        let ad2 = def.to_signed_advertisement().unwrap();
+        assert_eq!(
+            ad1.provider.did, ad2.provider.did,
+            "same name must always produce the same DID"
+        );
+    }
+
+    #[test]
+    fn new_empty_registry_has_zero_agents() {
+        let registry = WasmAgentRegistry::new_empty("test-empty")
+            .expect("new_empty should succeed");
+        assert_eq!(registry.agent_count(), 0);
+        assert!(registry.list_agents().is_empty());
+    }
+
+    #[test]
+    fn seed_default_catalog_seeds_all_agents() {
+        // Use the synchronous path: manually read catalog JSON and seed via the
+        // in-memory registry — this lets us test the seeding logic without an
+        // async runtime or browser IndexedDB.
+        let catalog_defs: Vec<WasmDynamicAgentDef> =
+            serde_json::from_str(CATALOG_JSON)
+                .expect("embedded catalog.json must deserialize");
+
+        assert!(
+            catalog_defs.len() >= 300,
+            "expected at least 300 catalog entries, got {}",
+            catalog_defs.len()
+        );
+
+        // Build advertisements for all catalog entries.
+        let mut count = 0usize;
+        for def in &catalog_defs {
+            let ad = def
+                .to_signed_advertisement()
+                .unwrap_or_else(|e| panic!("failed for '{}': {e}", def.name));
+            assert!(
+                ad.signature.is_some(),
+                "agent '{}' must have a signature",
+                def.name
+            );
+            count += 1;
+        }
+        assert!(count >= 300, "expected 300+ signed ads, got {count}");
+    }
+
+    #[test]
+    fn seed_default_catalog_returns_nonzero_count_on_fresh_db() {
+        let mut reg = WasmAgentRegistry::new_empty("test-seed-fresh")
+            .expect("new_empty should succeed");
+        let count = reg
+            .seed_default_catalog()
+            .expect("seed should succeed on fresh db");
+        assert!(
+            count >= 300,
+            "expected at least 300 agents seeded, got {count}"
+        );
+        // agent_count() reflects unique DIDs; count reflects unique registrations.
+        // They should be equal (or count could be slightly lower if two entries
+        // produce the same DID, which is an extremely rare SHA-256 collision).
+        assert!(
+            reg.agent_count() >= 300,
+            "agent_count must be at least 300 after seeding, got {}",
+            reg.agent_count()
+        );
+    }
+
+    #[test]
+    fn seed_default_catalog_is_idempotent() {
+        // Seed once — verify count, then seed again and verify Ok(0).
+        let mut reg = WasmAgentRegistry::new_empty("test-seed-idem")
+            .expect("new_empty should succeed");
+
+        let first = reg
+            .seed_default_catalog()
+            .expect("first seed should succeed");
+        assert!(first >= 300, "first seed must produce agents");
+        let count_after_first = reg.agent_count();
+
+        // Second call must be a no-op.
+        let second = reg
+            .seed_default_catalog()
+            .expect("second seed should succeed");
+        assert_eq!(second, 0, "second seed must return Ok(0) — idempotent");
+
+        // Count must be unchanged.
+        assert_eq!(
+            reg.agent_count(),
+            count_after_first,
+            "agent count must not change after second seed"
+        );
+    }
+
+    #[test]
+    fn seed_default_catalog_idempotent_via_db() {
+        // Simulate idempotency via pre-populated DB: if the DB already has
+        // entries, seed_default_catalog must return Ok(0) immediately.
+        let db = IndexedDbDatabase::new_with_persistence("test-idem")
+            .expect("db creation failed");
+        db.upsert_agent_def("existing", r#"{"name":"existing"}"#)
+            .expect("upsert should succeed");
+
+        let mut reg = WasmAgentRegistry::from_db(db)
+            .expect("from_db should succeed");
+
+        let count = reg
+            .seed_default_catalog()
+            .expect("seed on pre-populated db should succeed");
+        assert_eq!(
+            count, 0,
+            "seed must return Ok(0) when DB is already non-empty"
+        );
+    }
+
+    #[test]
+    fn query_by_action_filters_correctly() {
+        let mut registry =
+            WasmAgentRegistry::new_empty("test-query").expect("new_empty should succeed");
+
+        // Manually insert two agents: one SearchAction, one BuyAction.
+        let search_def = make_def("Search Agent");
+        let mut buy_def = make_def("Buy Agent");
+        buy_def.action = "schema:BuyAction".to_string();
+
+        let search_ad = search_def.to_signed_advertisement().unwrap();
+        let buy_ad = buy_def.to_signed_advertisement().unwrap();
+
+        registry
+            .registry
+            .register_local(search_ad)
+            .expect("register search");
+        registry
+            .registry
+            .register_local(buy_ad)
+            .expect("register buy");
+
+        let search_results = registry.query_by_action("schema:SearchAction");
+        assert_eq!(
+            search_results.len(),
+            1,
+            "only one SearchAction agent expected"
+        );
+        assert_eq!(search_results[0].name, "Search Agent");
+
+        let buy_results = registry.query_by_action("schema:BuyAction");
+        assert_eq!(buy_results.len(), 1, "only one BuyAction agent expected");
+        assert_eq!(buy_results[0].name, "Buy Agent");
+    }
+
+    #[test]
+    fn agent_count_reflects_registry_state() {
+        let mut registry =
+            WasmAgentRegistry::new_empty("test-count").expect("new_empty should succeed");
+        assert_eq!(registry.agent_count(), 0);
+
+        let def1 = make_def("Agent One");
+        let def2 = make_def("Agent Two");
+        registry
+            .registry
+            .register_local(def1.to_signed_advertisement().unwrap())
+            .unwrap();
+        registry
+            .registry
+            .register_local(def2.to_signed_advertisement().unwrap())
+            .unwrap();
+
+        assert_eq!(registry.agent_count(), 2);
+    }
+
+    #[test]
+    fn wasm_def_deserializes_from_full_dynamic_agent_json() {
+        // Verify that a JSON blob with all DynamicAgentDef fields (including
+        // `source` and `endpoint` which are in `extra`) deserializes cleanly.
+        let json = r#"{
+            "agent_did": null,
+            "schema_version": 1,
+            "version": "0.1.0",
+            "name": "DuckDuckGo Search",
+            "provider": "DuckDuckGo",
+            "description": "Web search via DuckDuckGo",
+            "action": "schema:SearchAction",
+            "object_types": ["schema:Thing"],
+            "requires_disclosure": [],
+            "returns": ["schema:SearchResult"],
+            "llm_instructions": "",
+            "subagents": [],
+            "published_to": [],
+            "catalog_path": "search/duckduckgo.toml",
+            "configurable_properties": [],
+            "created_at": "",
+            "updated_at": "",
+            "source": "Catalog",
+            "endpoint": {
+                "url_template": "https://api.duckduckgo.com/?q={query}&format=json",
+                "method": "Get",
+                "headers": {},
+                "body_template": null,
+                "response_jsonpath": "$",
+                "response_schema_type": "schema:SearchResult",
+                "response_mapping": {},
+                "timeout_secs": 5
+            }
+        }"#;
+
+        let def: WasmDynamicAgentDef =
+            serde_json::from_str(json).expect("must deserialize without error");
+        assert_eq!(def.name, "DuckDuckGo Search");
+        assert_eq!(def.action, "schema:SearchAction");
+        // `source` and `endpoint` land in `extra` without causing an error.
+        assert!(def.extra.contains_key("source"));
+        assert!(def.extra.contains_key("endpoint"));
+    }
+
+    #[test]
+    fn catalog_json_deserializes_to_wasm_defs() {
+        let defs: Vec<WasmDynamicAgentDef> =
+            serde_json::from_str(CATALOG_JSON)
+                .expect("embedded catalog.json must deserialize to WasmDynamicAgentDef");
+        assert!(
+            defs.len() >= 300,
+            "expected 300+ defs in catalog, got {}",
+            defs.len()
+        );
+        for def in &defs {
+            assert!(
+                def.action.starts_with("schema:"),
+                "action '{}' in '{}' must start with 'schema:'",
+                def.action,
+                def.name
+            );
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- **Embed PAP catalog at compile time** (`pap-agents/build.rs`): walks all 309 `catalog/**/*.toml` files at build time, serializes to `$OUT_DIR/catalog.json`, exposed as `pap_agents::default_catalog()` via `include_str!` — no filesystem access required in WASM
- **Extend `DatabaseOps` with agent def CRUD** (`papillon-shared`): 4 new methods (`upsert_agent_def`, `list_agent_defs`, `get_agent_def`, `delete_agent_def`) using a `(name, json_string)` interface; implemented in `WasmDatabase` (HashMap), `NativeDatabase` (SQLite), and `IndexedDbDatabase` (snapshot v2)
- **`WasmAgentRegistry`** (`papillon-shared/src/wasm_registry.rs`): WASM-safe local registry backed by IndexedDB + in-memory `FederatedRegistry`; `seed_default_catalog()` is idempotent, uses SHA-256(name) for deterministic keypairs (not persisted to IndexedDB)
- **Wire `WebService` to registry** (`apps/papillon/frontend`): `navigate_registry` and `list_registry_agents` stubs replaced with real implementations; catalog seeded on first launch

The `apps/registry` (Chrysalis) server was already complete — the "Install Catalog Agents" button in Settings has always worked. This PR closes the gap for the **Papillon WASM/browser build** so it has the same 309 default agents available locally via IndexedDB.

## Test plan

- [ ] `cargo test -p pap-agents` — 133 tests pass (includes new `embedded_catalog_deserializes` round-trip test)
- [ ] `cargo test -p papillon-shared` — 288 tests pass (includes agent def CRUD tests across all 3 backends)
- [ ] `cargo check --manifest-path apps/papillon/frontend/Cargo.toml --target wasm32-unknown-unknown` — clean
- [ ] First launch in browser: 309 agents seeded to IndexedDB; second launch: `seed_default_catalog` no-ops
- [ ] `list_registry_agents("schema:SearchAction")` returns search-capable agents only
- [ ] `list_registry_agents("")` returns all 309 agents

🤖 Generated with [Claude Code](https://claude.com/claude-code)