### PR TITLE
feat(registry): improve Chrysalis dashboard with real data

### DIFF
--- a/apps/registry/src/main.rs
+++ b/apps/registry/src/main.rs
@@ -5,8 +5,9 @@ use std::sync::{Arc, Mutex, RwLock};
 use anyhow::Context as _;
 
 use axum::extract::DefaultBodyLimit;
+use axum::middleware::{self, Next};
 use axum::routing::get;
-use axum::Router;
+use axum::{extract::Request, Router};
 use leptos::config::get_configuration;
 use pap_registry::state::SETTING_CORS_ORIGINS;
 use tower_governor::{
@@ -317,6 +318,7 @@ async fn main() -> anyhow::Result<()> {
     // ── Routers ───────────────────────────────────────────────────────────────
 
     // Federation protocol routes (PAP-compatible).
+    let fed_counters = app_state.endpoint_counters.clone();
     let federation_router = FederationServer::new(
         registry.clone(),
         config.port,
@@ -324,7 +326,26 @@ async fn main() -> anyhow::Result<()> {
         config.public_endpoint.clone(),
         cert_fingerprint,
     )
-    .router();
+    .router()
+    .layer(middleware::from_fn(move |req: Request, next: Next| {
+        let counters = fed_counters.clone();
+        async move {
+            use std::sync::atomic::Ordering;
+            let path = req.uri().path().to_owned();
+            let method = req.method().clone();
+            let resp = next.run(req).await;
+            if path == "/federation/identity" {
+                counters.federation_identity.fetch_add(1, Ordering::Relaxed);
+            } else if path.starts_with("/federation/query") {
+                counters.federation_query.fetch_add(1, Ordering::Relaxed);
+            } else if path == "/federation/announce" && method == axum::http::Method::POST {
+                counters.federation_announce.fetch_add(1, Ordering::Relaxed);
+            } else if path == "/federation/peers" {
+                counters.federation_peers.fetch_add(1, Ordering::Relaxed);
+            }
+            resp
+        }
+    }));
 
     // Admin API routes.
     let admin_router = routes::admin::router().with_state(app_state.clone());

--- a/apps/registry/src/routes/admin.rs
+++ b/apps/registry/src/routes/admin.rs
@@ -664,6 +664,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         router()
             .with_state(state)
@@ -855,6 +856,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -910,6 +912,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -956,6 +959,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1020,6 +1024,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1091,6 +1096,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1136,6 +1142,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1224,6 +1231,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1301,6 +1309,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1445,6 +1454,7 @@ mod tests {
             max_ads_per_principal: 2,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -1604,6 +1614,7 @@ mod tests {
             max_ads_per_principal: 1,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router().with_state(state);
 
@@ -2042,6 +2053,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(crate::state::EndpointCounters::default()),
         };
         let app = router()
             .with_state(state)

--- a/apps/registry/src/state.rs
+++ b/apps/registry/src/state.rs
@@ -1,6 +1,6 @@
 use std::collections::{HashMap, VecDeque};
-use std::sync::{Arc, Mutex, RwLock};
 use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, RwLock};
 
 use pap_federation::registry::FederatedRegistry;
 use serde::{Deserialize, Serialize};

--- a/apps/registry/src/state.rs
+++ b/apps/registry/src/state.rs
@@ -45,6 +45,17 @@ impl SyncEventLog {
             .map(|d| d.iter().cloned().collect())
             .unwrap_or_default()
     }
+
+    /// Return the most-recent event per peer, newest-first by timestamp.
+    pub fn all_latest(&self) -> Vec<(String, SyncEvent)> {
+        let map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut out: Vec<(String, SyncEvent)> = map
+            .iter()
+            .filter_map(|(did, deque)| deque.front().map(|e| (did.clone(), e.clone())))
+            .collect();
+        out.sort_by(|a, b| b.1.ts.cmp(&a.1.ts));
+        out
+    }
 }
 
 // ── AppState ───────────────────────────────────────────────────────────────

--- a/apps/registry/src/state.rs
+++ b/apps/registry/src/state.rs
@@ -1,5 +1,6 @@
 use std::collections::{HashMap, VecDeque};
 use std::sync::{Arc, Mutex, RwLock};
+use std::sync::atomic::{AtomicU64, Ordering};
 
 use pap_federation::registry::FederatedRegistry;
 use serde::{Deserialize, Serialize};
@@ -56,6 +57,40 @@ impl SyncEventLog {
         out.sort_by(|a, b| b.1.ts.cmp(&a.1.ts));
         out
     }
+
+    /// Return all events across all peers, newest-first by timestamp.
+    pub fn all_events_flat(&self) -> Vec<(String, SyncEvent)> {
+        let map = self.inner.lock().unwrap_or_else(|e| e.into_inner());
+        let mut out: Vec<(String, SyncEvent)> = map
+            .iter()
+            .flat_map(|(did, deque)| deque.iter().map(move |e| (did.clone(), e.clone())))
+            .collect();
+        out.sort_by(|a, b| b.1.ts.cmp(&a.1.ts));
+        out
+    }
+}
+
+// ── EndpointCounters ───────────────────────────────────────────────────────
+
+/// Per-endpoint hit counters shared across all request handlers.
+/// Each counter is a lock-free atomic u64 — increment on every inbound hit.
+#[derive(Default)]
+pub struct EndpointCounters {
+    pub federation_identity: AtomicU64,
+    pub federation_query: AtomicU64,
+    pub federation_announce: AtomicU64,
+    pub federation_peers: AtomicU64,
+}
+
+impl EndpointCounters {
+    pub fn snapshot(&self) -> [u64; 4] {
+        [
+            self.federation_identity.load(Ordering::Relaxed),
+            self.federation_query.load(Ordering::Relaxed),
+            self.federation_announce.load(Ordering::Relaxed),
+            self.federation_peers.load(Ordering::Relaxed),
+        ]
+    }
 }
 
 // ── AppState ───────────────────────────────────────────────────────────────
@@ -80,6 +115,8 @@ pub struct AppState {
     /// Each entry is an exact origin string, e.g. `"https://app.example.com"`.
     /// An empty list means allow nothing (safe default until seeded).
     pub cors_allowed_origins: Arc<RwLock<Vec<String>>>,
+    /// Hit counters for federation endpoints, incremented by middleware.
+    pub endpoint_counters: Arc<EndpointCounters>,
 }
 
 impl AppState {
@@ -101,6 +138,7 @@ impl AppState {
             max_ads_per_principal: config.max_ads_per_principal,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins,
+            endpoint_counters: Arc::new(EndpointCounters::default()),
         }
     }
 
@@ -138,6 +176,7 @@ mod tests {
             max_ads_per_principal: 100,
             sync_log: SyncEventLog::default(),
             cors_allowed_origins: Arc::new(RwLock::new(vec![])),
+            endpoint_counters: Arc::new(EndpointCounters::default()),
         }
     }
 

--- a/apps/registry/src/ui/api.rs
+++ b/apps/registry/src/ui/api.rs
@@ -11,7 +11,19 @@ pub struct RegistryStatus {
     pub cert_fingerprint: String,
     pub agent_count: usize,
     pub peer_count: usize,
+    pub peer_active: usize,
+    pub peer_probationary: usize,
     pub version: String,
+}
+
+/// Summary item for the dashboard sync-log feed.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncSummaryItem {
+    pub peer_did: String,
+    pub ts: String,
+    pub outcome: String,
+    pub merged_count: usize,
+    pub error: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -94,9 +106,19 @@ pub async fn get_status() -> Result<RegistryStatus, ServerFnError> {
     if !state.is_authorized(extract_bearer(&headers)) {
         return Err(ServerFnError::new("unauthorized"));
     }
-    let (agent_count, peer_count) = {
+    let (agent_count, peer_count, peer_active, peer_probationary) = {
+        use pap_federation::peer::PeerStatus;
         let registry = state.registry.lock().unwrap_or_else(|e| e.into_inner());
-        (registry.len(), registry.peers().len())
+        let peers = registry.peers();
+        let n_active = peers
+            .iter()
+            .filter(|p| p.status == PeerStatus::Active)
+            .count();
+        let n_probationary = peers
+            .iter()
+            .filter(|p| p.status == PeerStatus::Probationary)
+            .count();
+        (registry.len(), peers.len(), n_active, n_probationary)
     };
     Ok(RegistryStatus {
         did: state.node_did.clone(),
@@ -104,6 +126,8 @@ pub async fn get_status() -> Result<RegistryStatus, ServerFnError> {
         cert_fingerprint: state.cert_fingerprint.clone(),
         agent_count,
         peer_count,
+        peer_active,
+        peer_probationary,
         version: env!("CARGO_PKG_VERSION").to_string(),
     })
 }
@@ -680,4 +704,35 @@ pub async fn install_catalog_agents() -> Result<CatalogInstallResult, ServerFnEr
         errors,
         catalog_path: catalog_path_str,
     })
+}
+
+/// Return the most-recent sync event per peer for the dashboard feed.
+#[server]
+pub async fn get_sync_summary() -> Result<Vec<SyncSummaryItem>, ServerFnError> {
+    use crate::routes::admin::extract_bearer;
+    use crate::state::AppState;
+    use axum::http::HeaderMap;
+
+    let headers: HeaderMap = leptos_axum::extract()
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let state = use_context::<AppState>().ok_or_else(|| ServerFnError::new("no state"))?;
+    if !state.is_authorized(extract_bearer(&headers)) {
+        return Err(ServerFnError::new("unauthorized"));
+    }
+
+    let items = state
+        .sync_log
+        .all_latest()
+        .into_iter()
+        .map(|(peer_did, ev)| SyncSummaryItem {
+            peer_did,
+            ts: ev.ts,
+            outcome: ev.outcome,
+            merged_count: ev.merged_count,
+            error: ev.error,
+        })
+        .collect();
+
+    Ok(items)
 }

--- a/apps/registry/src/ui/api.rs
+++ b/apps/registry/src/ui/api.rs
@@ -26,6 +26,23 @@ pub struct SyncSummaryItem {
     pub error: Option<String>,
 }
 
+/// Snapshot of federation endpoint hit counts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct EndpointCounts {
+    pub federation_identity: u64,
+    pub federation_query: u64,
+    pub federation_announce: u64,
+    pub federation_peers: u64,
+}
+
+/// Sync event count bucketed by hour (last 12 h, newest last).
+/// `counts[i]` is the number of sync events that occurred in hour bucket `i`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncBuckets {
+    /// 12 buckets, index 0 = oldest hour, index 11 = current partial hour.
+    pub counts: Vec<u32>,
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Provider {
     #[serde(rename = "@type")]
@@ -704,6 +721,63 @@ pub async fn install_catalog_agents() -> Result<CatalogInstallResult, ServerFnEr
         errors,
         catalog_path: catalog_path_str,
     })
+}
+
+/// Return federation endpoint hit counts for the dashboard.
+#[server]
+pub async fn get_endpoint_counts() -> Result<EndpointCounts, ServerFnError> {
+    use crate::routes::admin::extract_bearer;
+    use crate::state::AppState;
+    use axum::http::HeaderMap;
+
+    let headers: HeaderMap = leptos_axum::extract()
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let state = use_context::<AppState>().ok_or_else(|| ServerFnError::new("no state"))?;
+    if !state.is_authorized(extract_bearer(&headers)) {
+        return Err(ServerFnError::new("unauthorized"));
+    }
+
+    let [identity, query, announce, peers] = state.endpoint_counters.snapshot();
+    Ok(EndpointCounts {
+        federation_identity: identity,
+        federation_query: query,
+        federation_announce: announce,
+        federation_peers: peers,
+    })
+}
+
+/// Bucket all sync events across all peers into 12 one-hour windows (last 12 h).
+#[server]
+pub async fn get_sync_buckets() -> Result<SyncBuckets, ServerFnError> {
+    use crate::routes::admin::extract_bearer;
+    use crate::state::AppState;
+    use axum::http::HeaderMap;
+
+    let headers: HeaderMap = leptos_axum::extract()
+        .await
+        .map_err(|e| ServerFnError::new(e.to_string()))?;
+    let state = use_context::<AppState>().ok_or_else(|| ServerFnError::new("no state"))?;
+    if !state.is_authorized(extract_bearer(&headers)) {
+        return Err(ServerFnError::new("unauthorized"));
+    }
+
+    let now = chrono::Utc::now();
+    let mut counts = vec![0u32; 12];
+
+    for (_, ev) in state.sync_log.all_events_flat() {
+        if let Ok(ts) = chrono::DateTime::parse_from_rfc3339(&ev.ts) {
+            let age_secs = (now - ts.with_timezone(&chrono::Utc)).num_seconds();
+            if age_secs >= 0 && age_secs < 12 * 3600 {
+                let bucket = (11 - (age_secs / 3600)) as usize;
+                if bucket < 12 {
+                    counts[bucket] += 1;
+                }
+            }
+        }
+    }
+
+    Ok(SyncBuckets { counts })
 }
 
 /// Return the most-recent sync event per peer for the dashboard feed.

--- a/apps/registry/src/ui/pages/dashboard.rs
+++ b/apps/registry/src/ui/pages/dashboard.rs
@@ -1,24 +1,30 @@
 use leptos::prelude::*;
 
-use crate::ui::api::{self, RegistryStatus};
+use crate::ui::api::{self, RegistryStatus, SyncSummaryItem};
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
     let status = Resource::new(|| (), |_| api::get_status());
+    let sync_summary = Resource::new(|| (), |_| api::get_sync_summary());
 
     view! {
         <div class="page">
             <div class="page-header">
                 <h1 class="page-title">"Chrysalis Dashboard"</h1>
-                <p class="page-subtitle">"Registry overview and agent federation network health."</p>
+                <p class="page-subtitle">"Registry overview, inbound pap:// traffic, and federation network health."</p>
             </div>
 
-            <Suspense fallback=|| view! { <div class="loading"><span class="loading-dot">"Loading..."</span></div> }>
+            <Suspense fallback=|| view! { <div class="loading"><span class="loading-dot">"Loading…"</span></div> }>
                 {move || status.get().map(|result| match result {
                     Err(e) => view! {
                         <div class="error-banner">"Failed to load status: " {e.to_string()}</div>
                     }.into_any(),
-                    Ok(s) => view! { <StatusView s=s /> }.into_any(),
+                    Ok(s) => {
+                        let sync = sync_summary.get()
+                            .and_then(|r| r.ok())
+                            .unwrap_or_default();
+                        view! { <DashboardView s=s sync=sync /> }.into_any()
+                    }
                 })}
             </Suspense>
         </div>
@@ -26,71 +32,213 @@ pub fn DashboardPage() -> impl IntoView {
 }
 
 #[component]
-fn StatusView(s: RegistryStatus) -> impl IntoView {
+fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView {
+    let peer_sub = format!(
+        "{} active · {} probationary",
+        s.peer_active,
+        s.peer_probationary
+    );
+    let sync_empty = sync.is_empty();
+
     view! {
-        <div>
-            <div class="stat-grid">
-                <div class="stat-card">
-                    <div class="stat-label">"Registered Agents"</div>
-                    <div class="stat-value teal">{s.agent_count}</div>
+        // ── STAT GRID ────────────────────────────────────────────────────────
+        <div class="stat-grid" role="region" aria-label="Key metrics">
+            <div class="stat-card">
+                <div class="stat-label" id="lbl-agents">"Registered Agents"</div>
+                <div class="stat-value teal" aria-labelledby="lbl-agents">{s.agent_count}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label" id="lbl-peers">"Federation Peers"</div>
+                <div class="stat-value accent" aria-labelledby="lbl-peers">{s.peer_count}</div>
+                <div class="stat-sub">{peer_sub}</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label" id="lbl-sessions">"pap:// Sessions (1h)"</div>
+                <div class="stat-value gold" aria-labelledby="lbl-sessions">"—"</div>
+                <div class="stat-sub">"Rolling 60-min window"</div>
+            </div>
+            <div class="stat-card">
+                <div class="stat-label" id="lbl-ver">"Version"</div>
+                <div class="stat-value mono" aria-labelledby="lbl-ver">{s.version.clone()}</div>
+            </div>
+        </div>
+
+        // ── TRAFFIC ──────────────────────────────────────────────────────────
+        <h2 class="section-header">"Inbound pap:// Traffic"</h2>
+        <div class="two-col">
+            <div class="card">
+                <div class="card-header">
+                    <span class="card-title">"Sessions over time"</span>
+                    <span class="card-badge">"last 12h · 1h buckets"</span>
                 </div>
-                <div class="stat-card">
-                    <div class="stat-label">"Federation Peers"</div>
-                    <div class="stat-value accent">{s.peer_count}</div>
-                </div>
-                <div class="stat-card">
-                    <div class="stat-label">"Version"</div>
-                    <div class="stat-value" style="font-size: 20px; font-family: var(--font-mono)">{s.version.clone()}</div>
+                <div class="card-body">
+                    <BarChart
+                        label="pap:// sessions / hour"
+                        color="purple"
+                        heights=vec![28,42,36,55,62,50,70,66,80,74,90,100]
+                    />
+                    <BarChart
+                        label="agent queries from clients / hour"
+                        color="teal"
+                        heights=vec![40,55,44,68,75,60,82,78,92,85,96,100]
+                    />
                 </div>
             </div>
 
-            <div class="identity-panel">
-                <div class="stat-label">"Node Identity"</div>
-                <div class="identity-did">{s.did.clone()}</div>
-                <div class="identity-fp">
-                    <span style="color: var(--text-3)">"TLS fingerprint: "</span>
-                    {s.cert_fingerprint.clone()}
+            <div class="card">
+                <div class="card-header">
+                    <span class="card-title">"PAP Handshake Funnel"</span>
+                    <span class="card-badge">"last 1h"</span>
                 </div>
-                <div style="margin-top: var(--sp-sm); font-size: 13px; color: var(--text-2)">
-                    "Public endpoint: "
-                    <span style="font-family: var(--font-mono); color: var(--blue)">{s.endpoint.clone()}</span>
+                <div class="card-body" role="region" aria-label="PAP 6-phase handshake completion rates">
+                    <PhaseRow num="①" name="Token Presentation"   pct=100 />
+                    <PhaseRow num="②" name="DID Exchange"         pct=99  />
+                    <PhaseRow num="③" name="Selective Disclosure" pct=97  />
+                    <PhaseRow num="④" name="Agent Execution"      pct=95  />
+                    <PhaseRow num="⑤" name="Co-Signed Receipt"    pct=90  />
+                    <PhaseRow num="⑥" name="Session Close"        pct=82  />
+                    <div class="funnel-footer">
+                        <span>"Funnel data available once session counters are instrumented"</span>
+                    </div>
+                </div>
+            </div>
+        </div>
+
+        // ── FEDERATION ───────────────────────────────────────────────────────
+        <h2 class="section-header">"Federation"</h2>
+        <div class="two-col">
+            <div class="card">
+                <div class="card-header">
+                    <span class="card-title">"Peer Sync Activity"</span>
+                    <span class="card-badge teal">"ring buffer · last 100/peer"</span>
+                </div>
+                <div class="card-body">
+                    <BarChart
+                        label="syncs / hour"
+                        color="gold"
+                        heights=vec![40,20,80,30,60,50,70,45,90,55,65,75]
+                    />
+                    <SyncFeed items=sync empty=sync_empty />
                 </div>
             </div>
 
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">"Federation Endpoints"</span>
+                    <span class="card-badge gold">"inbound protocol surface"</span>
                 </div>
                 <div class="card-body">
-                    <p style="font-size: 13px; color: var(--text-2); margin-bottom: var(--sp-md)">
-                        "Chrysalis exposes the PAP federation protocol. Other registries can connect at:"
+                    <p style="font-size:12px; color:var(--text-3); margin-bottom:var(--sp-md)">
+                        "Other registries and Papillon clients connect at:"
                     </p>
-                    <EndpointRow method="GET"  path="/federation/identity" desc="Node identity and cert fingerprint" />
-                    <EndpointRow method="GET"  path="/federation/query?action=..." desc="Query agents by Schema.org action" />
-                    <EndpointRow method="POST" path="/federation/announce" desc="Receive agent advertisement" />
-                    <EndpointRow method="GET"  path="/federation/peers" desc="Known peer list" />
+                    <EndpointRow method="GET"  path="/federation/identity"       desc="Node identity & cert" />
+                    <EndpointRow method="GET"  path="/federation/query?action=…" desc="Query by Schema.org action" />
+                    <EndpointRow method="POST" path="/federation/announce"        desc="Receive agent advertisement" />
+                    <EndpointRow method="GET"  path="/federation/peers"           desc="Known peer list" />
                 </div>
+            </div>
+        </div>
+
+        // ── NODE IDENTITY ────────────────────────────────────────────────────
+        <h2 class="section-header">"Node Identity"</h2>
+        <div class="identity-panel" role="region" aria-label="Node identity information">
+            <div class="stat-label">"Node DID"</div>
+            <div class="identity-did">{s.did.clone()}</div>
+            <div class="identity-row">
+                <span>"TLS:"</span>
+                <span class="val">{s.cert_fingerprint.clone()}</span>
+            </div>
+            <div class="identity-row">
+                <span>"Public endpoint:"</span>
+                <span class="val">{s.endpoint.clone()}</span>
             </div>
         </div>
     }
 }
 
 #[component]
-fn EndpointRow(method: &'static str, path: &'static str, desc: &'static str) -> impl IntoView {
-    let method_color = if method == "GET" {
-        "var(--teal)"
-    } else {
-        "var(--gold)"
-    };
+fn SyncFeed(items: Vec<SyncSummaryItem>, empty: bool) -> impl IntoView {
     view! {
-        <div style="display:flex; gap: var(--sp-md); align-items: baseline; padding: var(--sp-xs) 0; border-bottom: 1px solid var(--border-subtle)">
-            <span style=format!("font-family: var(--font-mono); font-size: 11px; font-weight: 600; color: {}; width: 36px; flex-shrink: 0", method_color)>
-                {method}
-            </span>
-            <span style="font-family: var(--font-mono); font-size: 12px; color: var(--purple); flex: 1">
-                {path}
-            </span>
-            <span style="font-size: 12px; color: var(--text-3)">{desc}</span>
+        <div role="log" aria-label="Recent sync events" aria-live="polite">
+            {items.into_iter().take(6).map(|item| {
+                let pill_class = if item.outcome == "success" { "log-pill ok" } else { "log-pill err" };
+                let extra = format!("+{}", item.merged_count);
+                let ts = item.ts.get(11..19).unwrap_or(&item.ts).to_string();
+                let did_len = item.peer_did.len();
+                let did_short = if did_len > 20 {
+                    format!("{}…{}", &item.peer_did[..16], &item.peer_did[did_len - 4..])
+                } else {
+                    item.peer_did.clone()
+                };
+                let msg = if let Some(err) = item.error {
+                    format!("{did_short} — {err}")
+                } else {
+                    did_short
+                };
+                view! {
+                    <div class="log-row">
+                        <span class="log-ts">{ts}</span>
+                        <span class=pill_class>{item.outcome}</span>
+                        <span class="log-msg">{msg}</span>
+                        <span class="log-extra">{extra}</span>
+                    </div>
+                }
+            }).collect_view()}
+            {empty.then(|| view! {
+                <p style="font-size:11px; color:var(--text-3); padding-top: var(--sp-sm)">
+                    "No sync events yet. Trigger a peer sync to populate this feed."
+                </p>
+            })}
+        </div>
+    }
+}
+
+#[component]
+fn BarChart(label: &'static str, color: &'static str, heights: Vec<u8>) -> impl IntoView {
+    view! {
+        <div class="mini-chart">
+            <div class="mini-chart-label">{label}</div>
+            <div class="bar-row" aria-hidden="true">
+                {heights.into_iter().map(|h| {
+                    view! { <div class=format!("bar {color}") style=format!("height:{}%", h)></div> }
+                }).collect_view()}
+            </div>
+            <div class="chart-x" aria-hidden="true">
+                <span>"12h ago"</span><span>"9h"</span><span>"6h"</span><span>"3h"</span><span>"now"</span>
+            </div>
+        </div>
+    }
+}
+
+#[component]
+fn PhaseRow(num: &'static str, name: &'static str, pct: u8) -> impl IntoView {
+    view! {
+        <div class="phase-row">
+            <span class="phase-num" aria-hidden="true">{num}</span>
+            <span class="phase-name">{name}</span>
+            <div
+                class="phase-bar-track"
+                role="progressbar"
+                aria-valuenow=pct
+                aria-valuemin=0
+                aria-valuemax=100
+                aria-label=format!("{pct}%")
+            >
+                <div class="phase-bar-fill" style=format!("width:{}%", pct)></div>
+            </div>
+            <span class="phase-pct">{format!("{}%", pct)}</span>
+        </div>
+    }
+}
+
+#[component]
+fn EndpointRow(method: &'static str, path: &'static str, desc: &'static str) -> impl IntoView {
+    let method_class = if method == "GET" { "method get" } else { "method post" };
+    view! {
+        <div class="endpoint-row">
+            <span class=method_class>{method}</span>
+            <span class="epath">{path}</span>
+            <span class="edesc">{desc}</span>
         </div>
     }
 }

--- a/apps/registry/src/ui/pages/dashboard.rs
+++ b/apps/registry/src/ui/pages/dashboard.rs
@@ -1,11 +1,15 @@
 use leptos::prelude::*;
 
-use crate::ui::api::{self, RegistryStatus, SyncSummaryItem};
+use crate::ui::api::{
+    self, EndpointCounts, RegistryStatus, SyncBuckets, SyncSummaryItem,
+};
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
     let status = Resource::new(|| (), |_| api::get_status());
     let sync_summary = Resource::new(|| (), |_| api::get_sync_summary());
+    let endpoint_counts = Resource::new(|| (), |_| api::get_endpoint_counts());
+    let sync_buckets = Resource::new(|| (), |_| api::get_sync_buckets());
 
     view! {
         <div class="page">
@@ -20,10 +24,10 @@ pub fn DashboardPage() -> impl IntoView {
                         <div class="error-banner">"Failed to load status: " {e.to_string()}</div>
                     }.into_any(),
                     Ok(s) => {
-                        let sync = sync_summary.get()
-                            .and_then(|r| r.ok())
-                            .unwrap_or_default();
-                        view! { <DashboardView s=s sync=sync /> }.into_any()
+                        let sync  = sync_summary.get().and_then(|r| r.ok()).unwrap_or_default();
+                        let counts = endpoint_counts.get().and_then(|r| r.ok());
+                        let buckets = sync_buckets.get().and_then(|r| r.ok());
+                        view! { <DashboardView s=s sync=sync counts=counts buckets=buckets /> }.into_any()
                     }
                 })}
             </Suspense>
@@ -32,13 +36,35 @@ pub fn DashboardPage() -> impl IntoView {
 }
 
 #[component]
-fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView {
+fn DashboardView(
+    s: RegistryStatus,
+    sync: Vec<SyncSummaryItem>,
+    counts: Option<EndpointCounts>,
+    buckets: Option<SyncBuckets>,
+) -> impl IntoView {
     let peer_sub = format!(
         "{} active · {} probationary",
-        s.peer_active,
-        s.peer_probationary
+        s.peer_active, s.peer_probationary
     );
     let sync_empty = sync.is_empty();
+
+    // Build bar heights (0–100) from real sync bucket counts.
+    let sync_bar_heights: Vec<u8> = match &buckets {
+        None => vec![0u8; 12],
+        Some(b) => {
+            let max = b.counts.iter().copied().max().unwrap_or(0);
+            b.counts
+                .iter()
+                .map(|&c| {
+                    if max == 0 {
+                        0u8
+                    } else {
+                        ((c as f32 / max as f32) * 100.0).round() as u8
+                    }
+                })
+                .collect()
+        }
+    };
 
     view! {
         // ── STAT GRID ────────────────────────────────────────────────────────
@@ -53,54 +79,15 @@ fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView
                 <div class="stat-sub">{peer_sub}</div>
             </div>
             <div class="stat-card">
-                <div class="stat-label" id="lbl-sessions">"pap:// Sessions (1h)"</div>
-                <div class="stat-value gold" aria-labelledby="lbl-sessions">"—"</div>
-                <div class="stat-sub">"Rolling 60-min window"</div>
+                <div class="stat-label" id="lbl-queries">"Fed. Queries (all-time)"</div>
+                {
+                    let q = counts.as_ref().map(|c| c.federation_query).unwrap_or(0);
+                    view! { <div class="stat-value gold" aria-labelledby="lbl-queries">{format_count(q)}</div> }
+                }
             </div>
             <div class="stat-card">
                 <div class="stat-label" id="lbl-ver">"Version"</div>
                 <div class="stat-value mono" aria-labelledby="lbl-ver">{s.version.clone()}</div>
-            </div>
-        </div>
-
-        // ── TRAFFIC ──────────────────────────────────────────────────────────
-        <h2 class="section-header">"Inbound pap:// Traffic"</h2>
-        <div class="two-col">
-            <div class="card">
-                <div class="card-header">
-                    <span class="card-title">"Sessions over time"</span>
-                    <span class="card-badge">"last 12h · 1h buckets"</span>
-                </div>
-                <div class="card-body">
-                    <BarChart
-                        label="pap:// sessions / hour"
-                        color="purple"
-                        heights=vec![28,42,36,55,62,50,70,66,80,74,90,100]
-                    />
-                    <BarChart
-                        label="agent queries from clients / hour"
-                        color="teal"
-                        heights=vec![40,55,44,68,75,60,82,78,92,85,96,100]
-                    />
-                </div>
-            </div>
-
-            <div class="card">
-                <div class="card-header">
-                    <span class="card-title">"PAP Handshake Funnel"</span>
-                    <span class="card-badge">"last 1h"</span>
-                </div>
-                <div class="card-body" role="region" aria-label="PAP 6-phase handshake completion rates">
-                    <PhaseRow num="①" name="Token Presentation"   pct=100 />
-                    <PhaseRow num="②" name="DID Exchange"         pct=99  />
-                    <PhaseRow num="③" name="Selective Disclosure" pct=97  />
-                    <PhaseRow num="④" name="Agent Execution"      pct=95  />
-                    <PhaseRow num="⑤" name="Co-Signed Receipt"    pct=90  />
-                    <PhaseRow num="⑥" name="Session Close"        pct=82  />
-                    <div class="funnel-footer">
-                        <span>"Funnel data available once session counters are instrumented"</span>
-                    </div>
-                </div>
             </div>
         </div>
 
@@ -114,9 +101,9 @@ fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView
                 </div>
                 <div class="card-body">
                     <BarChart
-                        label="syncs / hour"
+                        label="syncs / hour (last 12 h)"
                         color="gold"
-                        heights=vec![40,20,80,30,60,50,70,45,90,55,65,75]
+                        heights=sync_bar_heights
                     />
                     <SyncFeed items=sync empty=sync_empty />
                 </div>
@@ -125,16 +112,26 @@ fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView
             <div class="card">
                 <div class="card-header">
                     <span class="card-title">"Federation Endpoints"</span>
-                    <span class="card-badge gold">"inbound protocol surface"</span>
+                    <span class="card-badge gold">"hit counts · all-time"</span>
                 </div>
                 <div class="card-body">
                     <p style="font-size:12px; color:var(--text-3); margin-bottom:var(--sp-md)">
                         "Other registries and Papillon clients connect at:"
                     </p>
-                    <EndpointRow method="GET"  path="/federation/identity"       desc="Node identity & cert" />
-                    <EndpointRow method="GET"  path="/federation/query?action=…" desc="Query by Schema.org action" />
-                    <EndpointRow method="POST" path="/federation/announce"        desc="Receive agent advertisement" />
-                    <EndpointRow method="GET"  path="/federation/peers"           desc="Known peer list" />
+                    {
+                        let c = counts.clone().unwrap_or(EndpointCounts {
+                            federation_identity: 0,
+                            federation_query: 0,
+                            federation_announce: 0,
+                            federation_peers: 0,
+                        });
+                        view! {
+                            <EndpointRow method="GET"  path="/federation/identity"       desc="Node identity & cert"        hits=c.federation_identity />
+                            <EndpointRow method="GET"  path="/federation/query?action=…" desc="Query by Schema.org action"  hits=c.federation_query />
+                            <EndpointRow method="POST" path="/federation/announce"        desc="Receive agent advertisement" hits=c.federation_announce />
+                            <EndpointRow method="GET"  path="/federation/peers"           desc="Known peer list"            hits=c.federation_peers />
+                        }
+                    }
                 </div>
             </div>
         </div>
@@ -153,6 +150,16 @@ fn DashboardView(s: RegistryStatus, sync: Vec<SyncSummaryItem>) -> impl IntoView
                 <span class="val">{s.endpoint.clone()}</span>
             </div>
         </div>
+    }
+}
+
+fn format_count(n: u64) -> String {
+    if n >= 1_000_000 {
+        format!("{:.1}M", n as f64 / 1_000_000.0)
+    } else if n >= 1_000 {
+        format!("{:.1}k", n as f64 / 1_000.0)
+    } else {
+        n.to_string()
     }
 }
 
@@ -200,6 +207,7 @@ fn BarChart(label: &'static str, color: &'static str, heights: Vec<u8>) -> impl 
             <div class="mini-chart-label">{label}</div>
             <div class="bar-row" aria-hidden="true">
                 {heights.into_iter().map(|h| {
+                    let h = h.max(2); // keep bars visible even at zero
                     view! { <div class=format!("bar {color}") style=format!("height:{}%", h)></div> }
                 }).collect_view()}
             </div>
@@ -211,34 +219,14 @@ fn BarChart(label: &'static str, color: &'static str, heights: Vec<u8>) -> impl 
 }
 
 #[component]
-fn PhaseRow(num: &'static str, name: &'static str, pct: u8) -> impl IntoView {
-    view! {
-        <div class="phase-row">
-            <span class="phase-num" aria-hidden="true">{num}</span>
-            <span class="phase-name">{name}</span>
-            <div
-                class="phase-bar-track"
-                role="progressbar"
-                aria-valuenow=pct
-                aria-valuemin=0
-                aria-valuemax=100
-                aria-label=format!("{pct}%")
-            >
-                <div class="phase-bar-fill" style=format!("width:{}%", pct)></div>
-            </div>
-            <span class="phase-pct">{format!("{}%", pct)}</span>
-        </div>
-    }
-}
-
-#[component]
-fn EndpointRow(method: &'static str, path: &'static str, desc: &'static str) -> impl IntoView {
+fn EndpointRow(method: &'static str, path: &'static str, desc: &'static str, hits: u64) -> impl IntoView {
     let method_class = if method == "GET" { "method get" } else { "method post" };
     view! {
         <div class="endpoint-row">
             <span class=method_class>{method}</span>
             <span class="epath">{path}</span>
             <span class="edesc">{desc}</span>
+            <span class="hit-count">{format_count(hits)}</span>
         </div>
     }
 }

--- a/apps/registry/src/ui/pages/dashboard.rs
+++ b/apps/registry/src/ui/pages/dashboard.rs
@@ -1,8 +1,6 @@
 use leptos::prelude::*;
 
-use crate::ui::api::{
-    self, EndpointCounts, RegistryStatus, SyncBuckets, SyncSummaryItem,
-};
+use crate::ui::api::{self, EndpointCounts, RegistryStatus, SyncBuckets, SyncSummaryItem};
 
 #[component]
 pub fn DashboardPage() -> impl IntoView {
@@ -219,8 +217,17 @@ fn BarChart(label: &'static str, color: &'static str, heights: Vec<u8>) -> impl 
 }
 
 #[component]
-fn EndpointRow(method: &'static str, path: &'static str, desc: &'static str, hits: u64) -> impl IntoView {
-    let method_class = if method == "GET" { "method get" } else { "method post" };
+fn EndpointRow(
+    method: &'static str,
+    path: &'static str,
+    desc: &'static str,
+    hits: u64,
+) -> impl IntoView {
+    let method_class = if method == "GET" {
+        "method get"
+    } else {
+        "method post"
+    };
     view! {
         <div class="endpoint-row">
             <span class=method_class>{method}</span>

--- a/apps/registry/styles/main.css
+++ b/apps/registry/styles/main.css
@@ -1104,6 +1104,14 @@ body {
 
 .edesc { color: var(--text-3); font-size: 11px; }
 
+.hit-count {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--text-2);
+  margin-left: var(--sp-sm);
+  flex-shrink: 0;
+}
+
 /* --- Identity row --- */
 .identity-row {
   display: flex;

--- a/apps/registry/styles/main.css
+++ b/apps/registry/styles/main.css
@@ -878,12 +878,255 @@ body {
   color: var(--coral);
 }
 
+/* --- Dashboard layout helpers --- */
+.section-header {
+  font-size: 11px;
+  font-weight: 500;
+  color: var(--text-3);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-family: var(--font-mono);
+  margin: var(--sp-xl) 0 var(--sp-md);
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+}
+
+.section-header::after {
+  content: '';
+  flex: 1;
+  height: 1px;
+  background: var(--border-subtle);
+}
+
+.two-col {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--sp-md);
+  margin-bottom: var(--sp-md);
+}
+
+/* --- Card badge (small label in card header) --- */
+.card-badge {
+  font-size: 10px;
+  font-weight: 600;
+  font-family: var(--font-mono);
+  background: var(--purple-muted);
+  color: var(--purple);
+  padding: 2px 8px;
+  border-radius: 999px;
+}
+
+.card-badge.teal { background: rgba(46,196,160,0.12); color: var(--teal); }
+.card-badge.gold  { background: rgba(240,160,48,0.12);  color: var(--gold); }
+
+/* --- stat-sub (secondary line under stat value) --- */
+.stat-sub {
+  font-size: 12px;
+  color: var(--text-3);
+  margin-top: 4px;
+}
+
+.stat-value.mono {
+  font-size: 20px;
+  font-family: var(--font-mono);
+}
+
+/* --- Mini bar charts --- */
+.mini-chart {
+  background: var(--bg-2);
+  border-radius: var(--r-md);
+  padding: var(--sp-sm) var(--sp-md) var(--sp-xs);
+  margin-bottom: var(--sp-sm);
+}
+
+.mini-chart:last-child { margin-bottom: 0; }
+
+.mini-chart-label {
+  font-size: 10px;
+  color: var(--text-3);
+  margin-bottom: var(--sp-xs);
+  font-family: var(--font-mono);
+}
+
+.bar-row {
+  display: flex;
+  align-items: flex-end;
+  gap: 3px;
+  height: 44px;
+}
+
+.bar {
+  flex: 1;
+  border-radius: 2px 2px 0 0;
+  min-height: 2px;
+}
+
+.bar.purple { background: var(--purple); }
+.bar.teal   { background: var(--teal); }
+.bar.gold   { background: var(--gold); }
+
+.chart-x {
+  display: flex;
+  justify-content: space-between;
+  font-size: 9px;
+  color: var(--text-3);
+  margin-top: 4px;
+  font-family: var(--font-mono);
+}
+
+/* --- Handshake phase funnel --- */
+.phase-row {
+  display: flex;
+  align-items: center;
+  gap: var(--sp-sm);
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.phase-row:last-child { border-bottom: none; }
+
+.phase-num {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
+  width: 18px;
+  flex-shrink: 0;
+}
+
+.phase-name { color: var(--text-2); flex: 1; }
+
+.phase-bar-track {
+  width: 70px;
+  height: 4px;
+  background: var(--bg-3);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.phase-bar-fill {
+  height: 100%;
+  border-radius: 2px;
+  background: var(--purple);
+}
+
+.phase-count {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--text-1);
+  min-width: 38px;
+  text-align: right;
+}
+
+.phase-pct {
+  font-size: 10px;
+  color: var(--text-3);
+  min-width: 30px;
+  text-align: right;
+}
+
+.funnel-footer {
+  margin-top: var(--sp-sm);
+  padding-top: var(--sp-sm);
+  border-top: 1px solid var(--border-subtle);
+  display: flex;
+  gap: var(--sp-lg);
+  font-size: 11px;
+  color: var(--text-3);
+}
+
+/* --- Log feed (sync events) --- */
+.log-row {
+  display: flex;
+  gap: var(--sp-sm);
+  align-items: baseline;
+  padding: 6px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.log-row:last-child { border-bottom: none; }
+
+.log-ts {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  color: var(--text-3);
+  flex-shrink: 0;
+  min-width: 58px;
+}
+
+.log-pill {
+  font-size: 9px;
+  font-weight: 700;
+  padding: 1px 6px;
+  border-radius: 999px;
+  flex-shrink: 0;
+  text-transform: uppercase;
+  font-family: var(--font-mono);
+}
+
+.log-pill.ok  { background: rgba(46,196,160,0.15); color: var(--teal); }
+.log-pill.err { background: rgba(232,112,106,0.15); color: var(--coral); }
+
+.log-msg  { color: var(--text-2); flex: 1; }
+.log-extra { font-family: var(--font-mono); font-size: 11px; color: var(--teal); flex-shrink: 0; }
+
+/* --- Endpoint list rows --- */
+.endpoint-row {
+  display: flex;
+  gap: var(--sp-sm);
+  align-items: baseline;
+  padding: 7px 0;
+  border-bottom: 1px solid var(--border-subtle);
+  font-size: 12px;
+}
+
+.endpoint-row:last-child { border-bottom: none; }
+
+.method {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  font-weight: 700;
+  width: 32px;
+  flex-shrink: 0;
+}
+
+.method.get  { color: var(--teal); }
+.method.post { color: var(--gold); }
+
+.epath {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--purple);
+  flex: 1;
+}
+
+.edesc { color: var(--text-3); font-size: 11px; }
+
+/* --- Identity row --- */
+.identity-row {
+  display: flex;
+  gap: var(--sp-sm);
+  align-items: center;
+  font-size: 12px;
+  color: var(--text-2);
+  margin-top: var(--sp-sm);
+  flex-wrap: wrap;
+}
+
+.identity-row .val {
+  font-family: var(--font-mono);
+  color: var(--blue);
+}
+
 /* --- Responsive --- */
 @media (max-width: 640px) {
   .sidebar { width: 56px; }
   .sidebar-logo-text, .sidebar-logo-sub, .nav-link-label, .nav-section-label { display: none; }
   .page { padding: var(--sp-md); }
   .stat-grid { grid-template-columns: 1fr 1fr; }
+  .two-col { grid-template-columns: 1fr; }
   .designer-container { grid-template-columns: 1fr; }
   .preview-pane { position: static; }
 }


### PR DESCRIPTION
## Summary

- Rebuilds Chrysalis dashboard layout to match the approved mockup design: 4-stat grid, section-header dividers, two-column cards, mini bar charts, sync event log feed
- Wires **real data** throughout — no hardcoded numbers:
  - Peer active/probationary breakdown from `PeerStatus` enum
  - Federation endpoint hit counts via `AtomicU64` middleware on every `/federation/*` request
  - Sync activity bar chart bucketed from live `SyncEventLog` ring buffer (12 one-hour windows)
  - Sync event feed shows real per-peer events newest-first
- Adds `EndpointCounters`, `all_events_flat()`, `get_endpoint_counts()`, `get_sync_buckets()`, `get_sync_summary()` to the data layer
- All new CSS classes (`section-header`, `two-col`, `card-badge`, `mini-chart`, `bar-row`, `phase-row`, `log-row`, `endpoint-row`, `hit-count`, etc.) added to `main.css`
- Removed fake PAP handshake funnel and sessions-over-time chart — those paths aren't instrumented yet

## Test plan

- [ ] `cargo test -p pap-registry --features ssr --lib` — 207 passed, 0 failed
- [ ] `cargo check -p pap-registry` (WASM hydrate target) — clean
- [ ] `cargo check -p pap-registry --features ssr` — clean
- [ ] Dashboard loads and shows live agent count, peer breakdown, fed query counter, sync bar chart, sync feed, endpoint hit counts
- [ ] Endpoint counters increment when `/federation/identity`, `/federation/query`, `/federation/announce`, `/federation/peers` are hit

🤖 Generated with [Claude Code](https://claude.ai/claude-code)