### PR TITLE
fix(papillon-ui): declare wasm feature to silence check-cfg warnings

### DIFF
--- a/apps/papillon/frontend/Cargo.toml
+++ b/apps/papillon/frontend/Cargo.toml
@@ -8,6 +8,10 @@ edition = "2021"
 [lib]
 crate-type = ["cdylib"]
 
+[features]
+default = ["wasm"]
+wasm = []
+
 [dependencies]
 papillon-shared = { path = "../../../crates/papillon-shared", default-features = false, features = ["wasm"] }
 pap-did = { path = "../../../crates/pap-did", features = ["wasm"] }


### PR DESCRIPTION
## Summary

- Adds a `[features]` section to `apps/papillon/frontend/Cargo.toml` declaring `wasm = []` with `default = ["wasm"]`
- Silences 10+ `unexpected cfg condition value: 'wasm'` warnings that fired during `cargo tauri dev` since Rust 1.80's `check-cfg` lint became default
- Also resolves the downstream `unused variable: url` warning in `web_service.rs` line 315

## Root Cause

The `papillon-ui` cdylib crate used `#[cfg(feature = "wasm")]` throughout `web_service.rs` but never declared `wasm` as a feature in its own `Cargo.toml`. The `wasm` feature exists in `papillon-shared`'s Cargo.toml as a dependency feature, but `check-cfg` requires each crate to declare features it references in `#[cfg(feature = "...")]` within its own manifest.

## Test plan

- [ ] `cargo tauri dev` produces no `unexpected cfg condition value: 'wasm'` warnings
- [ ] `cargo tauri dev` produces no `unused variable: url` warning in `web_service.rs`
- [ ] CI build passes (WASM cdylib always compiled with `wasm` feature active via `default`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)