### PR TITLE
fix(ci): remove invalid working-directory from security-audit workflow

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -25,11 +25,9 @@ jobs:
         run: cargo install cargo-audit --locked
 
       - name: Run cargo audit
-        working-directory: pap
         run: cargo audit
 
       - name: Deny on any warning
-        working-directory: pap
         # --deny warnings catches vulnerabilities, unsoundness, AND unmaintained.
         # Every ignored advisory is explicitly documented in .cargo/audit.toml
         # with justification. Any new undocumented advisory will fail this step,


### PR DESCRIPTION
## Summary
- Removed `working-directory: pap` from both audit steps in the Security Audit workflow
- The repository root contains `Cargo.toml` — no `pap` subdirectory exists
- This was causing the job to fail with path error: `/home/runner/work/pap/pap/pap` not found

## Root cause
GitHub Actions workspace is already at `/home/runner/work/pap/pap`, so the extra `working-directory: pap` directive created an invalid path.

## Test plan
- [x] Security Audit workflow should now execute successfully
- [x] `cargo audit` runs from correct directory (repo root)

🤖 Generated with [Claude Code](https://claude.com/claude-code)