### PR TITLE
fix(pap-proto): implement multi-algorithm JWS verification dispatch

### DIFF
--- a/crates/pap-proto/src/didcomm/jws.rs
+++ b/crates/pap-proto/src/didcomm/jws.rs
@@ -50,8 +50,12 @@ pub fn sign_plaintext(
 
 /// Verify a DIDComm v2 signed message and extract the plaintext.
 ///
-/// Validates the first signature using the provided Ed25519 verifying key,
-/// then deserializes the payload into a `DIDCommPlaintext`.
+/// Dispatches to the correct verifier based on the JWS protected header `alg`
+/// field. Unknown or unsupported algorithms are rejected with
+/// `ProtoError::UnsupportedAlgorithm` — they never silently pass.
+///
+/// Per the PAP specification (Section 14.11.3), verifiers MUST reject messages
+/// where the `alg` header value is not `"EdDSA"`.
 pub fn verify_signed(
     signed: &DIDCommSigned,
     verifying_key: &VerifyingKey,
@@ -61,39 +65,41 @@ pub fn verify_signed(
         .first()
         .ok_or_else(|| ProtoError::DIDCommError("no signatures present".into()))?;
 
-    // Verify the protected header declares a supported algorithm
+    // Decode and parse the protected header to determine the algorithm.
     let header_bytes = URL_SAFE_NO_PAD
         .decode(&sig_entry.protected_header)
         .map_err(|e| ProtoError::DIDCommError(format!("invalid header encoding: {e}")))?;
     let header: JwsProtectedHeader = serde_json::from_slice(&header_bytes)
         .map_err(|e| ProtoError::DIDCommError(format!("invalid header JSON: {e}")))?;
-    // TODO: dispatch verification on algorithm when multi-alg lands
-    let _algorithm = match header.alg.as_str() {
+
+    // Dispatch verification on algorithm. Unknown algorithms are rejected
+    // immediately — never silently passed through.
+    let algorithm = match header.alg.as_str() {
         "EdDSA" => SignatureAlgorithm::Ed25519,
-        other => {
-            return Err(ProtoError::DIDCommError(format!(
-                "unsupported JWS algorithm: {other}"
-            )))
-        }
+        other => return Err(ProtoError::UnsupportedAlgorithm(other.to_owned())),
     };
 
-    // Reconstruct signing input and verify
+    // Reconstruct signing input and verify with the dispatched algorithm.
     let signing_input = format!("{}.{}", sig_entry.protected_header, signed.payload);
     let sig_bytes = URL_SAFE_NO_PAD
         .decode(&sig_entry.signature)
         .map_err(|e| ProtoError::DIDCommError(format!("invalid signature encoding: {e}")))?;
-    let signature = ed25519_dalek::Signature::from_bytes(
-        sig_bytes
-            .as_slice()
-            .try_into()
-            .map_err(|_| ProtoError::DIDCommError("invalid signature length".into()))?,
-    );
 
-    verifying_key
-        .verify_strict(signing_input.as_bytes(), &signature)
-        .map_err(|_| ProtoError::VerificationFailed)?;
+    match algorithm {
+        SignatureAlgorithm::Ed25519 => {
+            let signature = ed25519_dalek::Signature::try_from(sig_bytes.as_slice())
+                .map_err(|e| ProtoError::DIDCommError(format!("invalid signature bytes: {e}")))?;
+            verifying_key
+                .verify_strict(signing_input.as_bytes(), &signature)
+                .map_err(|_| ProtoError::VerificationFailed)?;
+        }
+        // SignatureAlgorithm is #[non_exhaustive]; any future variant that
+        // reaches here was accepted by the header dispatch but has no verifier
+        // wired up yet -- reject rather than silently pass.
+        _ => return Err(ProtoError::UnsupportedAlgorithm(header.alg.clone())),
+    }
 
-    // Decode and return the plaintext
+    // Decode and return the plaintext.
     let payload_bytes = URL_SAFE_NO_PAD
         .decode(&signed.payload)
         .map_err(|e| ProtoError::DIDCommError(format!("invalid payload encoding: {e}")))?;

--- a/crates/pap-proto/src/didcomm/tests.rs
+++ b/crates/pap-proto/src/didcomm/tests.rs
@@ -570,3 +570,78 @@ fn dummy_token() -> pap_core::session::CapabilityToken {
         Utc::now() + Duration::hours(1),
     )
 }
+
+// ── JWS algorithm dispatch (issue #330) ─────────────────────────
+
+/// Correct `EdDSA` algorithm: sign + verify round-trip succeeds.
+#[test]
+fn jws_eddsa_alg_verifies_correctly() {
+    let key = SigningKey::generate(&mut OsRng);
+    let vk = key.verifying_key();
+    let env = make_envelope(ProtocolMessage::SessionDidAck);
+
+    // to_signed always uses EdDSA; verify should succeed.
+    let signed = PapToDIDComm::to_signed(&env, &key).unwrap();
+
+    // Confirm the protected header really says "EdDSA".
+    let header_bytes = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .decode(&signed.signatures[0].protected_header)
+        .unwrap();
+    let header: serde_json::Value = serde_json::from_slice(&header_bytes).unwrap();
+    assert_eq!(header["alg"], "EdDSA");
+
+    let result = DIDCommToPap::from_signed(&signed, &vk);
+    assert!(result.is_ok(), "EdDSA verification should succeed: {result:?}");
+    assert_eq!(result.unwrap().session_id, env.session_id);
+}
+
+/// Wrong (mismatched) `alg` value that is syntactically valid but not
+/// `"EdDSA"` must be rejected with `ProtoError::UnsupportedAlgorithm`.
+#[test]
+fn jws_unsupported_algorithm_returns_correct_error() {
+    use crate::error::ProtoError;
+
+    let key = SigningKey::generate(&mut OsRng);
+    let env = make_envelope(ProtocolMessage::DisclosureAccepted);
+    let mut signed = PapToDIDComm::to_signed(&env, &key).unwrap();
+
+    // Swap in an RS256 alg header (valid JSON, wrong algorithm).
+    let bad_header =
+        serde_json::json!({"typ": "application/didcomm-signed+json", "alg": "RS256"});
+    signed.signatures[0].protected_header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_string(&bad_header).unwrap().as_bytes());
+
+    let result = DIDCommToPap::from_signed(&signed, &key.verifying_key());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ProtoError::UnsupportedAlgorithm(alg) => {
+            assert_eq!(alg, "RS256", "error should name the offending algorithm");
+        }
+        other => panic!("expected UnsupportedAlgorithm, got: {other:?}"),
+    }
+}
+
+/// Completely unknown / invented algorithm string must also return
+/// `ProtoError::UnsupportedAlgorithm` — never silently pass.
+#[test]
+fn jws_unknown_algorithm_never_silently_passes() {
+    use crate::error::ProtoError;
+
+    let key = SigningKey::generate(&mut OsRng);
+    let env = make_envelope(ProtocolMessage::SessionClosed);
+    let mut signed = PapToDIDComm::to_signed(&env, &key).unwrap();
+
+    let bad_header =
+        serde_json::json!({"typ": "application/didcomm-signed+json", "alg": "UNKNOWN-42"});
+    signed.signatures[0].protected_header = base64::engine::general_purpose::URL_SAFE_NO_PAD
+        .encode(serde_json::to_string(&bad_header).unwrap().as_bytes());
+
+    let result = DIDCommToPap::from_signed(&signed, &key.verifying_key());
+    assert!(result.is_err());
+    match result.unwrap_err() {
+        ProtoError::UnsupportedAlgorithm(alg) => {
+            assert_eq!(alg, "UNKNOWN-42");
+        }
+        other => panic!("expected UnsupportedAlgorithm, got: {other:?}"),
+    }
+}

--- a/crates/pap-proto/src/didcomm/tests.rs
+++ b/crates/pap-proto/src/didcomm/tests.rs
@@ -591,7 +591,10 @@ fn jws_eddsa_alg_verifies_correctly() {
     assert_eq!(header["alg"], "EdDSA");
 
     let result = DIDCommToPap::from_signed(&signed, &vk);
-    assert!(result.is_ok(), "EdDSA verification should succeed: {result:?}");
+    assert!(
+        result.is_ok(),
+        "EdDSA verification should succeed: {result:?}"
+    );
     assert_eq!(result.unwrap().session_id, env.session_id);
 }
 
@@ -606,8 +609,7 @@ fn jws_unsupported_algorithm_returns_correct_error() {
     let mut signed = PapToDIDComm::to_signed(&env, &key).unwrap();
 
     // Swap in an RS256 alg header (valid JSON, wrong algorithm).
-    let bad_header =
-        serde_json::json!({"typ": "application/didcomm-signed+json", "alg": "RS256"});
+    let bad_header = serde_json::json!({"typ": "application/didcomm-signed+json", "alg": "RS256"});
     signed.signatures[0].protected_header = base64::engine::general_purpose::URL_SAFE_NO_PAD
         .encode(serde_json::to_string(&bad_header).unwrap().as_bytes());
 

--- a/crates/pap-proto/src/error.rs
+++ b/crates/pap-proto/src/error.rs
@@ -17,6 +17,9 @@ pub enum ProtoError {
     #[error("signature verification failed")]
     VerificationFailed,
 
+    #[error("unsupported JWS algorithm: {0}")]
+    UnsupportedAlgorithm(String),
+
     #[error("serialization error: {0}")]
     SerializationError(String),
 


### PR DESCRIPTION
## Summary

- Resolves the `TODO: dispatch verification on algorithm when multi-alg lands` at `crates/pap-proto/src/didcomm/jws.rs:70`
- `alg` field in the JWS protected header now drives verifier selection
- `"EdDSA"` → Ed25519 verifier (the only currently supported algorithm)
- Any other `alg` value returns `Err(ProtoError::UnsupportedAlgorithm(...))` immediately — never silently passes
- Adds `ProtoError::UnsupportedAlgorithm(String)` error variant
- `#[non_exhaustive]` `SignatureAlgorithm` wildcard arm returns `UnsupportedAlgorithm` so future variants are handled safely
- 3 new tests: EdDSA round-trip, RS256 rejected, unknown algorithm errors

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)