### PR TITLE
test(pap-proto): remove redundant jws_bad_algorithm_rejected test

### DIFF
--- a/crates/pap-proto/src/didcomm/tests.rs
+++ b/crates/pap-proto/src/didcomm/tests.rs
@@ -497,21 +497,6 @@ fn plaintext_invalid_body_fails_restoration() {
 }
 
 #[test]
-fn jws_bad_algorithm_rejected() {
-    let key = SigningKey::generate(&mut OsRng);
-    let env = make_envelope(ProtocolMessage::SessionDidAck);
-    let mut signed = PapToDIDComm::to_signed(&env, &key).unwrap();
-
-    // Replace protected header with non-EdDSA algorithm
-    let bad_header = serde_json::json!({"typ": "application/didcomm-signed+json", "alg": "RS256"});
-    signed.signatures[0].protected_header = base64::engine::general_purpose::URL_SAFE_NO_PAD
-        .encode(serde_json::to_string(&bad_header).unwrap().as_bytes());
-
-    let result = DIDCommToPap::from_signed(&signed, &key.verifying_key());
-    assert!(result.is_err());
-}
-
-#[test]
 fn jws_invalid_signature_encoding_fails() {
     let signed = DIDCommSigned {
         payload: base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(b"{}"),


### PR DESCRIPTION
## Summary

Addresses Greptile P2 review comment on #346.

`jws_bad_algorithm_rejected` and `jws_unsupported_algorithm_returns_correct_error` both inject an RS256 protected header and call `from_signed`. The only difference was the new test additionally asserts `ProtoError::UnsupportedAlgorithm("RS256")` — making the old one a strict subset. Removed the weaker test to avoid maintaining two tests for the same scenario.

**Before**: 39 tests  
**After**: 38 tests (same coverage, less duplication)

## Test plan
- [ ] `cargo test -p pap-proto` passes (38/38)

🤖 Generated with [Claude Code](https://claude.com/claude-code)