### PR TITLE
fix(docs): update logo URL to current static asset

### DIFF
--- a/docs/chrysalis.html
+++ b/docs/chrysalis.html
@@ -27,7 +27,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="index.html" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">

--- a/docs/extension/index.html
+++ b/docs/extension/index.html
@@ -35,7 +35,7 @@
     <nav aria-label="Main navigation">
       <div class="nav-inner">
         <a href="../" class="nav-logo" aria-label="Baur Software">
-          <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+          <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
           <span class="nav-wordmark">Baur Software</span>
         </a>
         <ul class="nav-links" role="list">

--- a/docs/faq.html
+++ b/docs/faq.html
@@ -29,7 +29,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="index.html" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">

--- a/docs/get-pap.html
+++ b/docs/get-pap.html
@@ -29,7 +29,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="index.html" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">

--- a/docs/index.html
+++ b/docs/index.html
@@ -28,7 +28,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="index.html" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">

--- a/docs/pap/index.html
+++ b/docs/pap/index.html
@@ -29,7 +29,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="../" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">

--- a/docs/papillon/index.html
+++ b/docs/papillon/index.html
@@ -29,7 +29,7 @@
 <nav aria-label="Main navigation">
   <div class="nav-inner">
     <a href="../" class="nav-logo" aria-label="Baur Software">
-      <img src="https://www.baursoftware.com/wp-content/uploads/2025/11/cropped-Artboard-1.png" alt="Baur Software logo" />
+      <img src="https://www.baursoftware.com/static/images/logo.png" alt="Baur Software logo" />
       <span class="nav-wordmark">Baur Software</span>
     </a>
     <ul class="nav-links" role="list">


### PR DESCRIPTION
## Summary
- Replaces the 404'd `cropped-Artboard-1.png` WordPress media URL in all docs nav headers with the current static logo path (`https://www.baursoftware.com/static/images/logo.png`).
- Affects 7 files: `index.html`, `faq.html`, `get-pap.html`, `chrysalis.html`, `pap/index.html`, `papillon/index.html`, and `extension/index.html`.

## Test plan
- [ ] Open each affected docs page and verify the logo loads in the nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)