### PR TITLE
fix(registry): ALLOWED_ORIGINS env override + wildcard CORS for CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
               - 'Cargo.lock'
             e2e:
               - 'e2e/**'
-              - 'apps/papillon/frontend/**'
+              - 'apps/**'
               - 'crates/**'
               - 'Cargo.toml'
               - 'Cargo.lock'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -527,6 +527,7 @@ jobs:
             -e PAP_REGISTRY_PORT=$CHRYSALIS_PORT \
             -e PAP_REGISTRY_HOST=0.0.0.0 \
             -e PAP_REGISTRY_ENDPOINT=http://localhost:$CHRYSALIS_PORT \
+            -e ALLOWED_ORIGINS='*' \
             pap-registry:ci
 
       - name: Wait for Chrysalis to be ready
@@ -639,6 +640,7 @@ jobs:
           docker run -d \
             --name chrysalis-ci \
             -p 8080:8080 \
+            -e ALLOWED_ORIGINS='*' \
             chrysalis-ci:latest
       - name: Wait for Chrysalis to be healthy
         working-directory: e2e

--- a/apps/registry/src/main.rs
+++ b/apps/registry/src/main.rs
@@ -209,7 +209,10 @@ async fn main() -> anyhow::Result<()> {
             env_origins
         } else {
             let default = config.default_cors_origins();
-            info!("CORS: ALLOWED_ORIGINS empty, seeding from config: {}", default);
+            info!(
+                "CORS: ALLOWED_ORIGINS empty, seeding from config: {}",
+                default
+            );
             default
         }
     } else {

--- a/apps/registry/src/main.rs
+++ b/apps/registry/src/main.rs
@@ -199,13 +199,28 @@ async fn main() -> anyhow::Result<()> {
     }
 
     // ── CORS allowlist — loaded from DB, seeded from config on first boot ────
-    let cors_origins_raw = match store.load_setting(SETTING_CORS_ORIGINS).await? {
-        Some(v) if !v.is_empty() => v,
-        _ => {
+    // `ALLOWED_ORIGINS` env var overrides the DB value at startup. Useful in
+    // CI / container environments where the admin UI is not yet configured.
+    // Set to `"*"` for open access (e.g. tests) or a comma-separated list of
+    // exact origins for production.
+    let cors_origins_raw = if let Ok(env_origins) = std::env::var("ALLOWED_ORIGINS") {
+        if !env_origins.is_empty() {
+            info!("CORS: using ALLOWED_ORIGINS env override: {}", env_origins);
+            env_origins
+        } else {
             let default = config.default_cors_origins();
-            store.save_setting(SETTING_CORS_ORIGINS, &default).await?;
-            info!("CORS: seeded allowed origins from config: {}", default);
+            info!("CORS: ALLOWED_ORIGINS empty, seeding from config: {}", default);
             default
+        }
+    } else {
+        match store.load_setting(SETTING_CORS_ORIGINS).await? {
+            Some(v) if !v.is_empty() => v,
+            _ => {
+                let default = config.default_cors_origins();
+                store.save_setting(SETTING_CORS_ORIGINS, &default).await?;
+                info!("CORS: seeded allowed origins from config: {}", default);
+                default
+            }
         }
     };
     let cors_origins: Vec<String> = cors_origins_raw
@@ -248,23 +263,34 @@ async fn main() -> anyhow::Result<()> {
     let leptos_router = routes::leptos_handler::leptos_router(leptos_options.clone(), app_state)
         .with_state(leptos_options);
 
-    // CORS policy — reads the live allowlist from `AppState` on every request
-    // so changes made via the Settings UI take effect without a server restart.
-    //
-    // The default allowlist (localhost only) is seeded from config on first
-    // boot and stored in the `settings` DB table.  Operators can update it
-    // via the admin Settings page.
+    // CORS policy — build the layer from the current allowlist. If the list
+    // contains `"*"` respond with `Access-Control-Allow-Origin: *` via
+    // `Any`; otherwise use a per-request predicate that echoes back the
+    // exact origin for strict allowlist enforcement. The live `Arc<RwLock>`
+    // means changes saved via the admin Settings UI take effect immediately.
     let cors = {
-        let origins_ref = cors_allowed_origins.clone();
-        let allow_origin = AllowOrigin::predicate(move |origin, _req| {
-            let list = origins_ref.read().unwrap_or_else(|e| e.into_inner());
-            list.iter()
-                .any(|allowed| origin.as_bytes() == allowed.as_bytes())
-        });
-        CorsLayer::new()
-            .allow_origin(allow_origin)
-            .allow_methods(Any)
-            .allow_headers(Any)
+        let list = cors_allowed_origins
+            .read()
+            .unwrap_or_else(|e| e.into_inner())
+            .clone();
+        if list.iter().any(|o| o == "*") {
+            info!("CORS: open policy (*)");
+            CorsLayer::new()
+                .allow_origin(Any)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        } else {
+            let origins_ref = cors_allowed_origins.clone();
+            let allow_origin = AllowOrigin::predicate(move |origin, _req| {
+                let list = origins_ref.read().unwrap_or_else(|e| e.into_inner());
+                list.iter()
+                    .any(|allowed| origin.as_bytes() == allowed.as_bytes())
+            });
+            CorsLayer::new()
+                .allow_origin(allow_origin)
+                .allow_methods(Any)
+                .allow_headers(Any)
+        }
     };
 
     // Static assets (icon, favicon, logo).


### PR DESCRIPTION
## Summary

Fixes the E2E Tier 2 CORS test failures that have been broken on `main` since PR #345 merged the DB-backed CORS allowlist.

**Root cause**: PR #345 replaced `allow_origin(Any)` with an `AllowOrigin::predicate` driven by a DB-persisted allowlist. The CI Chrysalis container starts with a fresh DB and no `ALLOWED_ORIGINS` env var — so the list seeds to `"http://localhost:7890"`. The tier-2 tests send requests with `Origin: https://papillon.app` (etc.), which the predicate rejects → `Access-Control-Allow-Origin` header absent → 3 tests fail.

**Why `/federation/identity` passed**: `pap-federation`'s `FederationServer` has its own `CorsLayer::new().allow_origin(Any)` — it was never under the main registry's allowlist predicate.

### Changes

- **`apps/registry/src/main.rs`**:
  - `ALLOWED_ORIGINS` env var at startup overrides the DB-backed value (useful for CI, docs'd in #329)
  - When the resolved list contains `"*"`, use `allow_origin(Any)` (sends `Access-Control-Allow-Origin: *`); otherwise keep the per-request predicate for strict allowlist enforcement

- **`.github/workflows/ci.yml`**:
  - Pass `-e ALLOWED_ORIGINS='*'` to both Chrysalis docker containers in the tier-2 and integration test jobs

## Test plan
- [ ] `cargo check -p pap-registry` passes
- [ ] E2E Tier 2 CORS tests pass (all 4: GET identity, GET browse, OPTIONS identity, OPTIONS browse)
- [ ] Registry unit tests still pass (`cargo test -p pap-registry`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)