### PR TITLE
Add intent browser ghost UI and schema-driven search rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@ node_modules/
 /target
 apps/papillon/frontend/target
 apps/papillon/frontend/dist
+bindings/java/.gradle/
 registry.db
 apps/papillon/papillon.db
 .DS_STORE

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4724,7 +4724,7 @@ dependencies = [
 
 [[package]]
 name = "pap-agents"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "candle-core",
  "candle-transformers",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "pap-bench"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "criterion",
@@ -4772,7 +4772,7 @@ dependencies = [
 
 [[package]]
 name = "pap-bluefield"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -4791,7 +4791,7 @@ dependencies = [
 
 [[package]]
 name = "pap-bluefield-loopback"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-bluefield",
@@ -4804,7 +4804,7 @@ dependencies = [
 
 [[package]]
 name = "pap-c"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "cbindgen",
@@ -4822,7 +4822,7 @@ dependencies = [
 
 [[package]]
 name = "pap-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4842,7 +4842,7 @@ dependencies = [
 
 [[package]]
 name = "pap-credential"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -4861,7 +4861,7 @@ dependencies = [
 
 [[package]]
 name = "pap-credential-lifecycle-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -4874,7 +4874,7 @@ dependencies = [
 
 [[package]]
 name = "pap-credential-store"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "argon2",
@@ -4897,7 +4897,7 @@ dependencies = [
 
 [[package]]
 name = "pap-delegation-chain-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-core",
@@ -4907,7 +4907,7 @@ dependencies = [
 
 [[package]]
 name = "pap-did"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -4920,7 +4920,7 @@ dependencies = [
 
 [[package]]
 name = "pap-ecash"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "blind-rsa-signatures",
@@ -4932,7 +4932,7 @@ dependencies = [
 
 [[package]]
 name = "pap-federated-discovery-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -4948,7 +4948,7 @@ dependencies = [
 
 [[package]]
 name = "pap-federation"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "axum-server",
@@ -4985,7 +4985,7 @@ dependencies = [
 
 [[package]]
 name = "pap-intent-routing"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-agents",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "pap-marketplace"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "pap-networked-search-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "chrono",
@@ -5032,7 +5032,7 @@ dependencies = [
 
 [[package]]
 name = "pap-payment-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-core",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "pap-proto"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "base64 0.22.1",
@@ -5066,7 +5066,7 @@ dependencies = [
 
 [[package]]
 name = "pap-protocol-envelope-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "pap-python"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5097,7 +5097,7 @@ dependencies = [
 
 [[package]]
 name = "pap-registry"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "anyhow",
  "axum",
@@ -5146,7 +5146,7 @@ dependencies = [
 
 [[package]]
 name = "pap-sandbox"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "async-trait",
@@ -5173,7 +5173,7 @@ dependencies = [
 
 [[package]]
 name = "pap-search-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-core",
@@ -5185,7 +5185,7 @@ dependencies = [
 
 [[package]]
 name = "pap-selective-disclosure-decay-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ed25519-dalek",
  "pap-core",
@@ -5197,7 +5197,7 @@ dependencies = [
 
 [[package]]
 name = "pap-tee"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5212,7 +5212,7 @@ dependencies = [
 
 [[package]]
 name = "pap-test-utils"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "ed25519-dalek",
  "pap-did",
@@ -5221,7 +5221,7 @@ dependencies = [
 
 [[package]]
 name = "pap-transport"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "axum",
@@ -5250,7 +5250,7 @@ dependencies = [
 
 [[package]]
 name = "pap-travel-booking-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "pap-core",
@@ -5262,7 +5262,7 @@ dependencies = [
 
 [[package]]
 name = "pap-wasm"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5284,7 +5284,7 @@ dependencies = [
 
 [[package]]
 name = "pap-webauthn"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",
@@ -5301,7 +5301,7 @@ dependencies = [
 
 [[package]]
 name = "pap-webauthn-ceremony-example"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -5313,7 +5313,7 @@ dependencies = [
 
 [[package]]
 name = "papillon"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "axum",
  "axum-server",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "papillon-shared"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",
@@ -8209,7 +8209,7 @@ dependencies = [
 
 [[package]]
 name = "tee-attestation"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64 0.22.1",
  "chrono",

--- a/apps/papillon/frontend/Cargo.lock
+++ b/apps/papillon/frontend/Cargo.lock
@@ -1249,7 +1249,7 @@ checksum = "8c04f5d74368e4d0dfe06c45c8627c81bd7c317d52762d118fb9b3076f6420fd"
 
 [[package]]
 name = "pap-core"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1267,7 +1267,7 @@ dependencies = [
 
 [[package]]
 name = "pap-credential"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1285,7 +1285,7 @@ dependencies = [
 
 [[package]]
 name = "pap-did"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "bs58",
  "ed25519-dalek",
@@ -1298,7 +1298,7 @@ dependencies = [
 
 [[package]]
 name = "pap-federation"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1317,7 +1317,7 @@ dependencies = [
 
 [[package]]
 name = "pap-marketplace"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "base64",
  "chrono",
@@ -1334,7 +1334,7 @@ dependencies = [
 
 [[package]]
 name = "pap-proto"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "aes-gcm",
  "base64",
@@ -1356,7 +1356,7 @@ dependencies = [
 
 [[package]]
 name = "papillon-shared"
-version = "0.8.2"
+version = "0.8.3"
 dependencies = [
  "chrono",
  "ed25519-dalek",

--- a/apps/papillon/frontend/src/components/block_renderer/mod.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/mod.rs
@@ -61,7 +61,8 @@ pub fn create_default_registry() -> Arc<RendererRegistry> {
     // Reservations
     registry.register(Arc::new(templates::FlightTemplate));
     registry.register(Arc::new(templates::HotelTemplate));
-    // Q&A — SearchResultsPage/SearchAction handled by generic composite renderer
+    // Search / Q&A
+    registry.register(Arc::new(templates::SearchResultsTemplate));
     registry.register(Arc::new(templates::AnswerTemplate));
     // Entertainment
     registry.register(Arc::new(templates::MovieTemplate));

--- a/apps/papillon/frontend/src/components/block_renderer/templates.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/templates.rs
@@ -1,4 +1,6 @@
 use super::renderer::BlockRenderer;
+use super::BlockContext;
+use crate::state::canvas::CanvasState;
 use leptos::prelude::*;
 use serde_json::Value;
 
@@ -63,11 +65,303 @@ impl BlockRenderer for HotelTemplate {
     }
 }
 
-// SearchTemplate removed — SearchResultsPage and SearchAction are handled by
-// the generic composite renderer via flatten_to_entries(). The generic renderer
-// classifies each schema.org property by kind (URL, text, number, etc.) and
-// renders them without type-specific hardcoding. Custom rendering for specific
-// agents or types should use DeclarativeRenderer (dynamic templates) instead.
+/// SearchResultsPage template — turns Schema.org search JSON-LD into a browsable
+/// result list. Agents send data only; Papillon chooses this UI from `@type`.
+pub struct SearchResultsTemplate;
+
+#[derive(Clone, Debug)]
+struct SearchResultAction {
+    label: String,
+    target: String,
+}
+
+#[derive(Clone, Debug)]
+struct SearchResultItem {
+    name: String,
+    url: String,
+    description: String,
+    source: String,
+    actions: Vec<SearchResultAction>,
+}
+
+impl BlockRenderer for SearchResultsTemplate {
+    fn render(&self, content: &Value) -> AnyView {
+        let results = extract_search_results(content);
+        let result_count = results.len();
+        let canvas_state = use_context::<CanvasState>();
+        let source_block_id = use_context::<BlockContext>().map(|c| c.id.get_value());
+        let result_views = results
+            .into_iter()
+            .map(|item| {
+                let has_url = !item.url.is_empty();
+                let pap_url = to_pap_url(&item.url);
+                let pap_for_click = pap_url.clone();
+                let source_for_click = source_block_id.clone();
+                let canvas_for_click = canvas_state;
+                let title = if item.name.is_empty() {
+                    item.url.clone()
+                } else {
+                    item.name
+                };
+
+                let title_view = if has_url {
+                    view! {
+                        <a
+                            class="typed-search-title"
+                            href=pap_url
+                            on:click=move |e: leptos::ev::MouseEvent| {
+                                e.prevent_default();
+                                if let Some(cs) = canvas_for_click {
+                                    cs.submit_agent_link(pap_for_click.clone(), source_for_click.clone());
+                                }
+                            }
+                        >
+                            {title}
+                        </a>
+                    }
+                    .into_any()
+                } else {
+                    view! { <div class="typed-search-title">{title}</div> }.into_any()
+                };
+
+                let source_view = if item.source.is_empty() {
+                    view! { <></> }.into_any()
+                } else {
+                    view! { <div class="typed-search-url">{item.source}</div> }.into_any()
+                };
+
+                let description_view = if item.description.is_empty() {
+                    view! { <></> }.into_any()
+                } else {
+                    view! { <p class="typed-search-snippet">{item.description}</p> }.into_any()
+                };
+
+                let action_views = item
+                    .actions
+                    .into_iter()
+                    .map(|action| {
+                        let target_title = action.target;
+                        let target_for_click = to_pap_url(&target_title);
+                        let source_for_action = source_block_id.clone();
+                        let canvas_for_action = canvas_state;
+
+                        view! {
+                            <button
+                                class="typed-search-action"
+                                title=target_title
+                                on:click=move |e: leptos::ev::MouseEvent| {
+                                    e.stop_propagation();
+                                    if let Some(cs) = canvas_for_action {
+                                        cs.submit_agent_link(target_for_click.clone(), source_for_action.clone());
+                                    }
+                                }
+                            >
+                                {action.label}
+                            </button>
+                        }
+                    })
+                    .collect::<Vec<_>>();
+
+                let actions_view = if action_views.is_empty() {
+                    view! { <></> }.into_any()
+                } else {
+                    view! {
+                        <div class="typed-search-actions">
+                            {action_views}
+                        </div>
+                    }
+                    .into_any()
+                };
+
+                view! {
+                    <article class="typed-search-item">
+                        <div class="typed-search-main">
+                            {title_view}
+                            {source_view}
+                            {description_view}
+                        </div>
+                        {actions_view}
+                    </article>
+                }
+            })
+            .collect::<Vec<_>>();
+
+        let result_body = if result_count == 0 {
+            view! { <div class="typed-search-empty">"No structured results returned."</div> }
+                .into_any()
+        } else {
+            view! { <>{result_views}</> }.into_any()
+        };
+
+        view! {
+            <div class="typed-search-results">
+                <div class="typed-search-header">
+                    <span class="typed-search-kicker">"Schema.org SearchResultsPage"</span>
+                    <span class="typed-search-count">
+                        {if result_count == 1 {
+                            "1 result".to_string()
+                        } else {
+                            format!("{result_count} results")
+                        }}
+                    </span>
+                </div>
+                {result_body}
+            </div>
+        }
+        .into_any()
+    }
+
+    fn schema_types(&self) -> Vec<&'static str> {
+        vec!["SearchResultsPage", "SearchResult"]
+    }
+}
+
+fn extract_search_results(content: &Value) -> Vec<SearchResultItem> {
+    let mut raw_items: Vec<Value> = Vec::new();
+
+    if has_type(content, "SearchResult") {
+        raw_items.push(content.clone());
+    }
+
+    if let Some(items) = content
+        .get("mainEntity")
+        .and_then(|v| v.get("itemListElement"))
+        .and_then(|v| v.as_array())
+    {
+        raw_items.extend(items.iter().cloned());
+    }
+
+    if let Some(items) = content.get("itemListElement").and_then(|v| v.as_array()) {
+        raw_items.extend(items.iter().cloned());
+    }
+
+    if raw_items.is_empty() {
+        if let Some(items) = content.get("result").and_then(|v| v.as_array()) {
+            raw_items.extend(items.iter().cloned());
+        } else if let Some(items) = content
+            .get("result")
+            .and_then(|v| v.get("itemListElement"))
+            .and_then(|v| v.as_array())
+        {
+            raw_items.extend(items.iter().cloned());
+        }
+    }
+
+    raw_items
+        .iter()
+        .filter_map(search_item_from_value)
+        .take(20)
+        .collect()
+}
+
+fn search_item_from_value(value: &Value) -> Option<SearchResultItem> {
+    let item = value.get("item").unwrap_or(value);
+    let payload = if has_type(item, "ListItem") {
+        item.get("item").unwrap_or(item)
+    } else {
+        item
+    };
+
+    let name = textish(payload, "name")
+        .or_else(|| textish(payload, "headline"))
+        .or_else(|| textish(value, "name"))
+        .unwrap_or_else(|| "Untitled result".to_string());
+    let url = textish(payload, "url")
+        .or_else(|| textish(payload, "sameAs"))
+        .or_else(|| textish(value, "url"))
+        .unwrap_or_default();
+    let description = textish(payload, "description")
+        .or_else(|| textish(payload, "text"))
+        .or_else(|| textish(value, "description"))
+        .unwrap_or_default();
+    let source = if url.is_empty() {
+        textish(payload, "provider")
+            .or_else(|| textish(payload, "publisher"))
+            .or_else(|| textish(payload, "source"))
+            .unwrap_or_default()
+    } else {
+        url.clone()
+    };
+    let actions = extract_actions(payload);
+
+    if name.is_empty() && url.is_empty() && description.is_empty() {
+        None
+    } else {
+        Some(SearchResultItem {
+            name,
+            url,
+            description,
+            source,
+            actions,
+        })
+    }
+}
+
+fn extract_actions(value: &Value) -> Vec<SearchResultAction> {
+    let Some(actions) = value.get("potentialAction") else {
+        return vec![];
+    };
+
+    match actions {
+        Value::Array(items) => items.iter().filter_map(action_from_value).collect(),
+        other => action_from_value(other).into_iter().collect(),
+    }
+}
+
+fn action_from_value(value: &Value) -> Option<SearchResultAction> {
+    let label = textish(value, "name")
+        .or_else(|| textish(value, "@type").map(|t| t.trim_start_matches("schema:").to_string()))
+        .unwrap_or_else(|| "Open".to_string());
+    let target = textish(value, "target")
+        .or_else(|| value.get("target").and_then(|v| textish(v, "urlTemplate")))
+        .or_else(|| value.get("target").and_then(|v| textish(v, "url")))
+        .or_else(|| textish(value, "url"))
+        .unwrap_or_default();
+
+    if target.is_empty() {
+        None
+    } else {
+        Some(SearchResultAction { label, target })
+    }
+}
+
+fn has_type(value: &Value, expected: &str) -> bool {
+    match value.get("@type") {
+        Some(Value::String(t)) => t == expected || t.trim_start_matches("schema:") == expected,
+        Some(Value::Array(types)) => types.iter().any(|t| {
+            t.as_str()
+                .map(|s| s == expected || s.trim_start_matches("schema:") == expected)
+                .unwrap_or(false)
+        }),
+        _ => false,
+    }
+}
+
+fn textish(value: &Value, key: &str) -> Option<String> {
+    let value = value.get(key)?;
+    match value {
+        Value::String(s) if !s.trim().is_empty() => Some(s.trim().to_string()),
+        Value::Number(n) => Some(n.to_string()),
+        Value::Bool(b) => Some(b.to_string()),
+        Value::Object(_) => textish(value, "name").or_else(|| textish(value, "url")),
+        Value::Array(items) => items.iter().find_map(|item| match item {
+            Value::String(s) if !s.trim().is_empty() => Some(s.trim().to_string()),
+            Value::Object(_) => textish(item, "name").or_else(|| textish(item, "url")),
+            _ => None,
+        }),
+        _ => None,
+    }
+}
+
+fn to_pap_url(raw: &str) -> String {
+    if let Some(rest) = raw.strip_prefix("https://") {
+        format!("pap://{rest}")
+    } else if let Some(rest) = raw.strip_prefix("http://") {
+        format!("pap://{rest}")
+    } else {
+        raw.to_string()
+    }
+}
 
 /// Answer template — on-device AI response rendered as a paragraph.
 pub struct AnswerTemplate;
@@ -455,7 +749,12 @@ impl BlockRenderer for OrganizationTemplate {
     }
 
     fn schema_types(&self) -> Vec<&'static str> {
-        vec!["Organization", "LocalBusiness", "FoodEstablishment", "LodgingBusiness"]
+        vec![
+            "Organization",
+            "LocalBusiness",
+            "FoodEstablishment",
+            "LodgingBusiness",
+        ]
     }
 }
 
@@ -903,11 +1202,7 @@ impl BlockRenderer for WebPageTemplate {
         let date = if date_raw == "-" {
             String::new()
         } else {
-            date_raw
-                .split('T')
-                .next()
-                .unwrap_or(&date_raw)
-                .to_string()
+            date_raw.split('T').next().unwrap_or(&date_raw).to_string()
         };
 
         // Rewrite the URL to a pap:// link so it routes through submit_agent_link().

--- a/apps/papillon/frontend/src/components/block_renderer/templates.rs
+++ b/apps/papillon/frontend/src/components/block_renderer/templates.rs
@@ -93,9 +93,7 @@ impl BlockRenderer for SearchResultsTemplate {
         let result_views = results
             .into_iter()
             .map(|item| {
-                let has_url = !item.url.is_empty();
                 let pap_url = to_pap_url(&item.url);
-                let pap_for_click = pap_url.clone();
                 let source_for_click = source_block_id.clone();
                 let canvas_for_click = canvas_state;
                 let title = if item.name.is_empty() {
@@ -104,7 +102,8 @@ impl BlockRenderer for SearchResultsTemplate {
                     item.name
                 };
 
-                let title_view = if has_url {
+                let title_view = if let Some(pap_url) = pap_url {
+                    let pap_for_click = pap_url.clone();
                     view! {
                         <a
                             class="typed-search-title"
@@ -139,13 +138,13 @@ impl BlockRenderer for SearchResultsTemplate {
                 let action_views = item
                     .actions
                     .into_iter()
-                    .map(|action| {
+                    .filter_map(|action| {
                         let target_title = action.target;
-                        let target_for_click = to_pap_url(&target_title);
+                        let target_for_click = to_pap_url(&target_title)?;
                         let source_for_action = source_block_id.clone();
                         let canvas_for_action = canvas_state;
 
-                        view! {
+                        Some(view! {
                             <button
                                 class="typed-search-action"
                                 title=target_title
@@ -158,7 +157,7 @@ impl BlockRenderer for SearchResultsTemplate {
                             >
                                 {action.label}
                             </button>
-                        }
+                        })
                     })
                     .collect::<Vec<_>>();
 
@@ -212,14 +211,14 @@ impl BlockRenderer for SearchResultsTemplate {
     }
 
     fn schema_types(&self) -> Vec<&'static str> {
-        vec!["SearchResultsPage", "SearchResult"]
+        vec!["SearchResultsPage"]
     }
 }
 
 fn extract_search_results(content: &Value) -> Vec<SearchResultItem> {
     let mut raw_items: Vec<Value> = Vec::new();
 
-    if has_type(content, "SearchResult") {
+    if has_type(content, "SearchResult") && !has_result_collection(content) {
         raw_items.push(content.clone());
     }
 
@@ -252,6 +251,24 @@ fn extract_search_results(content: &Value) -> Vec<SearchResultItem> {
         .filter_map(search_item_from_value)
         .take(20)
         .collect()
+}
+
+fn has_result_collection(content: &Value) -> bool {
+    content
+        .get("mainEntity")
+        .and_then(|v| v.get("itemListElement"))
+        .and_then(|v| v.as_array())
+        .is_some()
+        || content
+            .get("itemListElement")
+            .and_then(|v| v.as_array())
+            .is_some()
+        || content.get("result").and_then(|v| v.as_array()).is_some()
+        || content
+            .get("result")
+            .and_then(|v| v.get("itemListElement"))
+            .and_then(|v| v.as_array())
+            .is_some()
 }
 
 fn search_item_from_value(value: &Value) -> Option<SearchResultItem> {
@@ -318,7 +335,7 @@ fn action_from_value(value: &Value) -> Option<SearchResultAction> {
         .or_else(|| textish(value, "url"))
         .unwrap_or_default();
 
-    if target.is_empty() {
+    if target.is_empty() || to_pap_url(&target).is_none() {
         None
     } else {
         Some(SearchResultAction { label, target })
@@ -353,13 +370,188 @@ fn textish(value: &Value, key: &str) -> Option<String> {
     }
 }
 
-fn to_pap_url(raw: &str) -> String {
-    if let Some(rest) = raw.strip_prefix("https://") {
-        format!("pap://{rest}")
-    } else if let Some(rest) = raw.strip_prefix("http://") {
-        format!("pap://{rest}")
+fn to_pap_url(raw: &str) -> Option<String> {
+    let trimmed = raw.trim();
+    if trimmed.is_empty()
+        || trimmed.contains('{')
+        || trimmed.contains('}')
+        || trimmed.chars().any(char::is_whitespace)
+    {
+        return None;
+    }
+
+    if let Some(rest) = trimmed.strip_prefix("https://") {
+        if rest.is_empty() {
+            None
+        } else {
+            Some(format!("pap://{rest}"))
+        }
+    } else if let Some(rest) = trimmed.strip_prefix("http://") {
+        if rest.is_empty() {
+            None
+        } else {
+            Some(format!("pap://{rest}"))
+        }
+    } else if trimmed.starts_with("pap://") && trimmed.len() > "pap://".len() {
+        Some(trimmed.to_string())
     } else {
-        raw.to_string()
+        None
+    }
+}
+
+#[cfg(test)]
+mod search_results_tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn extracts_search_results_from_item_list_shapes() {
+        let content = json!({
+            "@type": "SearchResultsPage",
+            "mainEntity": {
+                "@type": "ItemList",
+                "itemListElement": [
+                    {
+                        "@type": "ListItem",
+                        "item": {
+                            "@type": "SearchResult",
+                            "name": "Papillon overview",
+                            "url": "https://example.com/papillon",
+                            "description": "A schema-driven browser result.",
+                            "potentialAction": {
+                                "@type": "ReadAction",
+                                "target": "https://example.com/papillon/open"
+                            }
+                        }
+                    },
+                    {
+                        "@type": "SearchResult",
+                        "headline": "Agent registry",
+                        "sameAs": "https://registry.example/agents"
+                    }
+                ]
+            }
+        });
+
+        let results = extract_search_results(&content);
+
+        assert_eq!(results.len(), 2);
+        assert_eq!(results[0].name, "Papillon overview");
+        assert_eq!(results[0].url, "https://example.com/papillon");
+        assert_eq!(results[0].description, "A schema-driven browser result.");
+        assert_eq!(results[0].actions.len(), 1);
+        assert_eq!(results[1].name, "Agent registry");
+        assert_eq!(results[1].url, "https://registry.example/agents");
+    }
+
+    #[test]
+    fn does_not_duplicate_top_level_search_result_with_collection() {
+        let content = json!({
+            "@type": "SearchResult",
+            "name": "Wrapper result",
+            "itemListElement": [
+                {
+                    "@type": "SearchResult",
+                    "name": "Only child",
+                    "url": "https://example.com/child"
+                }
+            ]
+        });
+
+        let results = extract_search_results(&content);
+
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].name, "Only child");
+    }
+
+    #[test]
+    fn search_item_from_value_reads_list_item_payload() {
+        let value = json!({
+            "@type": "ListItem",
+            "name": "Position label",
+            "item": {
+                "@type": "SearchResult",
+                "name": "Payload title",
+                "url": "https://example.com/payload",
+                "description": "Payload description"
+            }
+        });
+
+        let item = search_item_from_value(&value).expect("item should parse");
+
+        assert_eq!(item.name, "Payload title");
+        assert_eq!(item.url, "https://example.com/payload");
+        assert_eq!(item.description, "Payload description");
+    }
+
+    #[test]
+    fn has_type_matches_schema_prefix_and_array_values() {
+        assert!(has_type(
+            &json!({"@type": "schema:SearchResultsPage"}),
+            "SearchResultsPage"
+        ));
+        assert!(has_type(
+            &json!({"@type": ["schema:Thing", "SearchResult"]}),
+            "SearchResult"
+        ));
+        assert!(!has_type(&json!({"@type": "Article"}), "SearchResult"));
+    }
+
+    #[test]
+    fn textish_reads_scalar_object_and_array_values() {
+        assert_eq!(
+            textish(&json!({"provider": {"name": "DuckDuckGo"}}), "provider").as_deref(),
+            Some("DuckDuckGo")
+        );
+        assert_eq!(textish(&json!({"rank": 3}), "rank").as_deref(), Some("3"));
+        assert_eq!(
+            textish(
+                &json!({"sameAs": ["", {"url": "https://example.com/alt"}]}),
+                "sameAs"
+            )
+            .as_deref(),
+            Some("https://example.com/alt")
+        );
+    }
+
+    #[test]
+    fn to_pap_url_rewrites_only_resolved_http_urls() {
+        assert_eq!(
+            to_pap_url("https://example.com/path?q=1").as_deref(),
+            Some("pap://example.com/path?q=1")
+        );
+        assert_eq!(
+            to_pap_url("http://example.com").as_deref(),
+            Some("pap://example.com")
+        );
+        assert_eq!(
+            to_pap_url("pap://registry.example/agent").as_deref(),
+            Some("pap://registry.example/agent")
+        );
+        assert_eq!(to_pap_url("{+url}"), None);
+        assert_eq!(to_pap_url("https://example.com/{id}"), None);
+        assert_eq!(to_pap_url("javascript:alert(1)"), None);
+    }
+
+    #[test]
+    fn action_from_value_skips_uri_templates() {
+        let action = json!({
+            "@type": "SearchAction",
+            "target": {
+                "@type": "EntryPoint",
+                "urlTemplate": "https://example.com/search?q={query}"
+            }
+        });
+
+        assert!(action_from_value(&action).is_none());
+    }
+
+    #[test]
+    fn search_results_template_only_registers_page_type() {
+        assert_eq!(
+            SearchResultsTemplate.schema_types(),
+            vec!["SearchResultsPage"]
+        );
     }
 }
 

--- a/apps/papillon/frontend/src/components/canvas_ghost_run_panel.rs
+++ b/apps/papillon/frontend/src/components/canvas_ghost_run_panel.rs
@@ -222,10 +222,13 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
             .map(|candidate| candidate.name.clone())
             .collect::<Vec<_>>(),
     );
+    let has_disclosures = !group.disclosure_props.is_empty();
     let filled_values: RwSignal<HashMap<String, String>> = RwSignal::new(HashMap::new());
+    let attributes_loading = RwSignal::new(has_disclosures && crate::bridge::tauri_available());
 
-    if !group.disclosure_props.is_empty() && crate::bridge::tauri_available() {
+    if has_disclosures && crate::bridge::tauri_available() {
         let values = filled_values;
+        let loading = attributes_loading;
         spawn_local(async move {
             if let Ok(attrs) = crate::bridge::invoke::<_, HashMap<String, String>>(
                 "get_principal_attributes",
@@ -235,6 +238,7 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
             {
                 values.set(attrs);
             }
+            loading.set(false);
         });
     }
 
@@ -243,7 +247,6 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
     let candidate_count = group.candidates.len();
     let item_count = group.items.len();
     let ttl_hours = group.ttl_hours;
-    let has_disclosures = !group.disclosure_props.is_empty();
     let group_for_render = group.clone();
     let group_for_deny = group.clone();
     let canvas_for_render = canvas_state;
@@ -311,6 +314,7 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
                         <input
                             type="text"
                             placeholder=label
+                            prop:disabled=move || attributes_loading.get()
                             prop:value=move || {
                                 filled_values
                                     .get()
@@ -336,7 +340,12 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
             })
             .collect::<Vec<_>>();
         view! {
-            <div class="ghost-disclosure-grid">{disclosure_field_views}</div>
+            <div class="ghost-disclosure-stack">
+                <Show when=move || attributes_loading.get()>
+                    <div class="ghost-disclosure-loading">"Loading saved fields"</div>
+                </Show>
+                <div class="ghost-disclosure-grid">{disclosure_field_views}</div>
+            </div>
         }
         .into_any()
     } else {
@@ -422,10 +431,15 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
                 <button
                     class="ghost-approval-btn ghost-approval-render"
                     type="button"
-                    prop:disabled=move || selected_agents.get().is_empty()
+                    prop:disabled=move || {
+                        selected_agents.get().is_empty() || attributes_loading.get()
+                    }
                     on:click=move |_| {
                         let selected = selected_agents.get();
-                        let values = filled_values.get();
+                        let values = filtered_disclosure_values(
+                            &filled_values.get(),
+                            &group_for_render.disclosure_props,
+                        );
                         for item in &group_for_render.items {
                             let item_selected = selected
                                 .iter()
@@ -445,7 +459,13 @@ fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
                         canvas_for_render.canvas_side.set(CanvasSide::Front);
                     }
                 >
-                    "Render selected"
+                    {move || {
+                        if attributes_loading.get() {
+                            "Loading disclosures"
+                        } else {
+                            "Render selected"
+                        }
+                    }}
                 </button>
             </div>
         </article>
@@ -537,6 +557,16 @@ fn merge_unique(target: &mut Vec<String>, values: Vec<String>) {
     }
 }
 
+fn filtered_disclosure_values(
+    values: &HashMap<String, String>,
+    allowed_props: &[String],
+) -> HashMap<String, String> {
+    allowed_props
+        .iter()
+        .filter_map(|prop| values.get(prop).map(|value| (prop.clone(), value.clone())))
+        .collect()
+}
+
 fn readable_returns(types: &[String]) -> String {
     if types.is_empty() {
         return "Structured result".into();
@@ -577,5 +607,205 @@ fn pluralize(count: usize, singular: &str) -> String {
         format!("1 {singular}")
     } else {
         format!("{count} {singular}s")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn strings(values: &[&str]) -> Vec<String> {
+        values.iter().map(|value| value.to_string()).collect()
+    }
+
+    fn candidate(name: &str, did: &str, disclosures: &[&str], returns: &[&str]) -> AgentCandidate {
+        AgentCandidate {
+            name: name.to_string(),
+            did: did.to_string(),
+            requires_disclosure: strings(disclosures),
+            returns: strings(returns),
+        }
+    }
+
+    fn plan(
+        action: &str,
+        disclosures: &[&str],
+        returns: &[&str],
+        candidates: Vec<AgentCandidate>,
+        ttl_hours: u32,
+        approval_request_id: &str,
+    ) -> IntentPlan {
+        let selected_agent_name = candidates
+            .first()
+            .map(|candidate| candidate.name.clone())
+            .unwrap_or_else(|| "Legacy agent".to_string());
+        let selected_agent_did = candidates.first().map(|candidate| candidate.did.clone());
+
+        IntentPlan {
+            action: action.to_string(),
+            selected_agent_name,
+            selected_agent_did,
+            requires_disclosure: strings(disclosures),
+            returns: strings(returns),
+            approval_request_id: approval_request_id.to_string(),
+            ttl_hours,
+            candidates,
+        }
+    }
+
+    fn block(id: &str, prompt: &str, plan: IntentPlan) -> CanvasBlock {
+        CanvasBlock {
+            id: id.to_string(),
+            prompt_id: format!("prompt-{id}"),
+            prompt_text: Some(prompt.to_string()),
+            state: BlockState::AwaitingApproval { plan },
+            schema_type: None,
+            content: None,
+            linked_block_ids: Vec::new(),
+            agent_did: None,
+            created_at: "2026-06-05T00:00:00Z".to_string(),
+            updated_at: "2026-06-05T00:00:00Z".to_string(),
+            mandate_expires_at: None,
+            preference_guided: false,
+            auto_expand: false,
+            retention_warning: None,
+        }
+    }
+
+    #[test]
+    fn grouped_approvals_merges_same_action_and_disclosures() {
+        let ddg = candidate(
+            "DuckDuckGo",
+            "did:pap:ddg",
+            &["schema:query"],
+            &["SearchResultsPage"],
+        );
+        let google = candidate(
+            "Google",
+            "did:pap:google",
+            &["schema:query"],
+            &["SearchResultsPage"],
+        );
+
+        let groups = grouped_approvals(vec![
+            block(
+                "block-1",
+                "Search the web",
+                plan(
+                    "schema:SearchAction",
+                    &["schema:query"],
+                    &["SearchResultsPage"],
+                    vec![ddg],
+                    8,
+                    "approval-1",
+                ),
+            ),
+            block(
+                "block-2",
+                "Search again",
+                plan(
+                    "schema:SearchAction",
+                    &["schema:query"],
+                    &["SearchResultsPage"],
+                    vec![google],
+                    4,
+                    "approval-2",
+                ),
+            ),
+        ]);
+
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0].action, "schema:SearchAction");
+        assert_eq!(groups[0].ttl_hours, 4);
+        assert_eq!(groups[0].items.len(), 2);
+        assert_eq!(groups[0].candidates.len(), 2);
+        assert_eq!(groups[0].disclosure_props, strings(&["schema:query"]));
+    }
+
+    #[test]
+    fn grouped_approvals_separates_different_disclosures() {
+        let groups = grouped_approvals(vec![
+            block(
+                "block-1",
+                "Search without disclosure",
+                plan(
+                    "schema:SearchAction",
+                    &[],
+                    &["SearchResultsPage"],
+                    vec![candidate(
+                        "Zero",
+                        "did:pap:zero",
+                        &[],
+                        &["SearchResultsPage"],
+                    )],
+                    8,
+                    "approval-1",
+                ),
+            ),
+            block(
+                "block-2",
+                "Search with query",
+                plan(
+                    "schema:SearchAction",
+                    &["schema:query"],
+                    &["SearchResultsPage"],
+                    vec![candidate(
+                        "Query",
+                        "did:pap:query",
+                        &["schema:query"],
+                        &["SearchResultsPage"],
+                    )],
+                    8,
+                    "approval-2",
+                ),
+            ),
+        ]);
+
+        assert_eq!(groups.len(), 2);
+        assert!(groups.iter().any(|group| group.disclosure_props.is_empty()));
+        assert!(groups
+            .iter()
+            .any(|group| group.disclosure_props == strings(&["schema:query"])));
+    }
+
+    #[test]
+    fn plan_candidates_falls_back_to_selected_agent_fields() {
+        let plan = IntentPlan {
+            action: "schema:SearchAction".to_string(),
+            selected_agent_name: "Legacy search".to_string(),
+            selected_agent_did: Some("did:pap:legacy".to_string()),
+            requires_disclosure: strings(&["schema:query"]),
+            returns: strings(&["SearchResultsPage"]),
+            approval_request_id: "approval-legacy".to_string(),
+            ttl_hours: 8,
+            candidates: Vec::new(),
+        };
+
+        let candidates = plan_candidates(&plan);
+
+        assert_eq!(candidates.len(), 1);
+        assert_eq!(candidates[0].name, "Legacy search");
+        assert_eq!(candidates[0].did, "did:pap:legacy");
+        assert_eq!(
+            candidates[0].requires_disclosure,
+            strings(&["schema:query"])
+        );
+    }
+
+    #[test]
+    fn filtered_disclosure_values_keeps_only_declared_fields() {
+        let values = HashMap::from([
+            ("schema:query".to_string(), "papillon".to_string()),
+            ("schema:email".to_string(), "hidden@example.com".to_string()),
+        ]);
+
+        let filtered = filtered_disclosure_values(&values, &strings(&["schema:query"]));
+
+        assert_eq!(filtered.len(), 1);
+        assert_eq!(
+            filtered.get("schema:query").map(String::as_str),
+            Some("papillon")
+        );
+        assert!(!filtered.contains_key("schema:email"));
     }
 }

--- a/apps/papillon/frontend/src/components/canvas_ghost_run_panel.rs
+++ b/apps/papillon/frontend/src/components/canvas_ghost_run_panel.rs
@@ -1,10 +1,41 @@
+use std::collections::{BTreeMap, HashMap};
+
 use leptos::prelude::*;
-use papillon_shared::{BlockState, OrchestratorStatus};
+use papillon_shared::{AgentCandidate, BlockState, CanvasBlock, IntentPlan, OrchestratorStatus};
+use wasm_bindgen_futures::spawn_local;
 
 use crate::components::canvas_chat_thread::CanvasChatThread;
-use crate::components::canvas_workflow_pipeline::{derive_block_trace, ApprovalPlanInline};
-use crate::state::canvas::{filter_messages_by_canvas, CanvasState};
+use crate::components::canvas_workflow_pipeline::derive_block_trace;
+use crate::state::canvas::{filter_messages_by_canvas, CanvasSide, CanvasState};
 use crate::state::orchestrator::OrchestratorState;
+use crate::workflow_labels::{humanize_schema_term, render_label_for_schema, workflow_port_label};
+
+#[derive(Clone, PartialEq)]
+struct ApprovalGroup {
+    id: String,
+    action: String,
+    disclosure_props: Vec<String>,
+    return_types: Vec<String>,
+    candidates: Vec<GroupCandidate>,
+    items: Vec<ApprovalGroupItem>,
+    ttl_hours: u32,
+}
+
+#[derive(Clone, PartialEq)]
+struct GroupCandidate {
+    name: String,
+    did: String,
+    disclosure_props: Vec<String>,
+    return_types: Vec<String>,
+}
+
+#[derive(Clone, PartialEq)]
+struct ApprovalGroupItem {
+    block_id: String,
+    approval_request_id: String,
+    prompt: String,
+    candidate_names: Vec<String>,
+}
 
 #[component]
 pub fn CanvasGhostRunPanel(#[prop(optional)] compact: bool) -> impl IntoView {
@@ -27,6 +58,7 @@ pub fn CanvasGhostRunPanel(#[prop(optional)] compact: bool) -> impl IntoView {
             })
             .collect::<Vec<_>>()
     };
+    let approval_groups = move || grouped_approvals(active_blocks());
 
     let trace_blocks = move || {
         active_blocks()
@@ -40,7 +72,12 @@ pub fn CanvasGhostRunPanel(#[prop(optional)] compact: bool) -> impl IntoView {
         let total = blocks.len();
         let resolving = blocks
             .iter()
-            .filter(|b| matches!(b.state, BlockState::Resolving { .. } | BlockState::Ghost { .. }))
+            .filter(|b| {
+                matches!(
+                    b.state,
+                    BlockState::Resolving { .. } | BlockState::Ghost { .. }
+                )
+            })
             .count();
         let approvals = blocks
             .iter()
@@ -55,10 +92,9 @@ pub fn CanvasGhostRunPanel(#[prop(optional)] compact: bool) -> impl IntoView {
 
     let orchestrator_badge = move || match orchestrator.status.get() {
         OrchestratorStatus::Ready => ("status-ready".to_string(), "ready".to_string()),
-        OrchestratorStatus::Disconnected => (
-            "status-disconnected".to_string(),
-            "offline".to_string(),
-        ),
+        OrchestratorStatus::Disconnected => {
+            ("status-disconnected".to_string(), "offline".to_string())
+        }
         OrchestratorStatus::Unconfigured => (
             "status-unconfigured".to_string(),
             "setup needed".to_string(),
@@ -101,23 +137,14 @@ pub fn CanvasGhostRunPanel(#[prop(optional)] compact: bool) -> impl IntoView {
             <Show when=move || !approvals().is_empty()>
                 <section class="ghost-run-section">
                     <div class="ghost-run-section-header">
-                        <span class="ghost-run-section-label">"Approvals"</span>
-                        <span class="ghost-run-section-count">{move || approvals().len()}</span>
+                        <span class="ghost-run-section-label">"Intent groups"</span>
+                        <span class="ghost-run-section-count">{move || approval_groups().len()}</span>
                     </div>
                     <div class="ghost-run-approvals">
                         <For
-                            each=approvals
-                            key=|(block, _)| block.id.clone()
-                            children=move |(block, plan)| {
-                                view! {
-                                    <article class="ghost-approval-card">
-                                        <div class="ghost-approval-prompt">
-                                            {block.prompt_text.unwrap_or_else(|| "Pending approval".into())}
-                                        </div>
-                                        <ApprovalPlanInline plan=plan />
-                                    </article>
-                                }
-                            }
+                            each=approval_groups
+                            key=|group| group.id.clone()
+                            children=move |group| view! { <GroupedApprovalCard group=group /> }
                         />
                     </div>
                 </section>
@@ -182,5 +209,373 @@ where
             <div class="ghost-metric-value">{value}</div>
             <div class="ghost-metric-label">{label}</div>
         </div>
+    }
+}
+
+#[component]
+fn GroupedApprovalCard(group: ApprovalGroup) -> impl IntoView {
+    let canvas_state = expect_context::<CanvasState>();
+    let selected_agents = RwSignal::new(
+        group
+            .candidates
+            .iter()
+            .map(|candidate| candidate.name.clone())
+            .collect::<Vec<_>>(),
+    );
+    let filled_values: RwSignal<HashMap<String, String>> = RwSignal::new(HashMap::new());
+
+    if !group.disclosure_props.is_empty() && crate::bridge::tauri_available() {
+        let values = filled_values;
+        spawn_local(async move {
+            if let Ok(attrs) = crate::bridge::invoke::<_, HashMap<String, String>>(
+                "get_principal_attributes",
+                &serde_json::json!({}),
+            )
+            .await
+            {
+                values.set(attrs);
+            }
+        });
+    }
+
+    let action_label = humanize_schema_term(&group.action);
+    let return_label = readable_returns(&group.return_types);
+    let candidate_count = group.candidates.len();
+    let item_count = group.items.len();
+    let ttl_hours = group.ttl_hours;
+    let has_disclosures = !group.disclosure_props.is_empty();
+    let group_for_render = group.clone();
+    let group_for_deny = group.clone();
+    let canvas_for_render = canvas_state;
+    let canvas_for_deny = canvas_state;
+    let candidate_views = group
+        .candidates
+        .clone()
+        .into_iter()
+        .map(|candidate| {
+            let candidate_name = candidate.name.clone();
+            let detail_text = candidate_detail(&candidate);
+            let candidate_name_for_checked = candidate_name.clone();
+            let candidate_name_for_change = candidate_name.clone();
+            view! {
+                <label class="ghost-agent-choice">
+                    <input
+                        type="checkbox"
+                        prop:checked=move || {
+                            selected_agents.get().contains(&candidate_name_for_checked)
+                        }
+                        on:change=move |event| {
+                            use wasm_bindgen::JsCast;
+                            let checked = event
+                                .target()
+                                .and_then(|target| target.dyn_into::<web_sys::HtmlInputElement>().ok())
+                                .map(|input| input.checked())
+                                .unwrap_or(false);
+                            let name = candidate_name_for_change.clone();
+                            selected_agents.update(|agents| {
+                                if checked {
+                                    if !agents.contains(&name) {
+                                        agents.push(name.clone());
+                                    }
+                                } else {
+                                    agents.retain(|agent| agent != &name);
+                                }
+                            });
+                        }
+                    />
+                    <span class="ghost-agent-choice-body">
+                        <span class="ghost-agent-choice-name">{candidate_name}</span>
+                        <span class="ghost-agent-choice-detail">{detail_text}</span>
+                    </span>
+                </label>
+            }
+        })
+        .collect::<Vec<_>>();
+    let candidate_list_view = view! {
+        <div class="ghost-agent-choice-list">{candidate_views}</div>
+    }
+    .into_any();
+
+    let disclosure_view = if has_disclosures {
+        let disclosure_field_views = group
+            .disclosure_props
+            .clone()
+            .into_iter()
+            .map(|prop| {
+                let field_key = prop.clone();
+                let field_key_for_input = prop.clone();
+                let label = workflow_port_label(&prop);
+                view! {
+                    <label class="ghost-disclosure-field">
+                        <span>{label.clone()}</span>
+                        <input
+                            type="text"
+                            placeholder=label
+                            prop:value=move || {
+                                filled_values
+                                    .get()
+                                    .get(&field_key)
+                                    .cloned()
+                                    .unwrap_or_default()
+                            }
+                            on:input=move |event| {
+                                use wasm_bindgen::JsCast;
+                                let value = event
+                                    .target()
+                                    .and_then(|target| target.dyn_into::<web_sys::HtmlInputElement>().ok())
+                                    .map(|input| input.value())
+                                    .unwrap_or_default();
+                                let key = field_key_for_input.clone();
+                                filled_values.update(|values| {
+                                    values.insert(key, value);
+                                });
+                            }
+                        />
+                    </label>
+                }
+            })
+            .collect::<Vec<_>>();
+        view! {
+            <div class="ghost-disclosure-grid">{disclosure_field_views}</div>
+        }
+        .into_any()
+    } else {
+        view! {
+            <div class="ghost-zero-disclosure">"No personal fields requested."</div>
+        }
+        .into_any()
+    };
+
+    let prompts_view = if item_count > 0 {
+        let prompt_views = group
+            .items
+            .clone()
+            .into_iter()
+            .map(|item| view! { <div class="ghost-approval-prompt">{item.prompt}</div> })
+            .collect::<Vec<_>>();
+        view! {
+            <div class="ghost-approval-prompts">{prompt_views}</div>
+        }
+        .into_any()
+    } else {
+        view! { <></> }.into_any()
+    };
+
+    view! {
+        <article class="ghost-approval-card ghost-approval-group">
+            <div class="ghost-approval-group-header">
+                <div>
+                    <div class="ghost-approval-kicker">"Dry-run group"</div>
+                    <div class="ghost-approval-title">{action_label}</div>
+                </div>
+                <div class="ghost-approval-meta">
+                    {format!(
+                        "{} · {}",
+                        pluralize(item_count, "intent"),
+                        pluralize(candidate_count, "agent")
+                    )}
+                </div>
+            </div>
+
+            <div class="ghost-approval-summary">
+                <div class="ghost-approval-summary-item">
+                    <span>"Will render"</span>
+                    <strong>{return_label}</strong>
+                </div>
+                <div class="ghost-approval-summary-item">
+                    <span>"Permission"</span>
+                    <strong>{if has_disclosures { "Disclosure required" } else { "Zero disclosure" }}</strong>
+                </div>
+                <div class="ghost-approval-summary-item">
+                    <span>"Valid for"</span>
+                    <strong>{format!("{ttl_hours}h")}</strong>
+                </div>
+            </div>
+
+            <div class="ghost-approval-subsection">
+                <div class="ghost-approval-subhead">"Agents to run"</div>
+                {candidate_list_view}
+            </div>
+
+            <div class="ghost-approval-subsection">
+                <div class="ghost-approval-subhead">"Will need from you"</div>
+                {disclosure_view}
+            </div>
+
+            {prompts_view}
+
+            <div class="ghost-approval-actions">
+                <button
+                    class="ghost-approval-btn ghost-approval-deny"
+                    type="button"
+                    on:click=move |_| {
+                        for item in &group_for_deny.items {
+                            canvas_for_deny.reject_block(
+                                item.block_id.clone(),
+                                item.approval_request_id.clone(),
+                            );
+                        }
+                    }
+                >
+                    "Deny group"
+                </button>
+                <button
+                    class="ghost-approval-btn ghost-approval-render"
+                    type="button"
+                    prop:disabled=move || selected_agents.get().is_empty()
+                    on:click=move |_| {
+                        let selected = selected_agents.get();
+                        let values = filled_values.get();
+                        for item in &group_for_render.items {
+                            let item_selected = selected
+                                .iter()
+                                .filter(|name| item.candidate_names.contains(name))
+                                .cloned()
+                                .collect::<Vec<_>>();
+                            if item_selected.is_empty() {
+                                continue;
+                            }
+                            canvas_for_render.approve_block(
+                                item.block_id.clone(),
+                                item.approval_request_id.clone(),
+                                values.clone(),
+                                item_selected,
+                            );
+                        }
+                        canvas_for_render.canvas_side.set(CanvasSide::Front);
+                    }
+                >
+                    "Render selected"
+                </button>
+            </div>
+        </article>
+    }
+}
+
+fn grouped_approvals(blocks: Vec<CanvasBlock>) -> Vec<ApprovalGroup> {
+    let mut groups = BTreeMap::<String, ApprovalGroup>::new();
+
+    for block in blocks {
+        let BlockState::AwaitingApproval { plan } = block.state.clone() else {
+            continue;
+        };
+        let key = approval_group_key(&plan);
+        let candidates = plan_candidates(&plan);
+        let group = groups.entry(key.clone()).or_insert_with(|| ApprovalGroup {
+            id: key,
+            action: plan.action.clone(),
+            disclosure_props: normalized_unique(plan.requires_disclosure.clone()),
+            return_types: Vec::new(),
+            candidates: Vec::new(),
+            items: Vec::new(),
+            ttl_hours: plan.ttl_hours,
+        });
+
+        merge_unique(&mut group.return_types, plan.returns.clone());
+        group.ttl_hours = group.ttl_hours.min(plan.ttl_hours);
+
+        for candidate in &candidates {
+            if !group
+                .candidates
+                .iter()
+                .any(|existing| existing.name == candidate.name)
+            {
+                group.candidates.push(GroupCandidate {
+                    name: candidate.name.clone(),
+                    did: candidate.did.clone(),
+                    disclosure_props: normalized_unique(candidate.requires_disclosure.clone()),
+                    return_types: normalized_unique(candidate.returns.clone()),
+                });
+            }
+        }
+
+        group.items.push(ApprovalGroupItem {
+            block_id: block.id,
+            approval_request_id: plan.approval_request_id,
+            prompt: block
+                .prompt_text
+                .unwrap_or_else(|| "Pending approval".to_string()),
+            candidate_names: candidates
+                .into_iter()
+                .map(|candidate| candidate.name)
+                .collect(),
+        });
+    }
+
+    groups.into_values().collect()
+}
+
+fn approval_group_key(plan: &IntentPlan) -> String {
+    let disclosures = normalized_unique(plan.requires_disclosure.clone()).join(",");
+    format!("{}|{}", plan.action, disclosures)
+}
+
+fn plan_candidates(plan: &IntentPlan) -> Vec<AgentCandidate> {
+    if plan.candidates.is_empty() {
+        vec![AgentCandidate {
+            name: plan.selected_agent_name.clone(),
+            did: plan.selected_agent_did.clone().unwrap_or_default(),
+            requires_disclosure: plan.requires_disclosure.clone(),
+            returns: plan.returns.clone(),
+        }]
+    } else {
+        plan.candidates.clone()
+    }
+}
+
+fn normalized_unique(mut values: Vec<String>) -> Vec<String> {
+    values.sort();
+    values.dedup();
+    values
+}
+
+fn merge_unique(target: &mut Vec<String>, values: Vec<String>) {
+    for value in values {
+        if !target.contains(&value) {
+            target.push(value);
+        }
+    }
+}
+
+fn readable_returns(types: &[String]) -> String {
+    if types.is_empty() {
+        return "Structured result".into();
+    }
+    let mut labels = types
+        .iter()
+        .map(|schema| render_label_for_schema(schema))
+        .collect::<Vec<_>>();
+    labels.sort();
+    labels.dedup();
+    if labels.len() > 2 {
+        format!("{} +{}", labels[..2].join(", "), labels.len() - 2)
+    } else {
+        labels.join(", ")
+    }
+}
+
+fn candidate_detail(candidate: &GroupCandidate) -> String {
+    let returns = readable_returns(&candidate.return_types);
+    if candidate.disclosure_props.is_empty() {
+        format!("{returns} · zero disclosure")
+    } else {
+        format!(
+            "{} · needs {}",
+            returns,
+            candidate
+                .disclosure_props
+                .iter()
+                .map(|prop| workflow_port_label(prop))
+                .collect::<Vec<_>>()
+                .join(", ")
+        )
+    }
+}
+
+fn pluralize(count: usize, singular: &str) -> String {
+    if count == 1 {
+        format!("1 {singular}")
+    } else {
+        format!("{count} {singular}s")
     }
 }

--- a/apps/papillon/frontend/src/handshake/mod.rs
+++ b/apps/papillon/frontend/src/handshake/mod.rs
@@ -679,6 +679,8 @@ mod tests {
             published_to: vec![],
             live: true,
             category: "general".to_string(),
+            execution_target: Default::default(),
+            lifecycle: Default::default(),
         }
     }
 

--- a/apps/papillon/frontend/src/pages/canvas.rs
+++ b/apps/papillon/frontend/src/pages/canvas.rs
@@ -4,6 +4,7 @@ use papillon_shared::{BlockState, CanvasBlock};
 use crate::components::block_renderer::BlockRenderer;
 use crate::components::canvas_aside::{AsideOpen, CanvasAside, CanvasAsideDockToggle};
 use crate::components::canvas_back_face::CanvasBackFace;
+use crate::components::canvas_empty_state::CanvasEmptyState;
 use crate::components::canvas_surface_title::CanvasSurfaceTitle;
 use crate::components::hitl_gate::HitlGate;
 use crate::state::canvas::{CanvasSide, CanvasState};
@@ -23,6 +24,7 @@ pub fn CanvasPage() -> impl IntoView {
             .filter(|block| !matches!(block.state, BlockState::Guide { .. }))
             .collect::<Vec<_>>()
     };
+    let has_any_blocks = move || !blocks.get().is_empty();
     let has_rendered_blocks = move || !rendered_blocks().is_empty();
     // Group blocks by semantic links for rendering
     let grouped_blocks = move || {
@@ -72,7 +74,14 @@ pub fn CanvasPage() -> impl IntoView {
                     <div class="canvas-stream">
                         <CanvasSurfaceTitle />
                         <Show when=move || !has_rendered_blocks()>
-                            <div class="canvas-surface-status">"Approve workflow to render"</div>
+                            <Show
+                                when=move || !has_any_blocks()
+                                fallback=|| view! {
+                                    <div class="canvas-surface-status">"Approve workflow to render"</div>
+                                }
+                            >
+                                <CanvasEmptyState />
+                            </Show>
                         </Show>
                         <Show when=has_rendered_blocks>
                             <For

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -3227,7 +3227,47 @@ body {
     gap: var(--sp-sm);
 }
 
+.typed-search-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: var(--sp-sm);
+    padding-bottom: var(--sp-xs);
+    border-bottom: 1px solid var(--border-subtle);
+}
+
+.typed-search-kicker,
+.typed-search-count {
+    font: var(--text-label);
+    font-family: var(--font-mono);
+    letter-spacing: var(--ls-label);
+    text-transform: uppercase;
+}
+
+.typed-search-kicker {
+    color: var(--text-3);
+}
+
+.typed-search-count {
+    color: var(--teal);
+}
+
+.typed-search-empty {
+    font: var(--text-small);
+    color: var(--text-3);
+}
+
 .typed-search-item {
+    display: flex;
+    flex-direction: column;
+    gap: var(--sp-xs);
+    padding: var(--sp-sm);
+    border: 1px solid var(--border-subtle);
+    border-radius: 8px;
+    background: rgba(255,255,255,0.025);
+}
+
+.typed-search-main {
     display: flex;
     flex-direction: column;
     gap: var(--sp-2xs);
@@ -3251,6 +3291,28 @@ body {
     font-family: var(--font-body);
     color: var(--text-2);
     line-height: 1.4;
+}
+
+.typed-search-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--sp-xs);
+}
+
+.typed-search-action {
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    background: rgba(255,255,255,0.03);
+    color: var(--text-2);
+    font: var(--text-label);
+    font-family: var(--font-mono);
+    padding: 6px 9px;
+    cursor: pointer;
+}
+
+.typed-search-action:hover {
+    color: var(--text-1);
+    border-color: rgba(108,92,231,0.5);
 }
 
 /* ── Typed template shared pattern ───────────────────────────── */
@@ -5313,13 +5375,10 @@ body {
 
 .canvas-empty-hero {
     width: 100%;
-    padding: 30px 30px 26px;
+    padding: 24px;
     border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 24px;
-    background:
-      radial-gradient(circle at top right, rgba(108,92,231,0.18), transparent 34%),
-      radial-gradient(circle at left center, rgba(46,196,160,0.09), transparent 30%),
-      linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015));
+    border-radius: 8px;
+    background: rgba(255,255,255,0.025);
 }
 
 .canvas-empty-kicker {
@@ -5331,8 +5390,8 @@ body {
 }
 
 .canvas-empty-title {
-    font: 700 40px/1.08 var(--font-display);
-    letter-spacing: -0.03em;
+    font: 700 28px/1.16 var(--font-display);
+    letter-spacing: 0;
     color: var(--text-1);
     max-width: 720px;
     margin-bottom: 12px;
@@ -7623,6 +7682,207 @@ body {
   line-height: 1.55;
 }
 
+.ghost-approval-group {
+  border-radius: 8px;
+  background: rgba(255,255,255,0.03);
+}
+
+.ghost-approval-group-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.ghost-approval-kicker,
+.ghost-approval-subhead,
+.ghost-approval-summary-item span {
+  font: var(--text-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.ghost-approval-kicker {
+  color: var(--teal);
+  margin-bottom: 4px;
+}
+
+.ghost-approval-title {
+  color: var(--text-1);
+  font: 700 17px/1.25 var(--font-display);
+}
+
+.ghost-approval-meta {
+  flex-shrink: 0;
+  color: var(--text-3);
+  font: var(--text-small);
+}
+
+.ghost-approval-summary {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.ghost-approval-summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 0;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(0,0,0,0.12);
+}
+
+.ghost-approval-summary-item span {
+  color: var(--text-3);
+}
+
+.ghost-approval-summary-item strong {
+  color: var(--text-1);
+  font: 600 12px/1.35 var(--font-body);
+}
+
+.ghost-approval-subsection {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-top: 14px;
+}
+
+.ghost-approval-subhead {
+  color: var(--text-2);
+}
+
+.ghost-agent-choice-list {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ghost-agent-choice {
+  display: grid;
+  grid-template-columns: 16px minmax(0, 1fr);
+  gap: 9px;
+  align-items: flex-start;
+  padding: 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.025);
+  cursor: pointer;
+}
+
+.ghost-agent-choice input {
+  margin: 2px 0 0;
+  accent-color: var(--teal);
+}
+
+.ghost-agent-choice-body {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+  min-width: 0;
+}
+
+.ghost-agent-choice-name {
+  color: var(--text-1);
+  font: 600 13px/1.35 var(--font-body);
+}
+
+.ghost-agent-choice-detail {
+  color: var(--text-3);
+  font: var(--text-small);
+  line-height: 1.45;
+}
+
+.ghost-disclosure-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
+  gap: 8px;
+}
+
+.ghost-disclosure-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  color: var(--text-2);
+  font: var(--text-small);
+}
+
+.ghost-disclosure-field input {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(0,0,0,0.2);
+  color: var(--text-1);
+  padding: 7px 9px;
+  font: var(--text-ui);
+}
+
+.ghost-zero-disclosure {
+  color: var(--teal);
+  font: var(--text-small);
+  padding: 9px 10px;
+  border: 1px solid rgba(46,196,160,0.18);
+  border-radius: 8px;
+  background: rgba(46,196,160,0.08);
+}
+
+.ghost-approval-prompts {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin-top: 14px;
+}
+
+.ghost-approval-prompts .ghost-approval-prompt {
+  padding: 8px 10px;
+  border-radius: 8px;
+  background: rgba(255,255,255,0.025);
+  color: var(--text-2);
+  font-size: 12px;
+}
+
+.ghost-approval-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+  margin-top: 14px;
+  flex-wrap: wrap;
+}
+
+.ghost-approval-btn {
+  min-height: 34px;
+  border-radius: 8px;
+  border: 1px solid var(--border-subtle);
+  background: rgba(255,255,255,0.035);
+  color: var(--text-2);
+  padding: 7px 11px;
+  font: var(--text-label);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+}
+
+.ghost-approval-btn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+
+.ghost-approval-render {
+  color: var(--teal);
+  border-color: rgba(46,196,160,0.34);
+  background: rgba(46,196,160,0.09);
+}
+
+.ghost-approval-deny {
+  color: var(--coral);
+  border-color: rgba(232,112,106,0.26);
+}
+
 .ghost-trace-header {
   display: flex;
   align-items: flex-start;
@@ -7720,6 +7980,10 @@ body {
 
   .ghost-run-metrics {
     grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .ghost-approval-summary {
+    grid-template-columns: 1fr;
   }
 
   .wf-design-layout {

--- a/apps/papillon/frontend/styles/main.css
+++ b/apps/papillon/frontend/styles/main.css
@@ -5375,10 +5375,13 @@ body {
 
 .canvas-empty-hero {
     width: 100%;
-    padding: 24px;
+    padding: 30px 30px 26px;
     border: 1px solid rgba(255,255,255,0.06);
-    border-radius: 8px;
-    background: rgba(255,255,255,0.025);
+    border-radius: 24px;
+    background:
+        radial-gradient(circle at top right, rgba(108,92,231,0.18), transparent 34%),
+        radial-gradient(circle at left center, rgba(46,196,160,0.09), transparent 30%),
+        linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.015));
 }
 
 .canvas-empty-kicker {
@@ -5390,7 +5393,7 @@ body {
 }
 
 .canvas-empty-title {
-    font: 700 28px/1.16 var(--font-display);
+    font: 700 40px/1.08 var(--font-display);
     letter-spacing: 0;
     color: var(--text-1);
     max-width: 720px;
@@ -7801,6 +7804,21 @@ body {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(170px, 1fr));
   gap: 8px;
+}
+
+.ghost-disclosure-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.ghost-disclosure-loading {
+  color: var(--text-3);
+  font: var(--text-small);
+  padding: 8px 10px;
+  border: 1px solid var(--border-subtle);
+  border-radius: 8px;
+  background: rgba(255,255,255,0.025);
 }
 
 .ghost-disclosure-field {


### PR DESCRIPTION
## Summary

This PR adds the first concrete UI slice for Papillon’s intent-browser model.

Papillon now treats agent output as structured Schema.org data and renders supported types directly in the canvas. It also improves the ghost/dry-run workflow by grouping pending approvals into intent groups, letting users select candidate agents, fill one shared disclosure form, and render approved results.

## What Changed

- Added a typed renderer for `schema:SearchResultsPage` and `schema:SearchResult`.
- Registered the search results renderer in the default block renderer registry.
- Replaced the empty rendered canvas state with the existing intent-browser empty state when there are no blocks.
- Added grouped ghost approvals in the orchestrator/ghost panel.
- Grouped approval blocks by action type and disclosure requirements.
- Added candidate-agent checkboxes inside each approval group.
- Added one shared disclosure form per grouped approval.
- Added `Render selected` to approve selected agents and flip back to the rendered canvas.
- Added `Deny group` to reject all approvals in a group.
- Added styling for search result cards, grouped approval cards, agent choices, and disclosure fields.
- Ignored generated Gradle state at `bindings/java/.gradle/`.

## Why

Todd described Papillon as an intent browser:

- users ask for an intent without needing AI,
- Papillon maps that intent to matching agents,
- the user sees a ghost/dry-run canvas before execution,
- agents advertise required disclosures,
- shared disclosure requirements become one approval form,
- approved results render from Schema.org types,
- canvases behave like browser tabs.

This PR starts that flow by making the ghost approval UX and Schema.org rendering concrete.

## Testing

Ran:

```sh
git diff --check
cargo check --manifest-path apps/papillon/frontend/Cargo.toml
just check-wasm
just run-example pap-search-example

Run browser UI:
env -u NO_COLOR just web

Open:
http://127.0.0.1:1420