### PR TITLE
fix(faq): correct Q02 OHTTP coverage — configurable setting, not always-on

### DIFF
--- a/docs/faq.html
+++ b/docs/faq.html
@@ -877,6 +877,81 @@
         </div>
       </div>
 
+      <!-- 13 -->
+      <div class="faq-item reveal reveal-delay-2" data-cat="enterprise">
+        <button class="faq-q" aria-expanded="false">
+          <div class="faq-q-left">
+            <span class="faq-num">13</span>
+            <div class="faq-q-text">
+              <div><span class="faq-badge badge-enterprise">Enterprise</span></div>
+              We're a regulated financial institution / healthcare system. Walk me through how PAP operates inside our compliance framework.
+            </div>
+          </div>
+          <svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </button>
+        <div class="faq-body">
+          <p>
+            <strong>Most enterprise software achieves compliance by adding controls on top of a
+            general-purpose system.</strong> PAP's compliance properties are protocol invariants —
+            they hold because of cryptographic enforcement, not configuration. Here is what that
+            means per framework.
+          </p>
+          <p>
+            <strong>HIPAA — Minimum Necessary Rule:</strong> Every agent session uses Selective
+            Disclosure JWT (<code>crates/pap-credential/src/sd_jwt.rs</code>). The mandate's
+            <code>DisclosureSet</code> specifies exactly which <code>schema:</code> properties an
+            agent may receive. An agent requesting <code>schema:SSN</code> when the mandate permits
+            only <code>schema:dateOfBirth</code> is filtered out by the marketplace before any
+            session is established — the over-disclosure attempt never reaches the transport layer.
+            For no-retention requirements, set <code>no_retention: true</code> on disclosure
+            entries; the session can be backed by a Trusted Execution Environment
+            (<code>crates/pap-tee/</code>) for cryptographic deletion enforcement, or
+            contractual-only assurance otherwise. Audit trail: co-signed receipts in
+            <code>pap-core/src/receipt.rs</code> record property type references
+            (<code>"schema:Patient.schema:dateOfBirth"</code>), never values — satisfying
+            §164.312(b) while being safer than access logs containing real data.
+          </p>
+          <p>
+            <strong>GDPR — Purpose Limitation and Erasure:</strong> A PAP mandate is
+            structured, machine-enforceable consent: the principal signs which agent may act,
+            which actions it may take (<code>Scope::deny_all()</code> baseline), which properties
+            it may see, and for how long. Non-renewal of a mandate initiates the decay state
+            machine (<code>Active → Degraded → ReadOnly → Suspended</code>): access cryptographically
+            expires without any deprovisioning step. The episode store
+            (<code>papillon-shared/src/episode_db.rs</code>) is a local SQLite database under
+            the principal's sole control — no platform coordinates erasure. Portability: PAP uses
+            no central registry; the principal's <code>did:key</code> is self-sovereign and moves
+            to any compatible orchestrator.
+          </p>
+          <p>
+            <strong>PCI-DSS — Access Control and Payment Privacy:</strong>
+            Mandate scope containment is cryptographically enforced at every delegation step
+            (<code>Scope::contains()</code> in <code>pap-core/src/scope.rs</code>); a child mandate
+            cannot exceed its parent's scope or TTL regardless of configuration. For payment
+            agents (<code>schema:PayAction</code>), mandates carry payment proofs from the ecash
+            system (<code>crates/pap-ecash/</code>) using RFC 9474 RSABSSA-PSS blind signatures —
+            the vendor cannot link the signing operation to the redemption, and receipts store
+            only a commitment hash, never amounts or card data.
+          </p>
+          <p>
+            <strong>SOC2 Type II in summary:</strong> CC3.1 (access control) — deny-by-default
+            scope, TTL bounds. CC6.1 (logical controls) — ephemeral session keys, automatic
+            credential expiry. CC7.1 (audit records) — immutable co-signed receipts. A1.2
+            (privacy) — <code>no_retention</code> flag with TEE attestation option. These map
+            to protocol mechanisms, not to policy documents that can drift.
+          </p>
+          <p>
+            Pre-built catalog agents exist for both verticals: healthcare agents cover FDA FAERS,
+            ClinicalTrials, PubMed, and MedlinePlus
+            (<code>crates/pap-agents/catalog/health/</code>); finance agents cover Nasdaq, ECB,
+            Treasury, and World Bank data (<code>crates/pap-agents/catalog/finance/</code>).
+            All public-data agents require zero personal disclosure
+            (<code>requires_disclosure: []</code>), giving you a no-PHI-exposure baseline to
+            build from.
+          </p>
+        </div>
+      </div>
+
     </div><!-- /faq-list -->
 
   </div><!-- /container-md -->

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -835,16 +835,16 @@
         </button>
         <div class="faq-body">
           <p>
-            <strong>If your first instinct is IdP integration, you're importing a centralized
-            assumption PAP is designed to make unnecessary.</strong> Okta and Azure AD solve a
-            hub-and-spoke problem: a central authority that decides who gets access to what.
-            PAP inverts this. Agents protect themselves — they advertise what they require,
-            principals present cryptographically scoped mandates, and the protocol enforces
-            access at the edge without any central authority in the loop.
+            <strong>The IdP question carries a centralized assumption PAP is designed to make
+            unnecessary.</strong> Okta and Azure AD solve a hub-and-spoke problem: a central
+            authority that decides who gets access to what. PAP inverts this. Agents protect
+            themselves — they advertise what they require, principals present cryptographically
+            scoped mandates, and the protocol enforces access at the edge without any central
+            authority in the loop.
           </p>
           <p>
             <strong>The PAP-native pattern for enterprise agent access control:</strong>
-            Your company runs agents on Chrysalis. Each agent declares its
+            An enterprise runs agents on Chrysalis. Each agent declares its
             <code>requires_disclosure</code> — the minimum SD-JWT claims it needs to execute
             (e.g. <code>schema:Organization.schema:memberOf</code> to verify employment, or
             a <code>schema:Role</code> claim scoped to a department). A principal's orchestrator
@@ -854,9 +854,9 @@
             is in the path. No central session store. The agent is the access control point.
           </p>
           <p>
-            <strong>For value exchange between agents, use ecash receipts rather than
+            <strong>For value exchange between agents, ecash receipts replace
             identity-gated permissions.</strong> Instead of "does this principal have the
-            Analyst role in Okta?", structure access as "does this principal hold a valid
+            Analyst role in Okta?", access is structured as "does this principal hold a valid
             payment proof for this action?" The ecash system (<code>crates/pap-ecash/</code>)
             issues blind-signed RFC 9474 RSABSSA-SHA384-PSS tokens — the agent validates
             the token without learning who holds it, and the receipt proves the exchange
@@ -865,14 +865,14 @@
             token is simply gone.
           </p>
           <p>
-            <strong>What your CISO actually needs</strong> is answered by the protocol, not
+            <strong>What security teams actually need</strong> is answered by the protocol, not
             by an IdP bridge: access policy is encoded in mandate scope
             (<code>Scope::deny_all()</code> baseline, cryptographically enforced containment);
             audit trail is the co-signed receipt chain (property references, never values,
             held by both parties locally); revocation is TTL decay
             (<code>Active → Degraded → ReadOnly → Suspended</code>) with no deprovisioning
-            step required. The threat model your CISO is used to — "who has a live session
-            token?" — doesn't apply to a system where every mandate expires by design.
+            step required. The threat model of "who has a live session token?" doesn't apply
+            to a system where every mandate expires by design.
           </p>
         </div>
       </div>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -898,17 +898,19 @@
           </p>
           <p>
             <strong>HIPAA — Minimum Necessary Rule:</strong> Every agent session uses Selective
-            Disclosure JWT (<code>crates/pap-credential/src/sd_jwt.rs</code>). The mandate's
-            <code>DisclosureSet</code> specifies exactly which <code>schema:</code> properties an
-            agent may receive. An agent requesting <code>schema:SSN</code> when the mandate permits
+            Disclosure JWT (<code>crates/pap-credential/src/sd_jwt.rs</code>) for claim-level
+            cryptographic hiding. The mandate's <code>DisclosureSet</code>
+            (<code>crates/pap-core/src/scope.rs</code>) specifies exactly which
+            <code>schema:</code> properties an agent may receive. An agent requesting <code>schema:SSN</code> when the mandate permits
             only <code>schema:dateOfBirth</code> is filtered out by the marketplace before any
             session is established — the over-disclosure attempt never reaches the transport layer.
             For no-retention requirements, set <code>no_retention: true</code> on disclosure
             entries; the session can be backed by a Trusted Execution Environment
-            (<code>crates/pap-tee/</code>) for cryptographic deletion enforcement, or
-            contractual-only assurance otherwise. Audit trail: co-signed receipts in
+            (<code>crates/pap-tee/</code>) — the TEE provides enclave measurement attestation
+            that the session ran in an isolated environment, making the retention commitment
+            auditable and binding rather than contractual-only. Audit trail: co-signed receipts in
             <code>pap-core/src/receipt.rs</code> record property type references
-            (<code>"schema:Patient.schema:dateOfBirth"</code>), never values — satisfying
+            (<code>"schema:Person.schema:dateOfBirth"</code>), never values — satisfying
             §164.312(b) while being safer than access logs containing real data.
           </p>
           <p>
@@ -929,15 +931,16 @@
             (<code>Scope::contains()</code> in <code>pap-core/src/scope.rs</code>); a child mandate
             cannot exceed its parent's scope or TTL regardless of configuration. For payment
             agents (<code>schema:PayAction</code>), mandates carry payment proofs from the ecash
-            system (<code>crates/pap-ecash/</code>) using RFC 9474 RSABSSA-PSS blind signatures —
+            system (<code>crates/pap-ecash/</code>) using RFC 9474 RSABSSA-SHA384-PSS blind signatures —
             the vendor cannot link the signing operation to the redemption, and receipts store
             only a commitment hash, never amounts or card data.
           </p>
           <p>
             <strong>SOC2 Type II in summary:</strong> CC3.1 (access control) — deny-by-default
             scope, TTL bounds. CC6.1 (logical controls) — ephemeral session keys, automatic
-            credential expiry. CC7.1 (audit records) — immutable co-signed receipts. A1.2
-            (privacy) — <code>no_retention</code> flag with TEE attestation option. These map
+            credential expiry. CC7.1 (audit records) — immutable co-signed receipts. Privacy
+            use limitation — <code>no_retention</code> flag enforces purpose limitation at
+            protocol level, with optional TEE attestation for stronger assurance. These map
             to protocol mechanisms, not to policy documents that can drift.
           </p>
           <p>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -6,12 +6,12 @@
   <title>FAQ — Principal Agent Protocol</title>
   <meta name="description" content="Honest answers to the hardest technical and enterprise questions about PAP — trust model, cryptography, governance, latency, compliance, and developer experience." />
   <meta property="og:title" content="FAQ — Principal Agent Protocol" />
-  <meta property="og:description" content="10 hard questions about PAP, answered honestly. Trust model, cryptographic limitations, enterprise identity, regulatory compliance, and Python integration." />
+  <meta property="og:description" content="13 hard questions about PAP, answered honestly. Trust model, cryptographic limitations, enterprise identity, regulatory compliance, and Python integration." />
   <meta property="og:type" content="website" />
   <meta property="og:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
   <meta name="twitter:card" content="summary_large_image" />
   <meta name="twitter:title" content="FAQ — Principal Agent Protocol" />
-  <meta name="twitter:description" content="10 hard questions about PAP, answered honestly." />
+  <meta name="twitter:description" content="13 hard questions about PAP, answered honestly." />
   <meta name="twitter:image" content="https://baur-software.github.io/pap/assets/images/og-card.png" />
   <link rel="preconnect" href="https://fonts.googleapis.com" />
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
@@ -173,6 +173,7 @@
     .filter-pill[data-cat="latency"].active    { border-color: rgba(139,127,245,.4); background: rgba(139,127,245,.08); color: var(--violet); }
     .filter-pill[data-cat="compliance"].active { border-color: rgba(225,112,85,.4); background: rgba(225,112,85,.08); color: var(--coral); }
     .filter-pill[data-cat="dx"].active         { border-color: rgba(46,196,160,.4); background: rgba(46,196,160,.08); color: var(--teal); }
+    .filter-pill[data-cat="enterprise"].active { border-color: rgba(99,102,241,.4); background: rgba(99,102,241,.08); color: #818cf8; }
 
     /* ─── FAQ accordion ───────────────────────────────────────────────── */
     .faq-list { display: flex; flex-direction: column; gap: 12px; margin-bottom: 80px; }
@@ -191,6 +192,7 @@
     .faq-item[data-cat="latency"]    { border-left: 3px solid rgba(139,127,245,.5); }
     .faq-item[data-cat="compliance"] { border-left: 3px solid rgba(225,112,85,.5); }
     .faq-item[data-cat="dx"]         { border-left: 3px solid rgba(46,196,160,.5); }
+    .faq-item[data-cat="enterprise"] { border-left: 3px solid rgba(99,102,241,.5); }
 
     .faq-q {
       width: 100%; display: flex; align-items: flex-start; gap: 16px;
@@ -221,6 +223,7 @@
     .badge-latency    { background: rgba(139,127,245,.12); color: var(--violet); }
     .badge-compliance { background: rgba(225,112,85,.12); color: var(--coral); }
     .badge-dx         { background: rgba(46,196,160,.12); color: var(--teal); }
+    .badge-enterprise { background: rgba(99,102,241,.12); color: #818cf8; }
 
     .faq-chevron {
       width: 20px; height: 20px; flex-shrink: 0; margin-top: 4px;
@@ -233,7 +236,7 @@
       transition: max-height .35s ease, padding .25s ease;
       padding: 0 24px 0 66px;
     }
-    .faq-item.open .faq-body { max-height: 600px; padding: 0 24px 24px 66px; }
+    .faq-item.open .faq-body { max-height: 1600px; padding: 0 24px 24px 66px; }
 
     .faq-body p { color: var(--muted); font-size: .93rem; line-height: 1.75; margin-bottom: 12px; }
     .faq-body p:last-child { margin-bottom: 0; }
@@ -313,7 +316,7 @@
       Every protocol has real limitations. PAP's are documented here, alongside what's
       currently implemented, what's on the roadmap, and where the open design questions live.
     </p>
-    <p class="hero-note">10 questions · reviewed April 2026</p>
+    <p class="hero-note">13 questions · reviewed April 2026</p>
   </div>
 </section>
 
@@ -330,6 +333,7 @@
       <button class="filter-pill" data-cat="latency">Latency</button>
       <button class="filter-pill" data-cat="compliance">Compliance</button>
       <button class="filter-pill" data-cat="dx">Developer UX</button>
+      <button class="filter-pill" data-cat="enterprise">Enterprise</button>
     </div>
 
     <div class="faq-list" id="faq-list">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -763,6 +763,64 @@
         </div>
       </div>
 
+      <!-- 11 -->
+      <div class="faq-item reveal" data-cat="enterprise">
+        <button class="faq-q" aria-expanded="false">
+          <div class="faq-q-left">
+            <span class="faq-num">11</span>
+            <div class="faq-q-text">
+              <div><span class="faq-badge badge-enterprise">Enterprise</span></div>
+              You've cryptographically secured the disclosure layer. How do you prevent the model itself from being the attack surface?
+            </div>
+          </div>
+          <svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </button>
+        <div class="faq-body">
+          <p>
+            <strong>The LLM touches exactly one function in the PAP stack.</strong> The
+            <code>LlmClient</code> trait in <code>crates/pap-agents/src/llm.rs</code> exposes two methods:
+            <code>classify_intent(text, candidate_actions)</code> and <code>complete(system, user)</code>.
+            That's the entire surface. The model receives the user's query string and a pre-computed list
+            of allowed <code>schema:*Action</code> strings. It does not receive — and cannot request —
+            mandate contents, scope, TTL, session DIDs, disclosure sets, or the principal's keypair.
+          </p>
+          <p>
+            <strong>Its output is validated before use.</strong> The return value of
+            <code>classify_intent</code> must match one of the strings in <code>candidate_actions</code>.
+            A hallucinated action that isn't on the list is discarded. The model controls which
+            catalog agent handles the query. It cannot alter the mandate that governs what that agent
+            is allowed to do — mandates are signed by the principal's device-bound Ed25519 key,
+            which the model never sees.
+          </p>
+          <p>
+            <strong>The four canonical LLM attack paths:</strong>
+            <strong>Prompt injection</strong> — succeeds only at routing the query to the wrong catalog
+            agent; it cannot forge the Ed25519 signature that authorizes scope. <strong>Context
+            exfiltration</strong> — the model only receives query text, never the mandate or session keys.
+            <strong>Session correlation</strong> — each session generates a fresh ephemeral DID discarded
+            at close; the model sees the query text, never the session DID. <strong>Scope escalation</strong>
+            — child mandates are cryptographically constrained to a subset of their parent's scope
+            (<code>Scope::deny_all()</code> baseline, <code>contains()</code> enforcement);
+            no model output can extend this.
+          </p>
+          <p>
+            <strong>The default is on-device.</strong> <code>LlmProvider::BuiltIn</code> runs inference
+            locally via Candle — no network call, no external endpoint, no logs leaving the device.
+            External providers (Mistral, Ollama, OpenAI-compatible) require the user to explicitly
+            configure an API key and endpoint URL. Even with an external provider, only query text
+            travels to the endpoint. For deployments requiring network-layer query privacy,
+            OHTTP (RFC 9458) with real HPKE decouples the IP address from the request content.
+          </p>
+          <p>
+            <strong>The LLM is also optional.</strong> The full 6-phase PAP handshake executes
+            deterministically via URL fast-path and BM25 semantic index without any model.
+            Setting <code>LlmProvider::None</code> gives a fully functional, cryptographically
+            sound protocol runtime. The model enhances intent resolution for ambiguous queries;
+            it gates no security decision.
+          </p>
+        </div>
+      </div>
+
     </div><!-- /faq-list -->
 
   </div><!-- /container-md -->

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -173,7 +173,7 @@
     .filter-pill[data-cat="latency"].active    { border-color: rgba(139,127,245,.4); background: rgba(139,127,245,.08); color: var(--violet); }
     .filter-pill[data-cat="compliance"].active { border-color: rgba(225,112,85,.4); background: rgba(225,112,85,.08); color: var(--coral); }
     .filter-pill[data-cat="dx"].active         { border-color: rgba(46,196,160,.4); background: rgba(46,196,160,.08); color: var(--teal); }
-    .filter-pill[data-cat="enterprise"].active { border-color: rgba(99,102,241,.4); background: rgba(99,102,241,.08); color: #818cf8; }
+    .filter-pill[data-cat="enterprise"].active { border-color: rgba(139,127,245,.4); background: rgba(139,127,245,.08); color: var(--violet); }
 
     /* ─── FAQ accordion ───────────────────────────────────────────────── */
     .faq-list { display: flex; flex-direction: column; gap: 12px; margin-bottom: 80px; }
@@ -192,7 +192,7 @@
     .faq-item[data-cat="latency"]    { border-left: 3px solid rgba(139,127,245,.5); }
     .faq-item[data-cat="compliance"] { border-left: 3px solid rgba(225,112,85,.5); }
     .faq-item[data-cat="dx"]         { border-left: 3px solid rgba(46,196,160,.5); }
-    .faq-item[data-cat="enterprise"] { border-left: 3px solid rgba(99,102,241,.5); }
+    .faq-item[data-cat="enterprise"] { border-left: 3px solid rgba(139,127,245,.5); }
 
     .faq-q {
       width: 100%; display: flex; align-items: flex-start; gap: 16px;
@@ -223,7 +223,7 @@
     .badge-latency    { background: rgba(139,127,245,.12); color: var(--violet); }
     .badge-compliance { background: rgba(225,112,85,.12); color: var(--coral); }
     .badge-dx         { background: rgba(46,196,160,.12); color: var(--teal); }
-    .badge-enterprise { background: rgba(99,102,241,.12); color: #818cf8; }
+    .badge-enterprise { background: rgba(139,127,245,.12); color: var(--violet); }
 
     .faq-chevron {
       width: 20px; height: 20px; flex-shrink: 0; margin-top: 4px;

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -256,6 +256,61 @@
       border-radius: 6px; padding: 3px 9px; margin-top: 10px;
     }
 
+    /* ─── Glossary ───────────────────────────────────────────────────── */
+    .glossary-section {
+      margin: 0 auto 80px;
+      max-width: 800px; padding: 0 24px;
+    }
+    .glossary-heading {
+      font-family: 'Satoshi', sans-serif; font-weight: 700;
+      font-size: 1.1rem; letter-spacing: -.01em;
+      color: var(--text); margin-bottom: 6px;
+    }
+    .glossary-sub {
+      font-size: .83rem; color: var(--faint);
+      margin-bottom: 28px;
+      font-family: 'JetBrains Mono', monospace;
+    }
+    .glossary-grid {
+      display: grid;
+      grid-template-columns: repeat(auto-fill, minmax(340px, 1fr));
+      gap: 1px;
+      border: 1px solid var(--border);
+      border-radius: var(--radius-lg);
+      overflow: hidden;
+      background: var(--border);
+    }
+    .glossary-term {
+      background: var(--surface);
+      padding: 16px 20px;
+    }
+    .glossary-term dt {
+      font-family: 'JetBrains Mono', monospace;
+      font-size: .82rem; font-weight: 600;
+      color: var(--violet); margin-bottom: 5px;
+    }
+    .glossary-term dd {
+      font-size: .87rem; color: var(--muted);
+      line-height: 1.6; margin: 0;
+    }
+    .glossary-term dd code {
+      font-family: 'JetBrains Mono', monospace; font-size: .82em;
+      background: rgba(255,255,255,.05); padding: 1px 5px; border-radius: 4px;
+      color: var(--teal);
+    }
+    /* glossary link style inside faq bodies */
+    .faq-body a.gloss {
+      color: var(--violet);
+      text-decoration: underline;
+      text-decoration-style: dotted;
+      text-decoration-color: rgba(139,127,245,.4);
+      text-underline-offset: 2px;
+    }
+    .faq-body a.gloss:hover {
+      color: var(--text);
+      text-decoration-color: var(--violet);
+    }
+
     /* ─── Footer ──────────────────────────────────────────────────────── */
     footer {
       border-top: 1px solid var(--border); padding: 40px 0;
@@ -353,11 +408,13 @@
         <div class="faq-body">
           <p>
             PAP v0.x is <strong>explicitly consumer-first</strong>. The trust anchor is a
-            <strong>device-bound Ed25519 keypair</strong> held by a single human principal
-            (<code>crates/pap-did/src/principal.rs</code>). Mandate delegation chains downstream
+            <strong>device-bound Ed25519 keypair</strong> held by a single human
+            <a href="#gloss-principal" class="gloss">principal</a>
+            (<code>crates/pap-did/src/principal.rs</code>).
+            <a href="#gloss-mandate" class="gloss">Mandate</a> delegation chains downstream
             <em>agents</em>, not other principals — principal-to-principal hierarchies are
             intentionally out of scope. Enterprise organizational structure is instead expressed
-            through Chrysalis-hosted agent workloads: a company runs agents in Chrysalis and
+            through <a href="#gloss-chrysalis" class="gloss">Chrysalis</a>-hosted agent workloads: a company runs agents in Chrysalis and
             routes advertisements to principals through normal PAP transport mechanisms, composing
             org-level orchestration at the agent layer without encoding it into the identity layer.
           </p>
@@ -402,7 +459,7 @@
         <div class="faq-body">
           <p>
             <strong>Yes — scoped to the recipient agent and cross-session receipt patterns.</strong>
-            SD-JWT (<code>pap-credential/src/sd_jwt.rs</code>) hides claim <em>values</em> via per-claim
+            <a href="#gloss-sd-jwt" class="gloss">SD-JWT</a> (<code>pap-credential/src/sd_jwt.rs</code>) hides claim <em>values</em> via per-claim
             salted hashes. It does not hide claim <em>structure</em>. Each agent in
             <code>pap-agents</code> declares exactly what it needs via
             <code>AgentMeta.requires_disclosure</code>
@@ -453,23 +510,26 @@
         </button>
         <div class="faq-body">
           <p>
-            <strong>Each Papillon instance and Chrysalis node runs its own embedded OHTTP relay.</strong>
-            Baur Software does not operate a relay. There is no external relay operator to capture.
-            The relay is colocated with your own deployment — decentralized by topology, not just by policy.
+            <strong><a href="#gloss-ohttp" class="gloss">OHTTP</a> relay capability is built into
+            <a href="#gloss-papillon" class="gloss">Papillon</a> and
+            <a href="#gloss-chrysalis" class="gloss">Chrysalis</a> — it runs
+            colocated with each deployment, not on Baur Software infrastructure.</strong>
+            When OHTTP is configured, there is no external relay operator to capture traffic.
+            The decentralization is topological: the relay lives alongside your own node.
           </p>
           <p>
-            In <code>pap-transport/src/ohttp.rs</code>, <code>relay_url</code> is typed <code>Option&lt;String&gt;</code>:
-            when absent the protocol falls back to a direct connection, so removing the relay degrades
-            privacy but never breaks the handshake. The core privacy guarantees — SD-JWT selective
-            disclosure, ephemeral session DIDs, deny-by-default mandates — do not depend on OHTTP.
+            <code>relay_url</code> in <code>pap-transport/src/ohttp.rs</code> is typed
+            <code>Option&lt;String&gt;</code>. When absent, the protocol falls back to a direct
+            connection — privacy degrades but the handshake never breaks. The core guarantees
+            (SD-JWT selective disclosure, ephemeral session DIDs, deny-by-default mandates)
+            do not depend on OHTTP being enabled.
           </p>
           <p>
-            The relay uses real
+            When the relay is active, it uses
             <a href="https://www.rfc-editor.org/rfc/rfc9458" target="_blank" rel="noopener">RFC 9458</a>
-            HPKE in <code>pap-transport/src/ohttp.rs</code>: DHKEM(X25519, HKDF-SHA256) +
-            HKDF-SHA256 + AES-128-GCM (RFC 9180). Relay operators and passive observers cannot
-            read SD-JWT disclosure structure or query content. The relay architecture is correct
-            and the cryptography is now real.
+            HPKE: DHKEM(X25519, HKDF-SHA256) + AES-128-GCM (RFC 9180). Relay operators and
+            passive observers cannot link IP addresses to query content or SD-JWT disclosure
+            structure.
           </p>
         </div>
       </div>
@@ -561,8 +621,9 @@
         </button>
         <div class="faq-body">
           <p>
-            Scope containment is <strong>cryptographically enforced at every delegation step</strong>.
-            <code>pap-core/src/scope.rs</code> <code>contains()</code> verifies that a child mandate's
+            <a href="#gloss-scope" class="gloss">Scope containment</a> is <strong>cryptographically enforced at every delegation step</strong>.
+            <code>pap-core/src/scope.rs</code> <code>contains()</code> verifies that a child
+            <a href="#gloss-mandate" class="gloss">mandate</a>'s
             action set is a strict subset of its parent's. <code>mandate.rs</code> <code>verify_chain()</code>
             binds each delegation to its parent by hash — you cannot forge a valid chain that expands scope.
             TTL cannot exceed the parent mandate either.
@@ -779,8 +840,8 @@
         </button>
         <div class="faq-body">
           <p>
-            <strong>The LLM touches exactly one function in the PAP stack.</strong> The
-            <code>LlmClient</code> trait in <code>crates/pap-agents/src/llm.rs</code> exposes two methods:
+            <strong>The LLM touches exactly one function in the PAP stack.</strong>
+            The <code>LlmClient</code> trait in <code>crates/pap-agents/src/llm.rs</code> exposes two methods:
             <code>classify_intent(text, candidate_actions)</code> and <code>complete(system, user)</code>.
             That's the entire surface. The model receives the user's query string and a pre-computed list
             of allowed <code>schema:*Action</code> strings. It does not receive — and cannot request —
@@ -799,7 +860,8 @@
             <strong>Prompt injection</strong> — succeeds only at routing the query to the wrong catalog
             agent; it cannot forge the Ed25519 signature that authorizes scope. <strong>Context
             exfiltration</strong> — the model only receives query text, never the mandate or session keys.
-            <strong>Session correlation</strong> — each session generates a fresh ephemeral DID discarded
+            <strong>Session correlation</strong> — each session generates a fresh
+            <a href="#gloss-session-did" class="gloss">ephemeral session DID</a> discarded
             at close; the model sees the query text, never the session DID. <strong>Scope escalation</strong>
             — child mandates are cryptographically constrained to a subset of their parent's scope
             (<code>Scope::deny_all()</code> baseline, <code>contains()</code> enforcement);
@@ -840,8 +902,9 @@
             <strong>The IdP question carries a centralized assumption PAP is designed to make
             unnecessary.</strong> Okta and Azure AD solve a hub-and-spoke problem: a central
             authority that decides who gets access to what. PAP inverts this. Agents protect
-            themselves — they advertise what they require, principals present cryptographically
-            scoped mandates, and the protocol enforces access at the edge without any central
+            themselves — they advertise what they require,
+            <a href="#gloss-principal" class="gloss">principals</a> present cryptographically
+            scoped <a href="#gloss-mandate" class="gloss">mandates</a>, and the protocol enforces access at the edge without any central
             authority in the loop.
           </p>
           <p>
@@ -859,7 +922,7 @@
             <strong>For value exchange between agents, ecash receipts replace
             identity-gated permissions.</strong> Instead of "does this principal have the
             Analyst role in Okta?", access is structured as "does this principal hold a valid
-            payment proof for this action?" The ecash system (<code>crates/pap-ecash/</code>)
+            payment proof for this action?" The <a href="#gloss-ecash" class="gloss">ecash system</a> (<code>crates/pap-ecash/</code>)
             issues blind-signed RFC 9474 RSABSSA-SHA384-PSS tokens — the agent validates
             the token without learning who holds it, and the receipt proves the exchange
             occurred without linking it to an identity. This is more privacy-preserving
@@ -870,8 +933,9 @@
             <strong>What security teams actually need</strong> is answered by the protocol, not
             by an IdP bridge: access policy is encoded in mandate scope
             (<code>Scope::deny_all()</code> baseline, cryptographically enforced containment);
-            audit trail is the co-signed receipt chain (property references, never values,
-            held by both parties locally); revocation is TTL decay
+            audit trail is the <a href="#gloss-receipt" class="gloss">co-signed receipt</a> chain (property references, never values,
+            held by both parties locally); revocation is
+            <a href="#gloss-decay" class="gloss">TTL decay</a>
             (<code>Active → Degraded → ReadOnly → Suspended</code>) with no deprovisioning
             step required. The threat model of "who has a live session token?" doesn't apply
             to a system where every mandate expires by design.
@@ -899,8 +963,9 @@
             means per framework.
           </p>
           <p>
-            <strong>HIPAA — Minimum Necessary Rule:</strong> Every agent session uses Selective
-            Disclosure JWT (<code>crates/pap-credential/src/sd_jwt.rs</code>) for claim-level
+            <strong>HIPAA — Minimum Necessary Rule:</strong> Every agent session uses
+            <a href="#gloss-sd-jwt" class="gloss">Selective Disclosure JWT</a>
+            (<code>crates/pap-credential/src/sd_jwt.rs</code>) for claim-level
             cryptographic hiding. The mandate's <code>DisclosureSet</code>
             (<code>crates/pap-core/src/scope.rs</code>) specifies exactly which
             <code>schema:</code> properties an agent may receive. An agent requesting <code>schema:SSN</code> when the mandate permits
@@ -924,7 +989,7 @@
             expires without any deprovisioning step. The episode store
             (<code>papillon-shared/src/episode_db.rs</code>) is a local SQLite database under
             the principal's sole control — no platform coordinates erasure. Portability: PAP uses
-            no central registry; the principal's <code>did:key</code> is self-sovereign and moves
+            no central registry; the principal's <a href="#gloss-did-key" class="gloss"><code>did:key</code></a> is self-sovereign and moves
             to any compatible orchestrator.
           </p>
           <p>
@@ -960,6 +1025,76 @@
     </div><!-- /faq-list -->
 
   </div><!-- /container-md -->
+
+  <!-- ─── Glossary ──────────────────────────────────────────────────────── -->
+  <div class="glossary-section reveal">
+    <h2 class="glossary-heading">Glossary</h2>
+    <p class="glossary-sub">Key terms used throughout this FAQ.</p>
+    <dl class="glossary-grid">
+
+      <div class="glossary-term" id="gloss-principal">
+        <dt>Principal</dt>
+        <dd>The human whose data and intent drives a PAP session. The principal holds the root Ed25519 keypair and is the only entity that can issue or authorize mandates. Agents act <em>on behalf of</em> the principal, never independently.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-mandate">
+        <dt>Mandate</dt>
+        <dd>A cryptographically signed authorization granted by the principal to an agent. Specifies which actions the agent may take (<code>schema:*Action</code>), which data properties it may see, and how long it is valid (TTL). Child mandates cannot exceed their parent's scope.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-sd-jwt">
+        <dt>SD-JWT (Selective Disclosure JWT)</dt>
+        <dd>A credential format that hides individual claim <em>values</em> via per-claim salted hashes. The orchestrator reveals only the property slots required by each agent — no more. Defined in <code>crates/pap-credential/src/sd_jwt.rs</code>.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-did-key">
+        <dt>did:key</dt>
+        <dd>A W3C Decentralized Identifier method that derives the DID directly from a public key — no registry, no DNS, no issuer. PAP uses <code>did:key</code> with Ed25519 keypairs. Each principal's identity is self-sovereign and portable.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-papillon">
+        <dt>Papillon</dt>
+        <dd>The PAP reference client. A desktop browser for the <code>pap://</code> protocol — analogous to what Mosaic was for HTTP. Handles the 6-phase handshake, renders schema.org results as typed UI blocks, and holds the principal's keypair locally.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-chrysalis">
+        <dt>Chrysalis</dt>
+        <dd>The PAP peer-to-peer agent registry and federation mesh. Organisations run agent workloads on Chrysalis; principals discover and interact with them through normal PAP transport. Entry requires vouch-based peer admission — not open registration.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-ohttp">
+        <dt>OHTTP (Oblivious HTTP)</dt>
+        <dd>RFC 9458. Wraps an HTTP request in HPKE encryption so the relay cannot link the client's IP address to the request content. A configurable setting in Papillon and Chrysalis — when enabled, the relay sees neither query content nor SD-JWT structure.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-decay">
+        <dt>Decay states</dt>
+        <dd>The lifecycle of a PAP mandate: <code>Active → Degraded → ReadOnly → Suspended</code>. Expiry is automatic at TTL without any deprovisioning step. Provides cryptographic revocation without a central revocation authority.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-receipt">
+        <dt>Co-signed receipt</dt>
+        <dd>An immutable record of a completed agent session, signed by both the orchestrator and the agent. Stores property type references only (e.g. <code>schema:Person.schema:email</code>) — never values. Both parties hold a local copy; no platform stores receipts.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-ecash">
+        <dt>ecash / blind signatures</dt>
+        <dd>RFC 9474 RSABSSA-SHA384-PSS blind-signed tokens used in <code>crates/pap-ecash/</code>. The issuer cannot link the signing operation to the redemption — enabling private value exchange between agents without identity-gated permissions.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-scope">
+        <dt>Scope::deny_all()</dt>
+        <dd>The baseline mandate scope in <code>pap-core/src/scope.rs</code>. Every mandate starts with all actions denied; permissions are added explicitly. Child mandates are verified with <code>contains()</code> — a child can never exceed its parent's scope.</dd>
+      </div>
+
+      <div class="glossary-term" id="gloss-session-did">
+        <dt>Ephemeral session DID</dt>
+        <dd>A temporary <code>did:key</code> generated fresh for each PAP session and discarded at close. The session DID is unlinkable to the principal's long-term identity, preventing session correlation across interactions.</dd>
+      </div>
+
+    </dl>
+  </div>
+
 </main>
 
 <!-- ─── Footer ───────────────────────────────────────────────────────────── -->

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -821,6 +821,62 @@
         </div>
       </div>
 
+      <!-- 12 -->
+      <div class="faq-item reveal reveal-delay-1" data-cat="enterprise">
+        <button class="faq-q" aria-expanded="false">
+          <div class="faq-q-left">
+            <span class="faq-num">12</span>
+            <div class="faq-q-text">
+              <div><span class="faq-badge badge-enterprise">Enterprise</span></div>
+              Our CISO won't deploy an agent framework without Okta / Azure AD integration. Does PAP have a SAML bridge?
+            </div>
+          </div>
+          <svg class="faq-chevron" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="6 9 12 15 18 9"></polyline></svg>
+        </button>
+        <div class="faq-body">
+          <p>
+            <strong>Not built in today — and here's why that's the right architecture.</strong>
+            PAP uses <code>did:key</code> Ed25519 keypairs as its sole identity primitive
+            (<code>crates/pap-did/src/principal.rs</code>). There is no SAML assertion parser,
+            no OIDC relying party, and no LDAP connector in the codebase. This is intentional:
+            enterprise IdP and PAP answer different questions.
+          </p>
+          <p>
+            <strong>IdP answers: "Is this human allowed to access this resource?"</strong>
+            It issues tokens representing an authenticated session. PAP answers: "Is this agent
+            authorized to act on this human's behalf, with exactly this scope, for exactly this
+            long?" These are complementary layers. A PAP Gateway bridges them: it validates your
+            OIDC or SAML token against your existing IdP, maps the user's roles to a PAP mandate
+            scope, and issues a cryptographically signed mandate that the PAP orchestrator treats
+            normally. The bridge is ~100 lines of Rust using <code>pap-core</code>,
+            <code>pap-did</code>, and any standard OIDC validation library.
+          </p>
+          <p>
+            The result: your IdP remains the authority for human identity. PAP is the authority
+            for agent delegation. A deprovisioned Okta user's token fails at the gateway —
+            no mandate is issued. A mandate's TTL enforces automatic expiry without requiring
+            active deprovisioning. These are independent, non-competing trust roots: compromising
+            the IdP does not give an attacker active-mandate agent access, and a PAP mandate
+            breach doesn't expose IdP credentials.
+          </p>
+          <p>
+            <strong>For your CISO's specific concerns:</strong> "Can we enforce access policies?"
+            — Yes, via role-to-scope mapping at the gateway. "Can we see who accessed what?"
+            — Yes; co-signed receipts log property type references (e.g. <code>schema:Person.schema:email</code>
+            was permitted), never values, providing a forensically richer and PII-safer audit
+            trail than standard access logs. "Can we revoke access?" — Yes; TTL expiry is
+            automatic. Mandate decay (<code>Active → Degraded → ReadOnly → Suspended</code>)
+            enforces revocation without administrator action.
+          </p>
+          <p>
+            <strong>What's on the roadmap:</strong> An open-source PAP Gateway reference
+            implementation (OIDC→PAP mandate bridge), a SCIM provisioning adapter for role-sync,
+            and an Okta marketplace app. If your enterprise deployment is on a timeline,
+            the SDK surface is available today.
+          </p>
+        </div>
+      </div>
+
     </div><!-- /faq-list -->
 
   </div><!-- /container-md -->

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -835,44 +835,44 @@
         </button>
         <div class="faq-body">
           <p>
-            <strong>Not built in today — and here's why that's the right architecture.</strong>
-            PAP uses <code>did:key</code> Ed25519 keypairs as its sole identity primitive
-            (<code>crates/pap-did/src/principal.rs</code>). There is no SAML assertion parser,
-            no OIDC relying party, and no LDAP connector in the codebase. This is intentional:
-            enterprise IdP and PAP answer different questions.
+            <strong>If your first instinct is IdP integration, you're importing a centralized
+            assumption PAP is designed to make unnecessary.</strong> Okta and Azure AD solve a
+            hub-and-spoke problem: a central authority that decides who gets access to what.
+            PAP inverts this. Agents protect themselves — they advertise what they require,
+            principals present cryptographically scoped mandates, and the protocol enforces
+            access at the edge without any central authority in the loop.
           </p>
           <p>
-            <strong>IdP answers: "Is this human allowed to access this resource?"</strong>
-            It issues tokens representing an authenticated session. PAP answers: "Is this agent
-            authorized to act on this human's behalf, with exactly this scope, for exactly this
-            long?" These are complementary layers. A PAP Gateway bridges them: it validates your
-            OIDC or SAML token against your existing IdP, maps the user's roles to a PAP mandate
-            scope, and issues a cryptographically signed mandate that the PAP orchestrator treats
-            normally. The bridge is ~100 lines of Rust using <code>pap-core</code>,
-            <code>pap-did</code>, and any standard OIDC validation library.
+            <strong>The PAP-native pattern for enterprise agent access control:</strong>
+            Your company runs agents on Chrysalis. Each agent declares its
+            <code>requires_disclosure</code> — the minimum SD-JWT claims it needs to execute
+            (e.g. <code>schema:Organization.schema:memberOf</code> to verify employment, or
+            a <code>schema:Role</code> claim scoped to a department). A principal's orchestrator
+            presents only those claims via selective disclosure
+            (<code>crates/pap-credential/src/sd_jwt.rs</code>); the agent verifies the
+            claim against its policy and either accepts the mandate or rejects it. No IdP
+            is in the path. No central session store. The agent is the access control point.
           </p>
           <p>
-            The result: your IdP remains the authority for human identity. PAP is the authority
-            for agent delegation. A deprovisioned Okta user's token fails at the gateway —
-            no mandate is issued. A mandate's TTL enforces automatic expiry without requiring
-            active deprovisioning. These are independent, non-competing trust roots: compromising
-            the IdP does not give an attacker active-mandate agent access, and a PAP mandate
-            breach doesn't expose IdP credentials.
+            <strong>For value exchange between agents, use ecash receipts rather than
+            identity-gated permissions.</strong> Instead of "does this principal have the
+            Analyst role in Okta?", structure access as "does this principal hold a valid
+            payment proof for this action?" The ecash system (<code>crates/pap-ecash/</code>)
+            issues blind-signed RFC 9474 RSABSSA-SHA384-PSS tokens — the agent validates
+            the token without learning who holds it, and the receipt proves the exchange
+            occurred without linking it to an identity. This is more privacy-preserving
+            than role-based access and eliminates the revocation problem entirely: a spent
+            token is simply gone.
           </p>
           <p>
-            <strong>For your CISO's specific concerns:</strong> "Can we enforce access policies?"
-            — Yes, via role-to-scope mapping at the gateway. "Can we see who accessed what?"
-            — Yes; co-signed receipts log property type references (e.g. <code>schema:Person.schema:email</code>
-            was permitted), never values, providing a forensically richer and PII-safer audit
-            trail than standard access logs. "Can we revoke access?" — Yes; TTL expiry is
-            automatic. Mandate decay (<code>Active → Degraded → ReadOnly → Suspended</code>)
-            enforces revocation without administrator action.
-          </p>
-          <p>
-            <strong>What's on the roadmap:</strong> An open-source PAP Gateway reference
-            implementation (OIDC→PAP mandate bridge), a SCIM provisioning adapter for role-sync,
-            and an Okta marketplace app. If your enterprise deployment is on a timeline,
-            the SDK surface is available today.
+            <strong>What your CISO actually needs</strong> is answered by the protocol, not
+            by an IdP bridge: access policy is encoded in mandate scope
+            (<code>Scope::deny_all()</code> baseline, cryptographically enforced containment);
+            audit trail is the co-signed receipt chain (property references, never values,
+            held by both parties locally); revocation is TTL decay
+            (<code>Active → Degraded → ReadOnly → Suspended</code>) with no deprovisioning
+            step required. The threat model your CISO is used to — "who has a live session
+            token?" — doesn't apply to a system where every mandate expires by design.
           </p>
         </div>
       </div>

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -409,9 +409,11 @@
             (<code>crates/pap-agents/src/executor.rs</code>) — the orchestrator sends only those
             property slots via SD-JWT selective disclosure, no more. The
             <strong>recipient agent</strong> always learns which property slots were disclosed;
-            that is the intent of the handshake. Network-level visibility is not a concern:
-            RFC 9458 OHTTP with real HPKE encrypts the transport, so relay operators and
-            passive observers see nothing.
+            that is the intent of the handshake. Network-level visibility is configurable:
+            OHTTP (RFC 9458, HPKE DHKEM-X25519 + AES-128-GCM) is a setting in Papillon and
+            Chrysalis — when enabled, relay operators and passive observers see nothing.
+            Without it, transport encryption is present but query structure is visible to
+            the relay hop.
           </p>
           <p>
             Receipts sharpen the concern: <code>pap-core/src/receipt.rs</code> stores

--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -438,6 +438,7 @@
       <li><a href="papillon/"><img src="assets/images/papillon-icon.png" alt="" class="nav-link-icon-img" /> Papillon</a></li>
       <li><a href="chrysalis.html"><img src="assets/images/chrysalis-icon.svg" alt="" class="nav-link-icon-img" /> Chrysalis</a></li>
       <li><a href="extension/">Extension</a></li>
+      <li><a href="faq.html">FAQ</a></li>
       <li><a href="get-pap.html" aria-current="page">Work With Us</a></li>
     </ul>
     <div class="nav-cta">


### PR DESCRIPTION
## Summary
- Q02 claimed "Network-level visibility is not a concern" and implied OHTTP was always active
- OHTTP (`relay_url: Option<String>`) is a user setting in Papillon and Chrysalis, not always-on
- Updated to: "Network-level visibility is **configurable**" + clarifies that without OHTTP, query structure is visible to the relay hop

## Test plan
- [ ] Open `docs/faq.html`, expand Q02, confirm updated language reads accurately
- [ ] Confirm GitHub Pages deploys via Actions after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)