### PR TITLE
fix(docs): eliminate navbar FOUC on light mode initial load

### DIFF
--- a/docs/assets/js/theme.js
+++ b/docs/assets/js/theme.js
@@ -1,13 +1,10 @@
-/* PAP Docs — theme toggle
-   Applies saved or system preference immediately (inline in <head> is ideal,
-   but as a deferred script this prevents FOUC on all except very first load). */
+/* PAP Docs — theme toggle (button wiring only)
+   FOUC prevention is handled by an inline <script> in each page's <head>
+   that runs synchronously before the first paint. This file wires the
+   toggle button after DOMContentLoaded. */
 (function () {
   var STORAGE_KEY = 'pap-theme';
   var html = document.documentElement;
-
-  // Apply saved preference before first paint
-  var saved = localStorage.getItem(STORAGE_KEY);
-  if (saved) html.dataset.theme = saved;
 
   document.addEventListener('DOMContentLoaded', function () {
     var btn = document.querySelector('.nav-theme-toggle');

--- a/docs/chrysalis.html
+++ b/docs/chrysalis.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Chrysalis — Publish your agent. Let any canvas find it.</title>
   <meta name="description" content="A self-hostable federated agent registry. Build an agent, sign its advertisement, publish it to the network. Any PAP canvas can discover it — no app store, no gatekeeper." />

--- a/docs/extension/index.html
+++ b/docs/extension/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
+    <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Papillon — PAP Protocol Handler for Browsers</title>
     <meta

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>FAQ — Principal Agent Protocol</title>
   <meta name="description" content="Honest answers to the hardest technical and enterprise questions about PAP — trust model, cryptography, governance, latency, compliance, and developer experience." />

--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Get PAP — Consulting &amp; Implementation by Baur Software</title>
   <meta name="description" content="PAP is a protocol, not a product. Baur Software works with your team to evaluate, plan, and implement trust-first agentic infrastructure — alongside your existing stack." />

--- a/docs/index.html
+++ b/docs/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Baur Software — Zero Trust Internet. Open Source Forever.</title>
   <meta name="description" content="Baur Software builds open-source tools for programmable delegation. PAP protocol, Papillon desktop app, and Chrysalis agent registry." />

--- a/docs/pap/index.html
+++ b/docs/pap/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>PAP — Principal Agent Protocol</title>
   <meta name="description" content="Any program on the Internet should answer to you. PAP is a zero-trust protocol for programmable delegation — cryptographic control over every service interaction." />

--- a/docs/papillon/index.html
+++ b/docs/papillon/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="UTF-8" />
+  <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Papillon — One canvas. Many agents. Your rules.</title>
   <meta name="description" content="A canvas where specialized agents work together on your tasks. Preview their plans, approve their actions, verify their results. No agent ever sees your full context." />


### PR DESCRIPTION
## Problem

On initial page load, users who had toggled to light mode saw the navbar render dark for a moment before switching to light. The `theme.js` script runs at the end of `<body>` — too late. The page paints with dark defaults, then the saved preference is applied, causing a visible flash.

The script even admitted it in its own comment:
> *"Applies saved or system preference immediately (inline in `<head>` is ideal, but as a deferred script this prevents FOUC on all except very first load)."*

## Fix

Split the theme application into two parts:

1. **Inline FOUC guard** — a one-liner added immediately after `<meta charset>` in every page's `<head>`. Runs synchronously before any stylesheet is parsed. Sets `data-theme` on `<html>` before the first paint.
   ```html
   <script>!function(){var t=localStorage.getItem('pap-theme');if(t)document.documentElement.dataset.theme=t}()</script>
   ```

2. **`theme.js`** — trimmed to button-wiring only (DOMContentLoaded listener for the toggle click). No longer responsible for initial theme application.

## Scope

All 7 navigated pages: `index.html`, `faq.html`, `get-pap.html`, `chrysalis.html`, `pap/index.html`, `papillon/index.html`, `extension/index.html`.

## Test plan
- [ ] In a browser, set theme to light (click toggle, confirm light mode)
- [ ] Hard-refresh the page — navbar should be light immediately with no dark flash
- [ ] Repeat across all 7 pages
- [ ] Confirm toggle still works in both directions after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)