### PR TITLE
fix(reliability): log preference write failures; propagate registry registration errors

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4605,6 +4605,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "pap-bluefield-loopback"
+version = "0.8.2"
+dependencies = [
+ "chrono",
+ "pap-bluefield",
+ "pap-core",
+ "pap-proto",
+ "pap-transport",
+ "serde_json",
+ "tokio",
+]
+
+[[package]]
 name = "pap-c"
 version = "0.8.2"
 dependencies = [
@@ -5123,6 +5136,7 @@ dependencies = [
  "sha2",
  "tempfile",
  "toml 0.8.23",
+ "tracing",
  "uuid",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/apps/registry/src/routes/admin.rs
+++ b/apps/registry/src/routes/admin.rs
@@ -241,7 +241,21 @@ async fn register_agent(
     }
     {
         let mut registry = state.registry.lock().unwrap_or_else(|e| e.into_inner());
-        let _ = registry.register_local(ad); // duplicate silently ignored
+        if let Err(e) = registry.register_local(ad) {
+            // DB write succeeded but in-memory registration failed — the two
+            // stores would diverge until restart.  Return 500 so the caller
+            // knows the registration did not fully apply.
+            tracing::error!(
+                "In-memory registration failed for agent {hash} after successful DB write: {e}"
+            );
+            return (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({
+                    "error": format!("agent persisted but in-memory registration failed: {e}")
+                })),
+            )
+                .into_response();
+        }
     }
     (
         StatusCode::CREATED,

--- a/crates/papillon-shared/Cargo.toml
+++ b/crates/papillon-shared/Cargo.toml
@@ -12,6 +12,7 @@ serde_json = { workspace = true }
 zeroize = { workspace = true }
 chrono = { workspace = true }
 uuid = { workspace = true }
+tracing = "0.1"
 
 # Database abstraction - feature gated
 rusqlite = { version = "0.32", features = ["bundled", "serde_json"], optional = true }

--- a/crates/papillon-shared/src/preference_engine.rs
+++ b/crates/papillon-shared/src/preference_engine.rs
@@ -202,7 +202,9 @@ impl<'a> PreferenceEngine<'a> {
             },
         };
 
-        let _ = self.db.upsert_preference(&signal);
+        if let Err(e) = self.db.upsert_preference(&signal) {
+            tracing::warn!("preference upsert failed: {e}");
+        }
     }
 
     /// Record the outcome of a session for `(action_type, schema_type, agent_did_hash)`.
@@ -232,7 +234,9 @@ impl<'a> PreferenceEngine<'a> {
                 updated_at: now,
                 ..prev
             };
-            let _ = self.db.upsert_preference(&signal);
+            if let Err(e) = self.db.upsert_preference(&signal) {
+                tracing::warn!("preference upsert failed: {e}");
+            }
         }
         // If no row exists yet, the outcome will be captured on the next selection.
     }
@@ -279,7 +283,9 @@ impl<'a> PreferenceEngine<'a> {
             updated_at: now,
             ..prev
         };
-        let _ = self.db.upsert_preference(&signal);
+        if let Err(e) = self.db.upsert_preference(&signal) {
+            tracing::warn!("preference upsert failed: {e}");
+        }
     }
 
     /// Record that the principal rejected `scope_refs` for `(action_type, schema_type)`.
@@ -323,7 +329,9 @@ impl<'a> PreferenceEngine<'a> {
             updated_at: now,
             ..prev
         };
-        let _ = self.db.upsert_preference(&signal);
+        if let Err(e) = self.db.upsert_preference(&signal) {
+            tracing::warn!("preference upsert failed: {e}");
+        }
     }
 
     /// True if any prior grant for `(action_type, schema_type)` covers all `required` scopes.
@@ -401,7 +409,9 @@ impl<'a> PreferenceEngine<'a> {
                 updated_at: now,
             },
         };
-        let _ = self.db.upsert_preference(&signal);
+        if let Err(e) = self.db.upsert_preference(&signal) {
+            tracing::warn!("preference upsert failed: {e}");
+        }
     }
 
     /// Return the intersection of approved scope refs across all agents for


### PR DESCRIPTION
## Summary

Closes #334.

Two classes of silent error swallowing have been eliminated:

- **Preference engine** (`crates/papillon-shared/src/preference_engine.rs`): Five sites where `let _ = self.db.upsert_preference(&signal)` silently discarded DB write failures have been replaced with `if let Err(e) = ... { tracing::warn!("preference upsert failed: {e}") }`. The preference store is advisory, so the methods remain non-fallible — but failures are now visible in logs instead of causing invisible degradation.

- **Registry admin handler** (`apps/registry/src/routes/admin.rs`): `let _ = registry.register_local(ad)` after a successful DB write has been replaced with proper error propagation. If in-memory registration fails the handler now returns HTTP 500 with a descriptive JSON body, preventing the DB and in-memory registry from silently diverging until the next restart.

- `tracing = "0.1"` added to `crates/papillon-shared/Cargo.toml` (WASM-compatible; no feature gate needed).

## Test plan

- [ ] `cargo check -p papillon-shared` — clean (verified)
- [ ] `cargo check -p pap-registry --features ssr` — clean (verified)
- [ ] `cargo test -p papillon-shared` passes (existing suite unchanged; the warn! path does not affect any test assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)