### PR TITLE
fix layer card border-radius miter artifact

### DIFF
--- a/docs/assets/css/index.css
+++ b/docs/assets/css/index.css
@@ -126,8 +126,8 @@
   background: var(--surface); border: 1px solid var(--border);
   border-radius: var(--radius-lg); padding: 28px 28px 24px;
 }
-.layer-card-pap { border-top: 2px solid var(--indigo); }
-.layer-card-chr { border-top: 2px solid var(--teal); }
+.layer-card-pap { box-shadow: inset 0 3px 0 var(--indigo); }
+.layer-card-chr { box-shadow: inset 0 3px 0 var(--teal); }
 .layer-label {
   font-size: .7rem; font-weight: 600; letter-spacing: .08em;
   text-transform: uppercase; margin-bottom: 12px;


### PR DESCRIPTION
## Summary

- Replace `border-top: 2px solid` with `box-shadow: inset 0 3px 0` on `.layer-card-pap` and `.layer-card-chr`
- `border-top` creates a miter join where the 2px colored stripe meets the 1px gray side borders at the rounded corners — visually broken
- `inset box-shadow` renders inside the `border-radius` curve, following it cleanly

## Test plan

- [ ] Open landing page, confirm PAP and Chrysalis layer card top accents curve cleanly at corners
- [ ] Check dark mode and light mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)