### PR TITLE
fix: sync Cargo.toml workspace version to 0.8.3

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,7 +40,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.8.2"
+version = "0.8.3"
 edition = "2021"
 license = "MIT OR Apache-2.0"
 repository = "https://github.com/Baur-Software/pap"


### PR DESCRIPTION
## Summary
- Update workspace version in `Cargo.toml` from 0.8.2 to 0.8.3 to match `VERSION` file

## Context
The Python SDK release workflow failed because:
1. `VERSION` file was bumped to 0.8.3
2. But `Cargo.toml` workspace version remained at 0.8.2
3. Maturin builds Python wheels using the Cargo.toml version, resulting in `pap_protocol-0.8.2-*.whl` files
4. PyPI rejected the upload since 0.8.2 already exists

This fix ensures both version sources are in sync so the next release workflow produces 0.8.3 wheels.

## Test plan
- [x] Version updated in Cargo.toml
- [ ] Merge to main and verify release workflow builds 0.8.3 wheels
- [ ] Confirm PyPI accepts the new version

🤖 Generated with [Claude Code](https://claude.com/claude-code)